### PR TITLE
Fix pg pool usage

### DIFF
--- a/api/src/controllers/namespace.ts
+++ b/api/src/controllers/namespace.ts
@@ -24,10 +24,11 @@ import DataManager from '../db';
 import shared from '../libs/shared';
 import { validateObjProps } from '../libs/utils';
 
+const dm = new DataManager(shared.pgPool);
+
 export const createNamespace = async (
   { params, body }: { params: any, body: any }, res: Response
 ): Promise<void> => {
-  const dm = new DataManager(shared.pgPool);
   const { NamespaceModel } = dm;
   const { profileId } = params;
   const aBody = { ...body, profileId };
@@ -52,7 +53,6 @@ export const createNamespace = async (
 export const fetchProfileNamespaces = async (
   { params }: { params: any }, res: Response
 ): Promise<void> => {
-  const dm = new DataManager(shared.pgPool);
   const { NamespaceModel } = dm;
   const { profileId } = params;
 
@@ -71,7 +71,6 @@ export const fetchProfileNamespaces = async (
 export const fetchProfileNamespace = async (
   { params }: { params: any }, res: Response
 ): Promise<void> => {
-  const dm = new DataManager(shared.pgPool);
   const { NamespaceModel } = dm;
   const { namespaceId } = params;
 
@@ -90,7 +89,6 @@ export const fetchProfileNamespace = async (
 export const updateProfileNamespace = async (
   { params, body }: { params: any, body: any }, res: Response
 ): Promise<void> => {
-  const dm = new DataManager(shared.pgPool);
   const { NamespaceModel } = dm;
   const { profileId, namespaceId } = params;
   const { name, clusterId } = body;
@@ -116,7 +114,6 @@ export const updateProfileNamespace = async (
 export const archiveProfileNamespace = async (
   { params }: { params: any }, res: Response
 ): Promise<void> => {
-  const dm = new DataManager(shared.pgPool);
   const { NamespaceModel } = dm;
   const { profileId, namespaceId } = params;
 

--- a/api/src/controllers/namespace.ts
+++ b/api/src/controllers/namespace.ts
@@ -20,14 +20,14 @@
 
 import { errorWithCode, logger } from '@bcgov/common-nodejs-utils';
 import { Response } from 'express';
-import config from '../config';
 import DataManager from '../db';
+import shared from '../libs/shared';
 import { validateObjProps } from '../libs/utils';
 
 export const createNamespace = async (
   { params, body }: { params: any, body: any }, res: Response
 ): Promise<void> => {
-  const dm = new DataManager(config);
+  const dm = new DataManager(shared.pgPool);
   const { NamespaceModel } = dm;
   const { profileId } = params;
   const aBody = { ...body, profileId };
@@ -52,7 +52,7 @@ export const createNamespace = async (
 export const fetchProfileNamespaces = async (
   { params }: { params: any }, res: Response
 ): Promise<void> => {
-  const dm = new DataManager(config);
+  const dm = new DataManager(shared.pgPool);
   const { NamespaceModel } = dm;
   const { profileId } = params;
 
@@ -71,7 +71,7 @@ export const fetchProfileNamespaces = async (
 export const fetchProfileNamespace = async (
   { params }: { params: any }, res: Response
 ): Promise<void> => {
-  const dm = new DataManager(config);
+  const dm = new DataManager(shared.pgPool);
   const { NamespaceModel } = dm;
   const { namespaceId } = params;
 
@@ -90,7 +90,7 @@ export const fetchProfileNamespace = async (
 export const updateProfileNamespace = async (
   { params, body }: { params: any, body: any }, res: Response
 ): Promise<void> => {
-  const dm = new DataManager(config);
+  const dm = new DataManager(shared.pgPool);
   const { NamespaceModel } = dm;
   const { profileId, namespaceId } = params;
   const { name, clusterId } = body;
@@ -116,7 +116,7 @@ export const updateProfileNamespace = async (
 export const archiveProfileNamespace = async (
   { params }: { params: any }, res: Response
 ): Promise<void> => {
-  const dm = new DataManager(config);
+  const dm = new DataManager(shared.pgPool);
   const { NamespaceModel } = dm;
   const { profileId, namespaceId } = params;
 

--- a/api/src/controllers/profile.ts
+++ b/api/src/controllers/profile.ts
@@ -24,8 +24,9 @@ import DataManager from '../db';
 import shared from '../libs/shared';
 import { validateObjProps } from '../libs/utils';
 
+const dm = new DataManager(shared.pgPool);
+
 export const fetchAllProjectProfiles = async (req: Request, res: Response): Promise<void> => {
-  const dm = new DataManager(shared.pgPool);
   const { ProfileModel } = dm;
 
   try {
@@ -43,7 +44,6 @@ export const fetchAllProjectProfiles = async (req: Request, res: Response): Prom
 export const fetchProjectProfile = async (
   { params }: { params: any }, res: Response
 ): Promise<void> => {
-  const dm = new DataManager(shared.pgPool);
   const { ProfileModel } = dm;
   const { profileId } = params;
 
@@ -62,7 +62,6 @@ export const fetchProjectProfile = async (
 export const createProjectProfile = async (
   { body }: { body: any }, res: Response
 ): Promise<void> => {
-  const dm = new DataManager(shared.pgPool);
   const { ProfileModel } = dm;
 
   const rv = validateObjProps(ProfileModel.requiredFields, body);
@@ -85,7 +84,6 @@ export const createProjectProfile = async (
 export const updateProjectProfile = async (
   { params, body }: { params: any, body: any }, res: Response
 ): Promise<void> => {
-  const dm = new DataManager(shared.pgPool);
   const { ProfileModel } = dm;
   const { profileId } = params;
   const {
@@ -125,7 +123,6 @@ export const updateProjectProfile = async (
 export const archiveProjectProfile = async (
   { params }: { params: any }, res: Response
 ): Promise<void> => {
-  const dm = new DataManager(shared.pgPool);
   const { ProfileModel } = dm;
   const { profileId } = params;
 

--- a/api/src/controllers/profile.ts
+++ b/api/src/controllers/profile.ts
@@ -20,12 +20,12 @@
 
 import { errorWithCode, logger } from '@bcgov/common-nodejs-utils';
 import { Request, Response } from 'express';
-import config from '../config';
 import DataManager from '../db';
+import shared from '../libs/shared';
 import { validateObjProps } from '../libs/utils';
 
 export const fetchAllProjectProfiles = async (req: Request, res: Response): Promise<void> => {
-  const dm = new DataManager(config);
+  const dm = new DataManager(shared.pgPool);
   const { ProfileModel } = dm;
 
   try {
@@ -43,7 +43,7 @@ export const fetchAllProjectProfiles = async (req: Request, res: Response): Prom
 export const fetchProjectProfile = async (
   { params }: { params: any }, res: Response
 ): Promise<void> => {
-  const dm = new DataManager(config);
+  const dm = new DataManager(shared.pgPool);
   const { ProfileModel } = dm;
   const { profileId } = params;
 
@@ -62,7 +62,7 @@ export const fetchProjectProfile = async (
 export const createProjectProfile = async (
   { body }: { body: any }, res: Response
 ): Promise<void> => {
-  const dm = new DataManager(config);
+  const dm = new DataManager(shared.pgPool);
   const { ProfileModel } = dm;
 
   const rv = validateObjProps(ProfileModel.requiredFields, body);
@@ -85,7 +85,7 @@ export const createProjectProfile = async (
 export const updateProjectProfile = async (
   { params, body }: { params: any, body: any }, res: Response
 ): Promise<void> => {
-  const dm = new DataManager(config);
+  const dm = new DataManager(shared.pgPool);
   const { ProfileModel } = dm;
   const { profileId } = params;
   const {
@@ -125,7 +125,7 @@ export const updateProjectProfile = async (
 export const archiveProjectProfile = async (
   { params }: { params: any }, res: Response
 ): Promise<void> => {
-  const dm = new DataManager(config);
+  const dm = new DataManager(shared.pgPool);
   const { ProfileModel } = dm;
   const { profileId } = params;
 

--- a/api/src/db/index.ts
+++ b/api/src/db/index.ts
@@ -7,20 +7,9 @@ export default class DataManager {
   ProfileModel: ProfileModel;
   NamespaceModel: NamespaceModel;
 
-  constructor(config: any) {
-    const params = {
-      host: config.get('db:host'),
-      port: config.get('db:port'),
-      database: config.get('db:database'),
-      user: config.get('db:user'),
-      password: config.get('db:password'),
-      max: 5,
-      idleTimeoutMillis: 30000,
-      connectionTimeoutMillis: 2000,
-    }
-
-    this.pool = new Pool(params)
-    this.ProfileModel = new ProfileModel(this.pool);
-    this.NamespaceModel = new NamespaceModel(this.pool);
+  constructor(pool: Pool) {
+    this.pool = pool;
+    this.ProfileModel = new ProfileModel(pool);
+    this.NamespaceModel = new NamespaceModel(pool);
   }
 }

--- a/api/src/db/model/model.ts
+++ b/api/src/db/model/model.ts
@@ -63,6 +63,10 @@ export abstract class Model {
   async runQuery(query: Query): Promise<any[]> {
     let client;
 
+    if (this.pool.waitingCount > 0) {
+      logger.warn(`Database pool has ${this.pool.waitingCount} waiting queries`);
+    }
+
     try {
       client = await this.pool.connect();
       const results = await client.query(query);


### PR DESCRIPTION
Each model was creating its own pool. As more models are added this will quickly and unnecessarily exhaust PostgreSQL available connections. This fixes the problem by creating a shared pool (the way it should be done).

Fixes #30