### PR TITLE
Only allow users with IDIR to authenticate against the registry

### DIFF
--- a/web/src/components/authbutton.tsx
+++ b/web/src/components/authbutton.tsx
@@ -53,7 +53,9 @@ const actionForCurrentState = (keycloak: any): any => {
     return () => keycloak.logout();
   }
 
-  return () => keycloak.login();
+  // TODO: will revert back once the better access control is in place
+  // where we check if users are part of our GitHub organization
+  return () => keycloak.login({ idpHint: 'idir' });
 };
 
 const Button: React.SFC<IButtonProps> = (props) => {


### PR DESCRIPTION
- limiting authentication methods through keycloak to only use IDIR
- adding TODO note so we can allow GitHub again after we implement better access control
Fixes #81 