### PR TITLE
Docs/Sample Configuration for backup container build/deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ curl -vX PUT -H "Content-Type: application/json" -H "Authorization: Bearer \${MY
 
 ## Build
 
+Configure initial project set RBAC (to allow images in -tools to be referenced by other projects)
+
+> Note: Namespace to apply to is hard-coded in the yaml
+
+`oc apply -f ./openshift/templates/project-set-rbac.yaml`
+
 ### API
 
 `oc process -f api/openshift/templates/build.yaml| oc apply -f -`

--- a/openshift/backup/backup-build.param
+++ b/openshift/backup/backup-build.param
@@ -1,0 +1,12 @@
+#=========================================================
+# OpenShift template parameters for:
+# Component: backup
+# Template File: https://github.com/BCDevOps/backup-container/blob/master/openshift/templates/backup/backup-build.json
+#=========================================================
+# Commented entries denote template default values
+# NAME=backup-postgres
+# GIT_REPO_URL=https://github.com/BCDevOps/backup-container.git
+# GIT_REF=master
+# SOURCE_CONTEXT_DIR=/docker
+# DOCKER_FILE_PATH=Dockerfile
+# OUTPUT_IMAGE_TAG=latest

--- a/openshift/backup/deploy-values.yaml
+++ b/openshift/backup/deploy-values.yaml
@@ -1,0 +1,30 @@
+image:
+  repository: image-registry.openshift-image-registry.svc:5000/platform-registry-tools/backup-postgres
+  pullPolicy: Always
+  tag: latest
+
+persistence:
+  backup:
+    size: 1Gi
+    storageClassName: netapp-file-backup
+  verification:
+    size: 1Gi
+
+db:
+  secretName: registry-patroni
+  usernameKey: superuser-username
+  passwordKey: superuser-password
+
+env:
+  DATABASE_SERVICE_NAME:
+    value: registry-patroni-master
+  ENVIRONMENT_FRIENDLY_NAME:
+    value: "Project Registry DB Backups"
+  ENVIRONMENT_NAME:
+    value: "dev"
+
+backupConfig: |
+  postgres=registry-patroni-master:5432/registry
+
+  0 1 * * * default ./backup.sh -s
+  0 4 * * * default ./backup.sh -s -v all

--- a/openshift/templates/project-set-rbac.yaml
+++ b/openshift/templates/project-set-rbac.yaml
@@ -1,0 +1,37 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: project-set:image-puller
+  namespace: platform-registry-tools
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:image-puller
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: platform-registry-dev
+- kind: ServiceAccount
+  name: default
+  namespace: platform-registry-test
+- kind: ServiceAccount
+  name: default
+  namespace: platform-registry-prod
+- kind: ServiceAccount
+  name: db-backup-backup-storage
+  namespace: platform-registry-dev
+- kind: ServiceAccount
+  name: db-backup-backup-storage
+  namespace: platform-registry-test
+- kind: ServiceAccount
+  name: db-backup-backup-storage
+  namespace: platform-registry-prod
+- kind: ServiceAccount
+  name: registry-patroni
+  namespace: platform-registry-dev
+- kind: ServiceAccount
+  name: registry-patroni
+  namespace: platform-registry-test
+- kind: ServiceAccount
+  name: registry-patroni
+  namespace: platform-registry-prod


### PR DESCRIPTION
Instructions to create a buildconfig for the backup-postgres image to be used by the backup-container (in tools)
- No tagging other than :latest has been added yet.

Instructions and an initial configuration for the deployment of the backup container.
- uses helm chart for deployment vs managing all manifests at the moment.  (can generate manifests for integration into the repository if wanted)

Assumes access to pull image from -tools is available (can modify image namespace in config if wanted)