### PR TITLE
Replace postgresql with Patroni service

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,73 +2,93 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/95db366ef76313d5d4eb/maintainability)](https://codeclimate.com/github/bcgov/platform-services-registry/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/95db366ef76313d5d4eb/test_coverage)](https://codeclimate.com/github/bcgov/platform-services-registry/test_coverage)
 
-
 # platform-services-registry
+
 Platform services OCP project registry
 
 ## Callbacks
+
 export SSO_TOKEN=YOUR_TOKEN_HERE
 export SSO_CLIENT_ID=YOUR_CLIENT_ID_HERE
 export SSO_TOKEN_URL=YOUR_TOKEN_URL_HERE
 
 curl -sX POST -H "Content-Type: application/x-www-form-urlencoded" \
-    --data "grant_type=client_credentials&client_id=${SSO_CLIENT_ID}&client_secret=${SSO_TOKEN}" \
-    ${SSO_TOKEN_URL} | \
-    jq '.access_token' |
-    cut -d "\"" -f 2
+ --data "grant_type=client_credentials&client_id=${SSO_CLIENT_ID}&client_secret=${SSO_TOKEN}" \
+ \${SSO_TOKEN_URL} | \
+ jq '.access_token' |
+cut -d "\"" -f 2
 
 Then use a callback:
-curl -vX PUT -H "Content-Type: application/json" -H "Authorization: Bearer ${MYT}" http://localhost:8100/api/v1/provision/1/namespace -d @data.json
+curl -vX PUT -H "Content-Type: application/json" -H "Authorization: Bearer \${MYT}" http://localhost:8100/api/v1/provision/1/namespace -d @data.json
 
 ## Build
 
-# API
-oc process -f api/openshift/templates/build.yaml| oc apply -f -
+### API
 
-# Web
+`oc process -f api/openshift/templates/build.yaml| oc apply -f -`
+
+### Web
 
 setup the s2i-caddy image as per:
 https://github.com/bcgov/s2i-caddy-nodejs
 
+`oc process -f web/openshift/templates/build.yaml -p SOURCE_IMAGE_NAMESPACE=\$(oc project --short) | oc apply -f -`
 
-oc process -f web/openshift/templates/build.yaml -p SOURCE_IMAGE_NAMESPACE=$(oc project --short) | oc apply -f -
+### Patroni
+
+Build if you need a local image (defaults in this build have been changed to leverage postgres:12). Note the `oc create` instead of `oc apply`, this is to support multiple base image versions.
+
+`oc process -f openshift/templates/patroni-build.yaml | oc -n platform-registry-tools create -f -`
 
 ## Deploy
+
+Deploy postgres service first (please set context to appropriate project/namespace):
+
+```bash
+oc process -f openshift/templates/patroni-pre-req.yaml -p NAME=registry-patroni | oc create -f -
+
+oc process -f openshift/templates/patroni-deploy.yaml \
+ -p NAME=registry-patroni \
+ -p "IMAGE_STREAM_NAMESPACE=platform-services-registry-tools" \
+ -p "IMAGE_STREAM_TAG=patroni:v12-latest" \
+ -p REPLICAS=3 \
+ -p PVC_SIZE=5Gi | oc apply -f -
+```
 
 Edit as needed then do:
 oc process -f api/openshift/templates/config.yaml | oc apply -f -
 
-oc process -f api/openshift/templates/deploy.yaml -p NAMESPACE=$(oc project --short) -p SOURCE_IMAGE_NAMESPACE=your-namespace-tools -p SOURCE_IMAGE_TAG=dev | oc apply -f -
+oc process -f api/openshift/templates/deploy.yaml -p NAMESPACE=\$(oc project --short) -p SOURCE_IMAGE_NAMESPACE=your-namespace-tools -p SOURCE_IMAGE_TAG=dev | oc apply -f -
 
-
-➜  platform-services-registry git:(master) ✗ oc tag platsrv-registry-web:latest platsrv-registry-web:dev
+➜ platform-services-registry git:(master) ✗ oc tag platsrv-registry-web:latest platsrv-registry-web:dev
 
 Web
 
-➜  platform-services-registry git:(master) ✗ oc process -f web/openshift/templates/config.yaml | oc apply -f -
+➜ platform-services-registry git:(master) ✗ oc process -f web/openshift/templates/config.yaml | oc apply -f -
 
-oc process -f web/openshift/templates/deploy.yaml -p NAMESPACE=$(oc project --short) -p SOURCE_IMAGE_NAMESPACE=platform-registry-tools -p SOURCE_IMAGE_TAG=dev | oc apply -f -
+oc process -f web/openshift/templates/deploy.yaml -p NAMESPACE=\$(oc project --short) -p SOURCE_IMAGE_NAMESPACE=platform-registry-tools -p SOURCE_IMAGE_TAG=dev | oc apply -f -
 
-10452  oc process -f web/openshift/templates/deploy.yaml -p NAMESPACE=$(oc project --short) -p SOURCE_IMAGE_NAMESPACE=platform-registry-tools -p SOURCE_IMAGE_TAG=dev -p SSO_BASE_URL="https://sso-dev.pathfinder.gov.bc.ca" -p CLUSTER_DOMAIN=apps.thetis.devops.gov.bc.ca | oc apply -f -
+10452 oc process -f web/openshift/templates/deploy.yaml -p NAMESPACE=\$(oc project --short) -p SOURCE_IMAGE_NAMESPACE=platform-registry-tools -p SOURCE_IMAGE_TAG=dev -p SSO_BASE_URL="https://sso-dev.pathfinder.gov.bc.ca" -p CLUSTER_DOMAIN=apps.thetis.devops.gov.bc.ca | oc apply -f -
 
 # schema
+
 oc get secret/registry-postgres-creds -o yaml
 
 oc port-forward registry-postgres-1-rz6nz 5432
 
-➜  platform-services-registry git:(master) ✗ docker run -it --rm --name blarb -v $(pwd):/opt/src postgres /bin/bash
+➜ platform-services-registry git:(master) ✗ docker run -it --rm --name blarb -v \$(pwd):/opt/src postgres /bin/bash
 root@d7fc5e936e34:/# psql -U postgres -h host.docker.internal
 psql (12.0 (Debian 12.0-1.pgdg100+1), server 12.1)
 Type "help" for help.
 
 postgres=# \du
-                                   List of roles
- Role name |                         Attributes                         | Member of 
+List of roles
+Role name | Attributes | Member of
 -----------+------------------------------------------------------------+-----------
- 6yve3bce  |                                                            | {}
- postgres  | Superuser, Create role, Create DB, Replication, Bypass RLS | {}
+6yve3bce | | {}
+postgres | Superuser, Create role, Create DB, Replication, Bypass RLS | {}
 
-postgres=# 
+postgres=#
 
 psql -U postgres -d registry -h host.docker.internal -f /opt/src/db/sql/0001.sql -v ROLLNAME=app_api_oksb6iie
 
@@ -76,26 +96,26 @@ Seeing an unresolved image or not deploying the API? Remember to tag:
 oc tag platsrv-registry-api:latest platsrv-registry-api:dev
 
 ult -n devops-security-aporeto-operator
- 4179  history|grep `oc policy`
- 4180  history|grep oc policy
- 4181  history|grep "oc policy"
- 5909  oc policy add-role-to-user system:image-puller system:serviceaccount:$(oc project --short=true):default -n devhub-tools
- 9974  oc policy add-role-to-user \\n    system:image-puller system:serviceaccount:$(:default \\n    --namespace=<your_tools_namespace>
- 9976  oc policy add-role-to-user \\n    system:image-puller system:serviceaccount:platform-registry-dev:default \\n    --namespace=platform-registry-tools
- 9977  oc policy add-role-to-group \\n    system:image-puller system:serviceaccounts:platform-registry-dev \\n    --namespace=platform-registry-tools
-10653  history|grep 'oc policy"
-10654  history|grep 'oc policy'
-➜  platform-services-registry git:(feature/prov-cb) ✗ !9976
-➜  platform-services-registry git:(feature/prov-cb) ✗ oc policy add-role-to-user \
-    system:image-puller system:serviceaccount:platform-registry-dev:default \
-    --namespace=platform-registry-tools
+4179 history|grep `oc policy`
+4180 history|grep oc policy
+4181 history|grep "oc policy"
+5909 oc policy add-role-to-user system:image-puller system:serviceaccount:$(oc project --short=true):default -n devhub-tools
+ 9974  oc policy add-role-to-user \\n    system:image-puller system:serviceaccount:$(:default \\n --namespace=<your_tools_namespace>
+9976 oc policy add-role-to-user \\n system:image-puller system:serviceaccount:platform-registry-dev:default \\n --namespace=platform-registry-tools
+9977 oc policy add-role-to-group \\n system:image-puller system:serviceaccounts:platform-registry-dev \\n --namespace=platform-registry-tools
+10653 history|grep 'oc policy"
+10654 history|grep 'oc policy'
+➜ platform-services-registry git:(feature/prov-cb) ✗ !9976
+➜ platform-services-registry git:(feature/prov-cb) ✗ oc policy add-role-to-user \
+ system:image-puller system:serviceaccount:platform-registry-dev:default \
+ --namespace=platform-registry-tools
 clusterrole.rbac.authorization.k8s.io/system:image-puller added: "system:serviceaccount:platform-registry-dev:default"
-➜  platform-services-registry git:(feature/prov-cb) ✗ !9977
-➜  platform-services-registry git:(feature/prov-cb) ✗ oc policy add-role-to-group \
-    system:image-puller system:serviceaccounts:platform-registry-dev \
-    --namespace=platform-registry-tools
+➜ platform-services-registry git:(feature/prov-cb) ✗ !9977
+➜ platform-services-registry git:(feature/prov-cb) ✗ oc policy add-role-to-group \
+ system:image-puller system:serviceaccounts:platform-registry-dev \
+ --namespace=platform-registry-tools
 clusterrole.rbac.authorization.k8s.io/system:image-puller added: "system:serviceaccounts:platform-registry-dev"
-➜  platform-services-registry git:(feature/prov-cb) ✗ oc process -f api/openshift/templates/deploy.yaml -p NAMESPACE=$(oc project --short) -p SOURCE_IMAGE_NAMESPACE=platform-registry-tools -p SOURCE_IMAGE_TAG=dev | oc apply -f -
+➜ platform-services-registry git:(feature/prov-cb) ✗ oc process -f api/openshift/templates/deploy.yaml -p NAMESPACE=\$(oc project --short) -p SOURCE_IMAGE_NAMESPACE=platform-registry-tools -p SOURCE_IMAGE_TAG=dev | oc apply -f -
 
 route.route.openshift.io/registry-api configured
 persistentvolumeclaim/registry-pgdata unchanged
@@ -103,17 +123,17 @@ service/registry-postgres unchanged
 service/registry-api unchanged
 deploymentconfig.apps.openshift.io/registry-postgres unchanged
 deploymentconfig.apps.openshift.io/registry-api configured
-➜  platform-services-registry git:(feature/prov-cb) ✗ oc get pods
-NAME                         READY   STATUS      RESTARTS   AGE
-registry-api-1-deploy        1/1     Running     0          18s
-registry-api-1-z2n4x         0/1     Running     0          15s
-registry-postgres-1-deploy   0/1     Completed   0          7m20s
-registry-postgres-1-ltv9z    1/1     Running     0          7m18s
-➜  platform-services-registry git:(feature/prov-cb) ✗ oc logs pod/registry-api-1-z2n4x -f
-Environment: 
-        DEV_MODE=false
-        NODE_ENV=production
-        DEBUG_PORT=5858
+➜ platform-services-registry git:(feature/prov-cb) ✗ oc get pods
+NAME READY STATUS RESTARTS AGE
+registry-api-1-deploy 1/1 Running 0 18s
+registry-api-1-z2n4x 0/1 Running 0 15s
+registry-postgres-1-deploy 0/1 Completed 0 7m20s
+registry-postgres-1-ltv9z 1/1 Running 0 7m18s
+➜ platform-services-registry git:(feature/prov-cb) ✗ oc logs pod/registry-api-1-z2n4x -f
+Environment:
+DEV_MODE=false
+NODE_ENV=production
+DEBUG_PORT=5858
 Launching via npm...
 npm info it worked if it ends with ok
 npm info using npm@6.13.4
@@ -130,118 +150,120 @@ npm info lifecycle platform-services-registry@0.0.1~start: platform-services-reg
 2020-07-28T19:41:45.110Z warn: Static assets location does not exist
 2020-07-28T19:41:45.304Z info: nats connect to nats.pye-sandbox.svc:4222
 ^C
-➜  platform-services-registry git:(feature/prov-cb) ✗ oc get pods
-NAME                         READY   STATUS      RESTARTS   AGE
-registry-api-1-deploy        0/1     Completed   0          66s
-registry-api-1-z2n4x         1/1     Running     0          63s
-registry-postgres-1-deploy   0/1     Completed   0          8m8s
-registry-postgres-1-ltv9z    1/1     Running     0          8m6s
-➜  platform-services-registry git:(feature/prov-cb) ✗ history|grep run|grep postg
- 8936  docker run --it -rm --name blarb postgres
- 8937  docker run -it --rm --name blarb postgres
- 9264  docker run -it --rm --name blarb postgres -v $(pwd):/opt/src
+➜ platform-services-registry git:(feature/prov-cb) ✗ oc get pods
+NAME READY STATUS RESTARTS AGE
+registry-api-1-deploy 0/1 Completed 0 66s
+registry-api-1-z2n4x 1/1 Running 0 63s
+registry-postgres-1-deploy 0/1 Completed 0 8m8s
+registry-postgres-1-ltv9z 1/1 Running 0 8m6s
+➜ platform-services-registry git:(feature/prov-cb) ✗ history|grep run|grep postg
+8936 docker run --it -rm --name blarb postgres
+8937 docker run -it --rm --name blarb postgres
+9264 docker run -it --rm --name blarb postgres -v $(pwd):/opt/src
  9360  history|grep run|grep postg
  9361  docker run -it --rm --name blarb -v $(pwd):/opt/src postgres
- 9646  history|grep docker|grep run| grep postgr
- 9702  docker run -it --rm --name blarb postgres /bin/bash
- 9843  docker run -it --rm --name blarb postgres -v $(pwd):/opt/src /bin/bash
+9646 history|grep docker|grep run| grep postgr
+9702 docker run -it --rm --name blarb postgres /bin/bash
+9843 docker run -it --rm --name blarb postgres -v $(pwd):/opt/src /bin/bash
  9991  docker run -it --rm --name blarb -v $(pwd):/opt/src postgres /bin/bash
-10046  docker run -it --rm --name blarb -v $(pwd):/opt/src postgres /bin/bash
+10046 docker run -it --rm --name blarb -v $(pwd):/opt/src postgres /bin/bash
 ➜  platform-services-registry git:(feature/prov-cb) ✗ !10046
 ➜  platform-services-registry git:(feature/prov-cb) ✗ docker run -it --rm --name blarb -v $(pwd):/opt/src postgres /bin/bash
 root@afa1e9a07da4:/# cd /opt/src/db/s
-scripts/ seed/    sql/     
+scripts/ seed/ sql/  
 root@afa1e9a07da4:/# cd /opt/src/db/sql/
 root@afa1e9a07da4:/opt/src/db/sql# psql -U postgres -d registry -h host.docker.internal
 psql (12.0 (Debian 12.0-1.pgdg100+1), server 12.1)
 Type "help" for help.
 
 registry=# \du
-                                       List of roles
-    Role name     |                         Attributes                         | Membe
-r of 
+List of roles
+Role name | Attributes | Membe
+r of
 ------------------+------------------------------------------------------------+------
------
- app_api_x1feiv1x |                                                            | {}
- postgres         | Superuser, Create role, Create DB, Replication, Bypass RLS | {}
+
+---
+
+app_api_x1feiv1x | | {}
+postgres | Superuser, Create role, Create DB, Replication, Bypass RLS | {}
 
 registry=# \q
 root@afa1e9a07da4:/opt/src/db/sql# app_api_x1feiv1x
 bash: app_api_x1feiv1x: command not found
 root@afa1e9a07da4:/opt/src/db/sql# ls
 0001.sql
-root@afa1e9a07da4:/opt/src/db/sql# psql -U postgres -d registry -h host.docker.internal -v ROLLNAME=app_api_x1feiv1x -f 0001.sql 
+root@afa1e9a07da4:/opt/src/db/sql# psql -U postgres -d registry -h host.docker.internal -v ROLLNAME=app_api_x1feiv1x -f 0001.sql
 BEGIN
 CREATE FUNCTION
 CREATE TABLE
 GRANT
-psql:0001.sql:27: NOTICE:  trigger "update_ref_cluster_changetimestamp" for relation "ref_cluster" does not exist, skipping
+psql:0001.sql:27: NOTICE: trigger "update_ref_cluster_changetimestamp" for relation "ref_cluster" does not exist, skipping
 DROP TRIGGER
 CREATE TRIGGER
 CREATE TABLE
 GRANT
-psql:0001.sql:41: NOTICE:  trigger "update_ref_bus_org_changetimestamp" for relation "ref_bus_org" does not exist, skipping
+psql:0001.sql:41: NOTICE: trigger "update_ref_bus_org_changetimestamp" for relation "ref_bus_org" does not exist, skipping
 DROP TRIGGER
 CREATE TRIGGER
 CREATE TABLE
 GRANT
 GRANT
-psql:0001.sql:60: NOTICE:  trigger "update_user_profile_changetimestamp" for relation "user_profile" does not exist, skipping
+psql:0001.sql:60: NOTICE: trigger "update_user_profile_changetimestamp" for relation "user_profile" does not exist, skipping
 DROP TRIGGER
 CREATE TRIGGER
 CREATE TABLE
 CREATE INDEX
 GRANT
 GRANT
-psql:0001.sql:87: NOTICE:  trigger "update_profile_changetimestamp" for relation "profile" does not exist, skipping
+psql:0001.sql:87: NOTICE: trigger "update_profile_changetimestamp" for relation "profile" does not exist, skipping
 DROP TRIGGER
 CREATE TRIGGER
 CREATE TABLE
 GRANT
 GRANT
-psql:0001.sql:107: NOTICE:  trigger "update_namespace_changetimestamp" for relation "namespace" does not exist, skipping
+psql:0001.sql:107: NOTICE: trigger "update_namespace_changetimestamp" for relation "namespace" does not exist, skipping
 DROP TRIGGER
 CREATE TRIGGER
 CREATE TABLE
 GRANT
 GRANT
-psql:0001.sql:126: NOTICE:  trigger "update_cluster_namespace_changetimestamp" for relation "cluster_namespace" does not exist, skipping
+psql:0001.sql:126: NOTICE: trigger "update_cluster_namespace_changetimestamp" for relation "cluster_namespace" does not exist, skipping
 DROP TRIGGER
 CREATE TRIGGER
 CREATE TABLE
 GRANT
-psql:0001.sql:141: NOTICE:  trigger "update_ref_role_changetimestamp" for relation "ref_role" does not exist, skipping
-DROP TRIGGER
-CREATE TRIGGER
-CREATE TABLE
-GRANT
-GRANT
-psql:0001.sql:163: NOTICE:  trigger "update_contact_changetimestamp" for relation "contact" does not exist, skipping
+psql:0001.sql:141: NOTICE: trigger "update_ref_role_changetimestamp" for relation "ref_role" does not exist, skipping
 DROP TRIGGER
 CREATE TRIGGER
 CREATE TABLE
 GRANT
 GRANT
-psql:0001.sql:181: NOTICE:  trigger "update_profile_contact_changetimestamp" for relation "profile_contact" does not exist, skipping
+psql:0001.sql:163: NOTICE: trigger "update_contact_changetimestamp" for relation "contact" does not exist, skipping
+DROP TRIGGER
+CREATE TRIGGER
+CREATE TABLE
+GRANT
+GRANT
+psql:0001.sql:181: NOTICE: trigger "update_profile_contact_changetimestamp" for relation "profile_contact" does not exist, skipping
 DROP TRIGGER
 CREATE TRIGGER
 COMMIT
 root@afa1e9a07da4:/opt/src/db/sql# cd ..
 root@afa1e9a07da4:/opt/src/db# ls
-Dockerfile  scripts  seed  sql
+Dockerfile scripts seed sql
 root@afa1e9a07da4:/opt/src/db# cd seed/
 root@afa1e9a07da4:/opt/src/db/seed# ls
-ref_bus_org.sql  ref_cluster.sql  ref_role.sql
-root@afa1e9a07da4:/opt/src/db/seed# psql -U postgres -d registry -h host.docker.internal -v ROLLNAME=app_api_x1feiv1x -f ref_bus_org.sql 
+ref_bus_org.sql ref_cluster.sql ref_role.sql
+root@afa1e9a07da4:/opt/src/db/seed# psql -U postgres -d registry -h host.docker.internal -v ROLLNAME=app_api_x1feiv1x -f ref_bus_org.sql
 BEGIN
 INSERT 0 26
 COMMIT
-root@afa1e9a07da4:/opt/src/db/seed# psql -U postgres -d registry -h host.docker.internal -v ROLLNAME=app_api_x1feiv1x -f ref_cluster.sql 
+root@afa1e9a07da4:/opt/src/db/seed# psql -U postgres -d registry -h host.docker.internal -v ROLLNAME=app_api_x1feiv1x -f ref_cluster.sql
 BEGIN
 INSERT 0 6
 COMMIT
-root@afa1e9a07da4:/opt/src/db/seed# psql -U postgres -d registry -h host.docker.internal -v ROLLNAME=app_api_x1feiv1x -f ref_role.sql 
+root@afa1e9a07da4:/opt/src/db/seed# psql -U postgres -d registry -h host.docker.internal -v ROLLNAME=app_api_x1feiv1x -f ref_role.sql
 BEGIN
 INSERT 0 2
 COMMIT
-root@afa1e9a07da4:/opt/src/db/seed# 
+root@afa1e9a07da4:/opt/src/db/seed#

--- a/api/openshift/templates/deploy.yaml
+++ b/api/openshift/templates/deploy.yaml
@@ -23,300 +23,280 @@ metadata:
     iconClass: icon-node
   name: platform-services-registry
 objects:
-- apiVersion: v1
-  kind: Route
-  metadata:
-    labels:
-      app: platsrv-registry
-    name: ${API_NAME}
-  spec:
-    path: ""
-    port:
-      targetPort: 8080-tcp
-    tls:
-      termination: edge
-    to:
-      kind: Service
+  - apiVersion: v1
+    kind: Route
+    metadata:
+      labels:
+        app: platsrv-registry
       name: ${API_NAME}
-      weight: 100
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    labels:
-      app: platsrv-registry
-    name: ${POSTGRES_VOLUME_NAME}
-  spec:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: ${POSTGRES_VOLUME_CAPACITY}
-    storageClassName: netapp-file-standard
-- apiVersion: v1
-  kind: Service
-  metadata:
-    labels:
-      app: platsrv-registry
-    name: ${POSTGRES_DEPLOYMENT_NAME}
-  spec:
-    selector:
-      deploymentconfig: ${POSTGRES_DEPLOYMENT_NAME}
-    ports:
-      - name: 5432-tcp
-        port: 5432
-        protocol: TCP
-        targetPort: 5432
-- apiVersion: v1
-  kind: Service
-  metadata:
-    labels:
-      app: platsrv-registry
-    name: ${API_NAME}
-  spec:
-    selector:
-      deploymentconfig: ${API_NAME}
-    ports:
-      - name: 8080-tcp
-        port: 8080
-        protocol: TCP
-        targetPort: 8080
-- apiVersion: v1
-  kind: DeploymentConfig
-  metadata:
-    labels:
-      app: platsrv-registry
-    name: ${POSTGRES_DEPLOYMENT_NAME}
-  spec:
-    replicas: 1
-    selector:
-      deploymentconfig: ${POSTGRES_DEPLOYMENT_NAME}
-    strategy:
-      type: Rolling
-    template:
-      metadata:
-        labels:
-          app: platsrv-registry
-          role: db
-          deploymentconfig: ${POSTGRES_DEPLOYMENT_NAME}
-        name: ${POSTGRES_DEPLOYMENT_NAME}
-      spec:
-        containers:
-        - env:
-          - name: POSTGRESQL_USER
-            valueFrom:
-              secretKeyRef:
-                key: user
-                name: ${POSTGRESQL_SECRET_NAME}
-          - name: POSTGRESQL_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                key: password
-                name: ${POSTGRESQL_SECRET_NAME}
-          - name: POSTGRESQL_DATABASE
-            value: ${POSTGRESQL_DATABASE}
-          image: registry.redhat.io/rhscl/postgresql-12-rhel7:latest
-          livenessProbe:
-            initialDelaySeconds: 60
-            tcpSocket:
-              port: 5432
-            timeoutSeconds: 1
-          name: ${POSTGRES_DEPLOYMENT_NAME}
-          ports:
-          - containerPort: 5432
-            protocol: TCP
-          readinessProbe:
-            exec:
-              command:
-              - /bin/sh
-              - -i
-              - -c
-              - psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c
-                'SELECT 1'
-            initialDelaySeconds: 5
-            timeoutSeconds: 1
-          resources:
-            limits:
-              memory: ${POSTGRESQL_MEMORY_LIMIT}
-          volumeMounts:
-          - mountPath: /var/lib/pgsql/data
-            name: ${POSTGRES_VOLUME_NAME}
-        volumes:
-        - name: ${POSTGRES_VOLUME_NAME}
-          persistentVolumeClaim:
-            claimName: ${POSTGRES_VOLUME_NAME}
-    triggers:
-      - type: ConfigChange
-- apiVersion: v1
-  kind: DeploymentConfig
-  metadata:
-    labels:
-      app: platsrv-registry
-    name: ${API_NAME}
-  spec:
-    strategy:
-      type: Rolling
-    triggers:
-      - type: ConfigChange
-      - type: ImageChange
-        imageChangeParams:
-          automatic: true
-          containerNames:
-            - ${API_NAME}
-          from:
-            kind: ImageStreamTag
-            name: ${SOURCE_IMAGE_NAME}:${SOURCE_IMAGE_TAG}
-            namespace: ${SOURCE_IMAGE_NAMESPACE}
-    replicas: 1
-    selector:
-      deploymentconfig: ${API_NAME}
-    template:
-      metadata:
-        labels:
-          app: platsrv-registry
-          role: api
-          deploymentconfig: ${API_NAME}
+    spec:
+      path: ""
+      port:
+        targetPort: 8080-tcp
+      tls:
+        termination: edge
+      to:
+        kind: Service
         name: ${API_NAME}
-      spec:
-        containers:
-          - name: ${API_NAME}
-            image: " "
-            readinessProbe:
-              httpGet:
-                path: /api/v1/ehlo
-                port: 8080
-              initialDelaySeconds: 10
-              timeoutSeconds: 3
-            ports:
-              - containerPort: 8080
-            env:
-              - name: LOG_LEVEL
-                value: debug
-              - name: PORT
-                value: "8080"
-              - name: NODE_ENV
-                value: production
-              - name: APP_DB_USER
-                valueFrom:
-                  secretKeyRef:
-                    key: user
-                    name: ${POSTGRESQL_SECRET_NAME}
-              - name: APP_DB_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    key: password
-                    name: ${POSTGRESQL_SECRET_NAME}
-              - name: POSTGRESQL_HOST
-                value: ${POSTGRES_DEPLOYMENT_NAME}.${NAMESPACE}.svc
-              - name: CHES_BASEURL
-                value: ${CHES_BASEURL}
-              - name: CHES_SSO_TOKEN_URL
-                value: ${CHES_SSO_TOKEN_URL}
-              - name: CHES_SSO_CLIENT_ID
-                valueFrom:
-                  secretKeyRef:
-                    key: clientId
-                    name: ${CHES_SECRET_NAME}
-              - name: CHES_SSO_CLIENT_SECRET
-                valueFrom:
-                  secretKeyRef:
-                    key: secret
-                    name: ${CHES_SECRET_NAME}
-              - name: NATS_HOST
-                value: ${NATS_HOST_URL}
-              - name: SSO_CLIENT_SECRET
-                valueFrom:
-                  secretKeyRef:
-                    key: secret
-                    name: ${SSO_SECRET_NAME}
-            resources:
-              limits:
-                cpu: 300m
-                memory: 128Mi
-              requests:
-                cpu: 200m
-                memory: 92Mi
-            volumeMounts:
-              - name: config-vol
-                mountPath: /opt/app-root/src/build/config/config.json
-                subPath: config.json
-        volumes:
-          - name: config-vol
-            configMap:
-              name: registry-api-config
+        weight: 100
+  # - apiVersion: v1
+  #   kind: PersistentVolumeClaim
+  #   metadata:
+  #     labels:
+  #       app: platsrv-registry
+  #     name: ${POSTGRES_VOLUME_NAME}
+  #   spec:
+  #     accessModes:
+  #     - ReadWriteOnce
+  #     resources:
+  #       requests:
+  #         storage: ${POSTGRES_VOLUME_CAPACITY}
+  #     storageClassName: netapp-file-standard
+  # - apiVersion: v1
+  #   kind: Service
+  #   metadata:
+  #     labels:
+  #       app: platsrv-registry
+  #     name: ${POSTGRES_DEPLOYMENT_NAME}
+  #   spec:
+  #     selector:
+  #       deploymentconfig: ${POSTGRES_DEPLOYMENT_NAME}
+  #     ports:
+  #       - name: 5432-tcp
+  #         port: 5432
+  #         protocol: TCP
+  #         targetPort: 5432
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app: platsrv-registry
+      name: ${API_NAME}
+    spec:
+      selector:
+        deploymentconfig: ${API_NAME}
+      ports:
+        - name: 8080-tcp
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+  # - apiVersion: v1
+  #   kind: DeploymentConfig
+  #   metadata:
+  #     labels:
+  #       app: platsrv-registry
+  #     name: ${POSTGRES_DEPLOYMENT_NAME}
+  #   spec:
+  #     replicas: 1
+  #     selector:
+  #       deploymentconfig: ${POSTGRES_DEPLOYMENT_NAME}
+  #     strategy:
+  #       type: Rolling
+  #     template:
+  #       metadata:
+  #         labels:
+  #           app: platsrv-registry
+  #           role: db
+  #           deploymentconfig: ${POSTGRES_DEPLOYMENT_NAME}
+  #         name: ${POSTGRES_DEPLOYMENT_NAME}
+  #       spec:
+  #         containers:
+  #         - env:
+  #           - name: POSTGRESQL_USER
+  #             valueFrom:
+  #               secretKeyRef:
+  #                 key: user
+  #                 name: ${POSTGRESQL_SECRET_NAME}
+  #           - name: POSTGRESQL_PASSWORD
+  #             valueFrom:
+  #               secretKeyRef:
+  #                 key: password
+  #                 name: ${POSTGRESQL_SECRET_NAME}
+  #           - name: POSTGRESQL_DATABASE
+  #             value: ${POSTGRESQL_DATABASE}
+  #           image: registry.redhat.io/rhscl/postgresql-12-rhel7:latest
+  #           livenessProbe:
+  #             initialDelaySeconds: 60
+  #             tcpSocket:
+  #               port: 5432
+  #             timeoutSeconds: 1
+  #           name: ${POSTGRES_DEPLOYMENT_NAME}
+  #           ports:
+  #           - containerPort: 5432
+  #             protocol: TCP
+  #           readinessProbe:
+  #             exec:
+  #               command:
+  #               - /bin/sh
+  #               - -i
+  #               - -c
+  #               - psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c
+  #                 'SELECT 1'
+  #             initialDelaySeconds: 5
+  #             timeoutSeconds: 1
+  #           resources:
+  #             limits:
+  #               memory: ${POSTGRESQL_MEMORY_LIMIT}
+  #           volumeMounts:
+  #           - mountPath: /var/lib/pgsql/data
+  #             name: ${POSTGRES_VOLUME_NAME}
+  #         volumes:
+  #         - name: ${POSTGRES_VOLUME_NAME}
+  #           persistentVolumeClaim:
+  #             claimName: ${POSTGRES_VOLUME_NAME}
+  #     triggers:
+  #       - type: ConfigChange
+  - apiVersion: v1
+    kind: DeploymentConfig
+    metadata:
+      labels:
+        app: platsrv-registry
+      name: ${API_NAME}
+    spec:
+      strategy:
+        type: Rolling
+      triggers:
+        - type: ConfigChange
+        - type: ImageChange
+          imageChangeParams:
+            automatic: true
+            containerNames:
+              - ${API_NAME}
+            from:
+              kind: ImageStreamTag
+              name: ${SOURCE_IMAGE_NAME}:${SOURCE_IMAGE_TAG}
+              namespace: ${SOURCE_IMAGE_NAMESPACE}
+      replicas: 1
+      selector:
+        deploymentconfig: ${API_NAME}
+      template:
+        metadata:
+          labels:
+            app: platsrv-registry
+            role: api
+            deploymentconfig: ${API_NAME}
+          name: ${API_NAME}
+        spec:
+          containers:
+            - name: ${API_NAME}
+              image: " "
+              readinessProbe:
+                httpGet:
+                  path: /api/v1/ehlo
+                  port: 8080
+                initialDelaySeconds: 10
+                timeoutSeconds: 3
+              ports:
+                - containerPort: 8080
+              env:
+                - name: LOG_LEVEL
+                  value: debug
+                - name: PORT
+                  value: "8080"
+                - name: NODE_ENV
+                  value: production
+                - name: APP_DB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      key: app-db-username
+                      name: ${POSTGRESQL_SECRET_NAME}
+                - name: APP_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: app-db-password
+                      name: ${POSTGRESQL_SECRET_NAME}
+                - name: POSTGRESQL_HOST
+                  value: ${POSTGRESQL_DATABASE}
+                - name: CHES_BASEURL
+                  value: ${CHES_BASEURL}
+                - name: CHES_SSO_TOKEN_URL
+                  value: ${CHES_SSO_TOKEN_URL}
+                - name: CHES_SSO_CLIENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      key: clientId
+                      name: ${CHES_SECRET_NAME}
+                - name: CHES_SSO_CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      key: secret
+                      name: ${CHES_SECRET_NAME}
+                - name: NATS_HOST
+                  value: ${NATS_HOST_URL}
+                - name: SSO_CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      key: secret
+                      name: ${SSO_SECRET_NAME}
+              resources:
+                limits:
+                  cpu: 300m
+                  memory: 128Mi
+                requests:
+                  cpu: 200m
+                  memory: 92Mi
+              volumeMounts:
+                - name: config-vol
+                  mountPath: /opt/app-root/src/build/config/config.json
+                  subPath: config.json
+          volumes:
+            - name: config-vol
+              configMap:
+                name: registry-api-config
 parameters:
-- description: The name assigned to all of the objects defined in this template.  You
-    should keep this as default unless your know what your doing.
-  displayName: Name
-  name: API_NAME
-  required: true
-  value: registry-api
-- description: The namespace of the OpenShift project containing the imagestream for
-    the application.
-  displayName: Environment namespace
-  name: NAMESPACE
-  required: true
-- description: The name assigned to all of the objects defined in this template.  You
-    should keep this as default unless your know what your doing.
-  displayName: Database Service Name
-  name: POSTGRES_DEPLOYMENT_NAME
-  required: true
-  value: registry-postgres
-- description: The secret name for the database.
-  displayName: PostgreSQL secret name
-  name: POSTGRESQL_SECRET_NAME
-  value: registry-postgres-creds
-- description: Maximum amount of memory the PostgreSQL container can use.
-  displayName: Memory Limit (PostgreSQL)
-  name: POSTGRESQL_MEMORY_LIMIT
-  required: true
-  value: 512Mi
-- displayName: The PostgreSQL database for the health check probe
-  name: POSTGRESQL_DATABASE
-  required: true
-  value: registry
-- description: The Postgres storage name as postgres-data
-  displayName: The Postgres storage name
-  name: POSTGRES_VOLUME_NAME
-  required: true
-  value: registry-pgdata
-- description: Volume space available for data, e.g. 512Mi, 2Gi
-  displayName: Volume Capacity
-  name: POSTGRES_VOLUME_CAPACITY
-  from: "[0-9]{3}Gi"
-  required: true
-  value: 1Gi
-- description: The openshift project where builds and target images are stored.
-  displayName: Build Project
-  name: SOURCE_IMAGE_NAMESPACE
-  required: true
-- description: The name of the source image.
-  displayName: Source Image Name
-  name: SOURCE_IMAGE_NAME
-  value: platsrv-registry-api
-  required: true
-- description: The tag of the source image.
-  displayName: Source Image Tag
-  name: SOURCE_IMAGE_TAG
-  required: true
-- description: The Common Hosted Email Service secret name 
-  displayName: Email Service Secret Name
-  name: CHES_SECRET_NAME
-  value: registry-ches-creds
-- description: The base URL for the Common Hosted Email Service API
-  displayName: Email Service API URL
-  name: CHES_BASEURL
-  required: true
-- description: The Common Hosted Email Service SSO URL
-  displayName: Email Service SSO URL
-  name: CHES_SSO_TOKEN_URL
-  required: true
-- description: |
-    The NATS host URI
-  displayName: NATS Host URI
-  name: NATS_HOST_URL
-  required: true
-- description: |
-    The name of the SSO client shared secret.
-  displayName: SSO Shared Secret Name
-  name: SSO_SECRET_NAME
-  value: registry-sso-creds
+  - description:
+      The name assigned to all of the objects defined in this template.  You
+      should keep this as default unless your know what your doing.
+    displayName: Name
+    name: API_NAME
+    required: true
+    value: registry-api
+  - description:
+      The namespace of the OpenShift project containing the imagestream for
+      the application.
+    displayName: Environment namespace
+    name: NAMESPACE
+    required: true
+  - description: The secret name for the database.
+    displayName: PostgreSQL secret name
+    name: POSTGRESQL_SECRET_NAME
+    value: registry-patroni
+  - displayName: The PostgreSQL database service name
+    name: POSTGRESQL_DATABASE
+    required: true
+    value: registry-patroni-master
+  - description: The openshift project where builds and target images are stored.
+    displayName: Build Project
+    name: SOURCE_IMAGE_NAMESPACE
+    required: true
+  - description: The name of the source image.
+    displayName: Source Image Name
+    name: SOURCE_IMAGE_NAME
+    value: platsrv-registry-api
+    required: true
+  - description: The tag of the source image.
+    displayName: Source Image Tag
+    name: SOURCE_IMAGE_TAG
+    required: true
+  - description: The Common Hosted Email Service secret name
+    displayName: Email Service Secret Name
+    name: CHES_SECRET_NAME
+    value: registry-ches-creds
+  - description: The base URL for the Common Hosted Email Service API
+    displayName: Email Service API URL
+    name: CHES_BASEURL
+    required: true
+  - description: The Common Hosted Email Service SSO URL
+    displayName: Email Service SSO URL
+    name: CHES_SSO_TOKEN_URL
+    required: true
+  - description: |
+      The NATS host URI
+    displayName: NATS Host URI
+    name: NATS_HOST_URL
+    required: true
+  - description: |
+      The name of the SSO client shared secret.
+    displayName: SSO Shared Secret Name
+    name: SSO_SECRET_NAME
+    value: registry-sso-creds

--- a/api/openshift/templates/secret.yaml
+++ b/api/openshift/templates/secret.yaml
@@ -18,76 +18,76 @@ kind: Template
 metadata:
   annotations:
     description: |
-      Deployment template for the Platform Serices
+      Deployment template for the Platform Services
       project registry.
     iconClass: icon-node
   name: platform-services-registry
 objects:
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    labels:
-      app: platsrv-registry
-    name: ${SSO_CLIENT_SECRET_NAME}
-  stringData:
-    secret: ${SSO_CLIENT_SECRET}
-  type: Opaque
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    labels:
-      app: platsrv-registry
-    name: ${POSTGRESQL_SECRET_NAME}
-  stringData:
-    password: ${POSTGRESQL_PASSWORD}
-    user: app_api_${POSTGRESQL_USER}
-  type: Opaque
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    labels:
-      app: platsrv-registry
-    name: ${CHES_SECRET_NAME}
-  stringData:
-    clientId: ${CHES_SSO_CLIENT_ID}
-    secret: ${CHES_SSO_CLIENT_SECRET}
-  type: Opaque
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        app: platsrv-registry
+      name: ${SSO_CLIENT_SECRET_NAME}
+    stringData:
+      secret: ${SSO_CLIENT_SECRET}
+    type: Opaque
+  # - apiVersion: v1
+  #   kind: Secret
+  #   metadata:
+  #     labels:
+  #       app: platsrv-registry
+  #     name: ${POSTGRESQL_SECRET_NAME}
+  #   stringData:
+  #     password: ${POSTGRESQL_PASSWORD}
+  #     user: app_api_${POSTGRESQL_USER}
+  #   type: Opaque
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        app: platsrv-registry
+      name: ${CHES_SECRET_NAME}
+    stringData:
+      clientId: ${CHES_SSO_CLIENT_ID}
+      secret: ${CHES_SSO_CLIENT_SECRET}
+    type: Opaque
 parameters:
-- description: The secret name of database.
-  displayName: PostgreSQL secret name
-  name: POSTGRESQL_SECRET_NAME
-  value: registry-postgres-creds
-- displayName: The PostgreSQL db user name
-  from: '[a-z0-9]{8}'
-  generate: expression
-  name: POSTGRESQL_USER
-  required: true
-- displayName: The PostgreSQL user password
-  from: '[a-z0-9]{16}'
-  generate: expression
-  name: POSTGRESQL_PASSWORD
-  required: true
-- description: The Common Hosted Email Service secret name
-  displayName: Common Hosted Email Service Credentials
-  name: CHES_SECRET_NAME
-  value: registry-ches-creds
-- description: The Common Hosted Email Service client ID
-  displayName: Email Service Client ID
-  name: CHES_SSO_CLIENT_ID
-  required: true
-- description: The Common Hosted Email Service shared secret
-  displayName: Email Service Client Secret
-  name: CHES_SSO_CLIENT_SECRET
-  required: true
-- description: |
-    The name of the SSO client shared secret. This allows
-    machine-2-macine authentication and usage of the API.
-  displayName: SSO Shared Secret Name
-  name: SSO_CLIENT_SECRET_NAME
-  value: registry-sso-creds
-- description: |
-    The SSO client shared secret. This allows machine-2-macine
-    authentication and usage of the API.
-  displayName: SSO Shared Secret
-  name: SSO_CLIENT_SECRET
-  required: true
+  - description: The secret name of database.
+    displayName: PostgreSQL secret name
+    name: POSTGRESQL_SECRET_NAME
+    value: registry-postgres-creds
+  - displayName: The PostgreSQL db user name
+    from: "[a-z0-9]{8}"
+    generate: expression
+    name: POSTGRESQL_USER
+    required: true
+  - displayName: The PostgreSQL user password
+    from: "[a-z0-9]{16}"
+    generate: expression
+    name: POSTGRESQL_PASSWORD
+    required: true
+  - description: The Common Hosted Email Service secret name
+    displayName: Common Hosted Email Service Credentials
+    name: CHES_SECRET_NAME
+    value: registry-ches-creds
+  - description: The Common Hosted Email Service client ID
+    displayName: Email Service Client ID
+    name: CHES_SSO_CLIENT_ID
+    required: true
+  - description: The Common Hosted Email Service shared secret
+    displayName: Email Service Client Secret
+    name: CHES_SSO_CLIENT_SECRET
+    required: true
+  - description: |
+      The name of the SSO client shared secret. This allows
+      machine-2-macine authentication and usage of the API.
+    displayName: SSO Shared Secret Name
+    name: SSO_CLIENT_SECRET_NAME
+    value: registry-sso-creds
+  - description: |
+      The SSO client shared secret. This allows machine-2-macine
+      authentication and usage of the API.
+    displayName: SSO Shared Secret
+    name: SSO_CLIENT_SECRET
+    required: true

--- a/openshift/templates/patroni-build.yaml
+++ b/openshift/templates/patroni-build.yaml
@@ -1,0 +1,91 @@
+apiVersion: v1
+kind: Template
+metadata:
+  creationTimestamp: null
+  name: patroni
+labels:
+  app: ${NAME}${SUFFIX}
+  phase: build
+  app.kubernetes.io/component: database
+  app.kubernetes.io/name: patroni
+  app.kubernetes.io/managed-by: template
+  app.kubernetes.io/version: "${PG_VERSION}"
+parameters:
+  - name: NAME
+    value: patroni
+  - name: SUFFIX
+  - name: OUT_VERSION
+    description: Ouput version
+    value: "v12-latest"
+  - name: GIT_URI
+    value: https://github.com/BCDevOps/platform-services.git
+  - name: GIT_REF
+    value: master
+  - name: PG_VERSION
+    value: "12"
+objects:
+  #Postgres ImageStream is created if it doesn't already exist
+  - apiVersion: image.openshift.io/v1
+    kind: ImageStream
+    metadata:
+      name: postgres
+    spec:
+      lookupPolicy:
+        local: false
+  - apiVersion: v1
+    kind: ImageStreamTag
+    lookupPolicy:
+      local: false
+    metadata:
+      name: postgres:${PG_VERSION}
+    tag:
+      annotations: null
+      from:
+        kind: DockerImage
+        name: registry.hub.docker.com/library/postgres:${PG_VERSION}
+      importPolicy:
+        scheduled: true
+      name: "${PG_VERSION}"
+      referencePolicy:
+        type: Source
+  - apiVersion: v1
+    kind: ImageStream
+    metadata:
+      creationTimestamp: null
+      name: ${NAME}
+    spec:
+      lookupPolicy:
+        local: false
+    status:
+      dockerImageRepository: ""
+  - apiVersion: v1
+    kind: BuildConfig
+    metadata:
+      creationTimestamp: null
+      name: ${NAME}${SUFFIX}
+    spec:
+      nodeSelector: null
+      output:
+        to:
+          kind: ImageStreamTag
+          name: "${NAME}:${OUT_VERSION}"
+      postCommit: {}
+      resources: {}
+      source:
+        contextDir: apps/pgsql/patroni/docker
+        git:
+          ref: ${GIT_REF}
+          uri: ${GIT_URI}
+        type: Git
+      strategy:
+        dockerStrategy:
+          from:
+            kind: ImageStreamTag
+            name: postgres:${PG_VERSION}
+        type: Docker
+      triggers:
+        - type: ConfigChange
+        - imageChange: {}
+          type: ImageChange
+    status:
+      lastVersion: 0

--- a/openshift/templates/patroni-deploy.yaml
+++ b/openshift/templates/patroni-deploy.yaml
@@ -1,0 +1,302 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  annotations:
+    description: |-
+      Patroni Postgresql database cluster, with persistent storage.
+    iconClass: icon-postgresql
+    openshift.io/display-name: Patroni Postgresql (Persistent)
+    openshift.io/long-description: This template deploys a patroni postgresql HA
+      cluster with persistent storage.
+    tags: postgresql
+  name: patroni-pgsql-persistent
+labels:
+  app: ${NAME}${SUFFIX}
+  phase: deploy
+  app.kubernetes.io/instance: ${NAME}${SUFFIX}
+  app.kubernetes.io/component: database
+  app.kubernetes.io/name: patroni  
+  app.kubernetes.io/managed-by: template
+objects:
+# It doesn't seem to be used/needed - remote it?
+#- apiVersion: v1
+#  kind: Service
+#  metadata:
+#    creationTimestamp: null
+#    labels:
+#      cluster-name: ${NAME}${SUFFIX}
+#    name: ${NAME}${SUFFIX}
+#  spec:
+#    ports:
+#    - name: 'postgresql'
+#      port: 5432
+#      protocol: TCP
+#      targetPort: 5432
+#    sessionAffinity: None
+#    type: ClusterIP
+#  status:
+#    loadBalancer: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      cluster-name: ${NAME}${SUFFIX}
+    name: ${NAME}-master${SUFFIX}
+  spec:
+    ports:
+    - port: 5432
+#      name: 'postgresql'
+      protocol: TCP
+      targetPort: 5432
+    selector:
+      cluster-name: ${NAME}${SUFFIX}
+      role: master
+      app.kubernetes.io/name: patroni
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+#- apiVersion: v1
+#  kind: Service
+#  metadata:
+#    creationTimestamp: null
+#    labels:
+#      cluster-name: ${NAME}${SUFFIX}
+#    name: ${NAME}-replica${SUFFIX}
+#  spec:
+#    ports:
+#    - port: 5432
+##      name: 'postgresql'
+#      protocol: TCP
+#      targetPort: 5432
+#    selector:
+#      cluster-name: ${NAME}${SUFFIX}
+#      app.kubernetes.io/name: patroni
+#      role: replica
+#    sessionAffinity: None
+#    type: ClusterIP
+#  status:
+#    loadBalancer: {}
+# - apiVersion: v1
+#   kind: ConfigMap
+#   metadata:
+#     name: ${NAME}${SUFFIX}-config
+# - apiVersion: v1
+#   kind: ConfigMap
+#   metadata:
+#     name: ${NAME}${SUFFIX}-leader
+- apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    creationTimestamp: null
+    generation: 3
+    labels:
+      cluster-name: ${NAME}${SUFFIX}
+    name: ${NAME}${SUFFIX}
+  spec:
+    podManagementPolicy: OrderedReady
+    replicas: ${{REPLICAS}}
+    revisionHistoryLimit: 10
+    selector:
+      matchLabels:
+        statefulset: ${NAME}${SUFFIX}
+    serviceName: ${NAME}${SUFFIX}
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          statefulset: ${NAME}${SUFFIX}
+          cluster-name: ${NAME}${SUFFIX}
+          app.kubernetes.io/name: patroni
+      spec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: statefulset
+                  operator: In
+                  values: 
+                  - ${NAME}${SUFFIX}
+              topologyKey: "kubernetes.io/hostname"
+        containers:
+        - env:
+          #TODO: Remove POD_IP in favor of PATRONI_KUBERNETES_POD_IP
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+#          - name: PATRONI_KUBERNETES_USE_ENDPOINTS
+#            value: 'true'
+#          - name: PATRONI_KUBERNETES_POD_IP
+#            valueFrom:
+#              fieldRef:
+#                apiVersion: v1
+#                fieldPath: status.podIP
+#          - name: PATRONI_KUBERNETES_PORTS
+#            value: '{[{"name": "postgresql", "port": 5432}]}'
+          - name: PATRONI_KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: PATRONI_KUBERNETES_LABELS
+            value: '{"cluster-name": "${NAME}${SUFFIX}", "app.kubernetes.io/name": "patroni"}'
+          - name: PATRONI_SUPERUSER_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: superuser-username
+                name: ${NAME}${SUFFIX}
+          - name: PATRONI_SUPERUSER_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: superuser-password
+                name: ${NAME}${SUFFIX}
+          - name: PATRONI_REPLICATION_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: replication-username
+                name: ${NAME}${SUFFIX}
+          - name: PATRONI_REPLICATION_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: replication-password
+                name: ${NAME}${SUFFIX}
+          - name: APP_USER
+            valueFrom:
+              secretKeyRef:
+                key: app-db-username
+                name: ${NAME}${SUFFIX}
+          - name: APP_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: app-db-password
+                name: ${NAME}${SUFFIX}
+          - name: APP_DATABASE
+            valueFrom:
+              secretKeyRef:
+                key: app-db-name
+                name: ${NAME}${SUFFIX}
+          - name: PATRONI_SCOPE
+            value: ${NAME}${SUFFIX}
+          - name: PATRONI_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: PATRONI_LOG_LEVEL
+            value: WARNING
+          - name: PATRONI_POSTGRESQL_DATA_DIR
+            value: /home/postgres/pgdata/pgroot/data
+          - name: PATRONI_POSTGRESQL_PGPASS
+            value: /tmp/pgpass
+          - name: PATRONI_POSTGRESQL_LISTEN
+            value: 0.0.0.0:5432
+          - name: PATRONI_RESTAPI_LISTEN
+            value: 0.0.0.0:8008
+          image: ${IMAGE_REGISTRY}/${IMAGE_STREAM_NAMESPACE}/${IMAGE_STREAM_TAG}
+          # Because we are using image reference to a tag, we need to always pull the image otherwise
+          #   we end up with outdated/out-of-sync image depending on the node where it is running
+          imagePullPolicy: Always
+          name: postgresql
+          ports:
+          - containerPort: 8008
+            protocol: TCP
+          - containerPort: 5432
+            protocol: TCP
+          resources:
+            requests:
+              cpu: ${CPU_REQUEST}
+              memory: ${MEMORY_REQUEST}
+            limits:
+              cpu: ${CPU_LIMIT}
+              memory: ${MEMORY_LIMIT}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          readinessProbe:
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 4
+            exec:
+              command:
+                - /usr/share/scripts/patroni/health_check.sh
+          volumeMounts:
+          - mountPath: /home/postgres/pgdata
+            name: postgresql
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        serviceAccountName: ${NAME}${SUFFIX}
+        terminationGracePeriodSeconds: 0
+    updateStrategy:
+      type: RollingUpdate
+    volumeClaimTemplates:
+    - metadata:
+        annotations:
+          volume.beta.kubernetes.io/storage-class: ${STORAGE_CLASS}
+        labels:
+          app: ${NAME}${SUFFIX}
+        name: postgresql
+      spec:
+        storageClassName: ${STORAGE_CLASS}
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: ${PVC_SIZE}
+# It doesn't seem to be used/needed - remote it?
+#- apiVersion: v1
+#  kind: Endpoints
+#  metadata:
+#    labels:
+#      app: ${NAME}${SUFFIX}
+#      cluster-name: ${NAME}${SUFFIX}
+#    name: ${NAME}${SUFFIX}
+#  subsets: []
+parameters:
+- description: The name of the application for labelling all artifacts.
+  displayName: Application Name
+  name: NAME
+  value: patroni
+- name: SUFFIX
+  description: A suffix appended to all artifact's name (NAME)
+- name: REPLICAS
+  displayName: REPLICAS
+  description: The number of statefulSet replicas to use.
+  value: '3'
+- description: Starting amount of CPU the container can use.
+  displayName: CPU REQUEST
+  name: CPU_REQUEST
+  value: '250m'
+- description: Maximum amount of CPU the container can use.
+  displayName: CPU Limit
+  name: CPU_LIMIT
+  value: '1'
+- description: Starting amount of memory the container can use.
+  displayName: Memory Request
+  name: MEMORY_REQUEST
+  value: 512Mi
+- description: Maximum amount of memory the container can use.
+  displayName: Memory Limit
+  name: MEMORY_LIMIT
+  value: 512Mi
+- description: The OpenShift Namespace where the patroni and postgresql ImageStream
+    resides.
+  displayName: ImageStream Namespace
+  name: IMAGE_STREAM_NAMESPACE
+  value: "bcgov"
+- name: IMAGE_STREAM_TAG
+  description: Patroni ImageTag
+  value: patroni:v11-stable
+- description: The size of the persistent volume to create.
+  displayName: Persistent Volume Size
+  name: PVC_SIZE
+  value: 1Gi
+- name: STORAGE_CLASS
+  value: netapp-block-standard
+- name: IMAGE_REGISTRY
+  #ocp3#docker-registry.default.svc:5000
+  value: image-registry.openshift-image-registry.svc:5000

--- a/openshift/templates/patroni-pre-req.yaml
+++ b/openshift/templates/patroni-pre-req.yaml
@@ -1,0 +1,139 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  annotations:
+    description: |-
+      Patroni Postgresql database cluster (prerequisites)
+    iconClass: icon-postgresql
+    openshift.io/display-name: Patroni Postgresql prerequisites
+    openshift.io/long-description: This template deploys patroni prerequisites for an HA DB (secret, service account, role)
+    tags: postgresql
+  name: patroni-pgsql-pre-requisite
+labels:
+  app.kubernetes.io/component: database
+  app.kubernetes.io/name: patroni
+  app.kubernetes.io/managed-by: template
+objects:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        app: ${NAME}${SUFFIX}
+        cluster-name: ${NAME}${SUFFIX}
+      name: ${NAME}${SUFFIX}
+    stringData:
+      replication-username: ${PATRONI_REPLICATION_USERNAME}
+      replication-password: ${PATRONI_REPLICATION_PASSWORD}
+      superuser-username: ${PATRONI_SUPERUSER_USERNAME}
+      superuser-password: ${PATRONI_SUPERUSER_PASSWORD}
+      app-db-name: ${APP_DB_NAME}
+      app-db-username: app_api_${APP_DB_USERNAME}
+      app-db-password: ${APP_DB_PASSWORD}
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        cluster-name: ${NAME}${SUFFIX}
+      name: ${NAME}${SUFFIX}
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        cluster-name: ${NAME}${SUFFIX}
+      name: ${NAME}${SUFFIX}
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - services
+        verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+          - delete
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+        verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+          - delete
+      - apiGroups:
+          - ""
+        resources:
+          - endpoints
+        verbs:
+          - get
+          - patch
+          - update
+          - create
+          - list
+          - watch
+          - delete
+      - apiGroups:
+          - ""
+        resources:
+          - pods
+        verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        cluster-name: ${NAME}${SUFFIX}
+      name: ${NAME}${SUFFIX}
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: ${NAME}${SUFFIX}
+    subjects:
+      - kind: ServiceAccount
+        name: ${NAME}${SUFFIX}
+parameters:
+  - description: The name of the application for labelling all artifacts.
+    displayName: Application Name
+    name: NAME
+    value: patroni
+  - name: SUFFIX
+  - description: Username of the superuser account for initialization.
+    displayName: Superuser Username
+    name: PATRONI_SUPERUSER_USERNAME
+    value: postgres
+  #  generate: expression
+  #  from: super-[a-zA-Z0-9]{6}
+  - description: Password of the superuser account for initialization.
+    displayName: Superuser Password
+    name: PATRONI_SUPERUSER_PASSWORD
+    generate: expression
+    from: "[a-zA-Z0-9]{32}"
+  - description: Username of the replication account for initialization.
+    displayName: Replication Username
+    name: PATRONI_REPLICATION_USERNAME
+    value: replication
+  #  generate: expression
+  #  from: rep-[a-zA-Z0-9]{6}
+  - description: Password of the replication account for initialization.
+    displayName: Replication Password
+    name: PATRONI_REPLICATION_PASSWORD
+    generate: expression
+    from: "[a-zA-Z0-9]{32}"
+  - name: APP_DB_USERNAME
+    generate: expression
+    from: "[a-zA-Z0-9]{8}"
+  - name: APP_DB_NAME
+    value: registry
+  - name: APP_DB_PASSWORD
+    generate: expression
+    from: "[a-zA-Z0-9]{32}"


### PR DESCRIPTION
- Updated build/deploy instructions in the README.md to add steps to build/deploy a patroni service. 
>no requirement for a build, but it's there for convenience.  Simply need to change the IMAGE_STREAM_xxx parameters to leverage the patroni image you want.

- Updates made to remove postgresql secrets, pvc, service, deployment from existing templates
- Updated env variables in api deployment to use new patroni secrets

## TODO:
- Integrated deployment testing - Patroni build/deploy test out fine, but I'm currently unable to deploy the rest of the app without additional assistance.
- create a build/deploy/config for the backup-container

/bot-ignore-length