### PR TITLE
Bug fixing and enhancement around the form for creating new project set

### DIFF
--- a/web/src/AppRouter.tsx
+++ b/web/src/AppRouter.tsx
@@ -18,7 +18,7 @@ import { createBrowserHistory } from 'history';
 import React from 'react';
 import { Redirect, Router, Switch } from 'react-router-dom';
 import Layout from './components/Layout';
-import { HOME_PAGE_URL, LAYOUT_SET_AUTH, LAYOUT_SET_MIN, LAYOUT_SET_UNAUTH } from './constants';
+import { HOME_PAGE_URL, LAYOUT_SET_AUTH, LAYOUT_SET_MIN, LAYOUT_SET_UNAUTH, ROUTE_PATHS } from './constants';
 import AppRoute from './utils/AppRoute';
 import { Dashboard } from './views/Dashboard';
 import form from './views/form';
@@ -31,12 +31,12 @@ const AppRouter: React.FC = () => {
   return (
     <Router history={browserHistory}>
       <Switch>
-        <Redirect exact from='/' to='/public-landing' />
-        <AppRoute path='/public-landing' component={PublicLanding} layout={Layout} layoutName={LAYOUT_SET_UNAUTH} />
-        <AppRoute path='/namespaces/create' component={form} layout={Layout} layoutName={LAYOUT_SET_AUTH} />
+        <Redirect exact from='/' to={ROUTE_PATHS.LANDING} />
+        <AppRoute path={ROUTE_PATHS.LANDING} component={PublicLanding} layout={Layout} layoutName={LAYOUT_SET_UNAUTH} />
+        <AppRoute exact path={ROUTE_PATHS.FORM} component={form} layout={Layout} layoutName={LAYOUT_SET_AUTH} />
         <AppRoute exact path={HOME_PAGE_URL} component={Dashboard} layout={Layout} layoutName={LAYOUT_SET_AUTH} />
-        <AppRoute path='/page-not-found' component={NotFound} layout={Layout} layoutName={LAYOUT_SET_MIN} />
-        <Redirect to='/page-not-found' />
+        <AppRoute path={ROUTE_PATHS.NOT_FOUND} component={NotFound} layout={Layout} layoutName={LAYOUT_SET_MIN} />
+        <Redirect to={ROUTE_PATHS.NOT_FOUND} />
       </Switch>
     </Router>
   );

--- a/web/src/__tests__/__snapshots__/form.test.tsx.snap
+++ b/web/src/__tests__/__snapshots__/form.test.tsx.snap
@@ -16,17 +16,17 @@ exports[`matches the snapshot 1`] = `
             Tell us about your project
           </h1>
           <div
-            class="css-761hsa"
+            class="css-j2gbad"
             style="position: relative;"
           >
             <label
-              class="css-knfhfe"
+              class="css-1h8msqk"
               for="project-name"
             >
               Name
             </label>
             <input
-              class="css-4y926w"
+              class="css-1f2jrlr"
               id="project-name"
               name="project-name"
               placeholder="Project X"
@@ -35,17 +35,17 @@ exports[`matches the snapshot 1`] = `
             />
           </div>
           <div
-            class="css-761hsa"
+            class="css-j2gbad"
             style="position: relative;"
           >
             <label
-              class="css-knfhfe"
+              class="css-1h8msqk"
               for="project-description"
             >
               Description
             </label>
             <textarea
-              class="css-4y926w"
+              class="css-1f2jrlr"
               id="project-description"
               name="project-description"
               placeholder="A cutting edge web platform that enables Citizens to ..."
@@ -53,10 +53,10 @@ exports[`matches the snapshot 1`] = `
             />
           </div>
           <div
-            class="css-4cffwv"
+            class="css-1alsiom"
           >
             <label
-              class="css-knfhfe"
+              class="css-1h8msqk"
             >
               Is this a Priority Application?
             </label>
@@ -64,7 +64,7 @@ exports[`matches the snapshot 1`] = `
               class="css-xtali0"
             >
               <label
-                class="css-v4bk2t"
+                class="css-1grp5jk"
               >
                 <input
                   name="project-prioritySystem"
@@ -76,7 +76,7 @@ exports[`matches the snapshot 1`] = `
             </div>
           </div>
           <div
-            class="css-4cffwv"
+            class="css-1alsiom"
           >
             <label
               class="css-knfhfe"
@@ -425,7 +425,8 @@ exports[`matches the snapshot 1`] = `
             </div>
           </div>
           <div
-            class="css-4cffwv"
+            class="css-1vmgfxl"
+            style="position: relative;"
           >
             <label
               class="css-knfhfe"
@@ -489,17 +490,17 @@ exports[`matches the snapshot 1`] = `
             Who is the product owner for this project?
           </h1>
           <div
-            class="css-761hsa"
+            class="css-j2gbad"
             style="position: relative;"
           >
             <label
-              class="css-knfhfe"
+              class="css-1h8msqk"
               for="po-first-name"
             >
               First Name
             </label>
             <input
-              class="css-4y926w"
+              class="css-1f2jrlr"
               id="po-first-name"
               name="po-firstName"
               placeholder="Jane"
@@ -508,17 +509,17 @@ exports[`matches the snapshot 1`] = `
             />
           </div>
           <div
-            class="css-761hsa"
+            class="css-j2gbad"
             style="position: relative;"
           >
             <label
-              class="css-knfhfe"
+              class="css-1h8msqk"
               for="po-last-name"
             >
               Last Name
             </label>
             <input
-              class="css-4y926w"
+              class="css-1f2jrlr"
               id="po-last-name"
               name="po-lastName"
               placeholder="Doe"
@@ -527,17 +528,17 @@ exports[`matches the snapshot 1`] = `
             />
           </div>
           <div
-            class="css-761hsa"
+            class="css-j2gbad"
             style="position: relative;"
           >
             <label
-              class="css-knfhfe"
+              class="css-1h8msqk"
               for="po-email"
             >
               eMail Address
             </label>
             <input
-              class="css-4y926w"
+              class="css-1f2jrlr"
               id="po-email"
               name="po-email"
               placeholder="jane.doe@gov.bc.ca"
@@ -546,17 +547,17 @@ exports[`matches the snapshot 1`] = `
             />
           </div>
           <div
-            class="css-761hsa"
+            class="css-j2gbad"
             style="position: relative;"
           >
             <label
-              class="css-knfhfe"
+              class="css-1h8msqk"
               for="po-github-id"
             >
               GitHub ID
             </label>
             <input
-              class="css-4y926w"
+              class="css-1f2jrlr"
               id="po-github-id"
               name="po-githubId"
               placeholder="jane1100"
@@ -589,17 +590,17 @@ exports[`matches the snapshot 1`] = `
             Who is the technical contact for this project?
           </h1>
           <div
-            class="css-761hsa"
+            class="css-j2gbad"
             style="position: relative;"
           >
             <label
-              class="css-knfhfe"
+              class="css-1h8msqk"
               for="tc-first-name"
             >
               First Name
             </label>
             <input
-              class="css-4y926w"
+              class="css-1f2jrlr"
               id="tc-first-name"
               name="tc-firstName"
               placeholder="Jane"
@@ -608,17 +609,17 @@ exports[`matches the snapshot 1`] = `
             />
           </div>
           <div
-            class="css-761hsa"
+            class="css-j2gbad"
             style="position: relative;"
           >
             <label
-              class="css-knfhfe"
+              class="css-1h8msqk"
               for="tc-last-name"
             >
               Last Name
             </label>
             <input
-              class="css-4y926w"
+              class="css-1f2jrlr"
               id="tc-last-name"
               name="tc-lastName"
               placeholder="Doe"
@@ -627,17 +628,17 @@ exports[`matches the snapshot 1`] = `
             />
           </div>
           <div
-            class="css-761hsa"
+            class="css-j2gbad"
             style="position: relative;"
           >
             <label
-              class="css-knfhfe"
+              class="css-1h8msqk"
               for="tc-email"
             >
               eMail Address
             </label>
             <input
-              class="css-4y926w"
+              class="css-1f2jrlr"
               id="tc-email"
               name="tc-email"
               placeholder="jane.doe@gov.bc.ca"
@@ -646,17 +647,17 @@ exports[`matches the snapshot 1`] = `
             />
           </div>
           <div
-            class="css-761hsa"
+            class="css-j2gbad"
             style="position: relative;"
           >
             <label
-              class="css-knfhfe"
+              class="css-1h8msqk"
               for="tc-github-id"
             >
               GitHub ID
             </label>
             <input
-              class="css-4y926w"
+              class="css-1f2jrlr"
               id="tc-github-id"
               name="tc-githubId"
               placeholder="jane1100"

--- a/web/src/components/DropdownMenu.tsx
+++ b/web/src/components/DropdownMenu.tsx
@@ -15,7 +15,7 @@
 //
 
 import styled from '@emotion/styled';
-import { default as React } from 'react';
+import { default as React, MouseEventHandler } from 'react';
 import theme from '../theme';
 import { MenuItem } from '../types';
 import DropdownMenuItem from './DropdownMenuItem';
@@ -33,10 +33,11 @@ const StyledDropdown = styled.div`
 interface IDropdownMenuProps {
   menuItems: Array<MenuItem>;
   ref?: any;
+  handleDDDesktop: MouseEventHandler<React.ReactNode>;
 }
 
 const DropdownMenu: React.FC<IDropdownMenuProps> = React.forwardRef((props, ref) => {
-  const { menuItems } = props;
+  const { menuItems, handleDDDesktop } = props;
 
   return (
     // TODO: investigate ref type error
@@ -45,7 +46,7 @@ const DropdownMenu: React.FC<IDropdownMenuProps> = React.forwardRef((props, ref)
       <StyledDropdown>
         {menuItems.map(
           (item, index) =>
-            <DropdownMenuItem key={index + item.title} href={item.href} title={item.title} subTitle={item.subTitle} onClickCB={item.onClickCB} />
+            <DropdownMenuItem handleDDDesktop={handleDDDesktop} key={index + item.title} href={item.href} title={item.title} subTitle={item.subTitle} onClickCB={item.onClickCB} />
         )}
       </StyledDropdown>
     </div>

--- a/web/src/components/DropdownMenu.tsx
+++ b/web/src/components/DropdownMenu.tsx
@@ -33,11 +33,11 @@ const StyledDropdown = styled.div`
 interface IDropdownMenuProps {
   menuItems: Array<MenuItem>;
   ref?: any;
-  handleDDDesktop: MouseEventHandler<React.ReactNode>;
+  handleOnClick: MouseEventHandler<React.ReactNode>;
 }
 
 const DropdownMenu: React.FC<IDropdownMenuProps> = React.forwardRef((props, ref) => {
-  const { menuItems, handleDDDesktop } = props;
+  const { menuItems, handleOnClick } = props;
 
   return (
     // TODO: investigate ref type error
@@ -46,7 +46,7 @@ const DropdownMenu: React.FC<IDropdownMenuProps> = React.forwardRef((props, ref)
       <StyledDropdown>
         {menuItems.map(
           (item, index) =>
-            <DropdownMenuItem handleDDDesktop={handleDDDesktop} key={index + item.title} href={item.href} title={item.title} subTitle={item.subTitle} onClickCB={item.onClickCB} />
+            <DropdownMenuItem handleOnClick={handleOnClick} key={index + item.title} href={item.href} title={item.title} subTitle={item.subTitle} onClickCB={item.onClickCB} />
         )}
       </StyledDropdown>
     </div>

--- a/web/src/components/DropdownMenuItem.tsx
+++ b/web/src/components/DropdownMenuItem.tsx
@@ -22,7 +22,7 @@ import theme from '../theme';
 import { MenuItem as IMenuItemProps } from '../types';
 
 const StyledDropdownItem = styled.div`
-  margin: 15px 15px 15px 0px;
+  margin: 20px 15px 15px 0px;
   border-bottom: 1px solid;
   @media (max-width: ${theme.breakpoints[1]}) {
     color: ${theme.colors.contrast};
@@ -30,13 +30,14 @@ const StyledDropdownItem = styled.div`
 `;
 
 const DropdownMenuItem: React.FC<IMenuItemProps> = (props) => {
-  const { href, title, subTitle, onClickCB } = props;
+  const { href, title, subTitle, onClickCB, handleDDDesktop } = props;
+
   if (!!href) {
     return (
       <RouterLink className='misc-class-m-dropdown-link' to={href}>
-        <StyledDropdownItem>
+        <StyledDropdownItem onClick={handleDDDesktop}>
           <h3>{title}</h3>
-          <Text color={theme.colors.grey} mb='12px'>{subTitle}</Text>
+          <Text mb='12px'>{subTitle}</Text>
         </StyledDropdownItem>
       </RouterLink>
     );

--- a/web/src/components/DropdownMenuItem.tsx
+++ b/web/src/components/DropdownMenuItem.tsx
@@ -30,12 +30,12 @@ const StyledDropdownItem = styled.div`
 `;
 
 const DropdownMenuItem: React.FC<IMenuItemProps> = (props) => {
-  const { href, title, subTitle, onClickCB, handleDDDesktop } = props;
+  const { href, title, subTitle, onClickCB, handleOnClick } = props;
 
   if (!!href) {
     return (
       <RouterLink className='misc-class-m-dropdown-link' to={href}>
-        <StyledDropdownItem onClick={handleDDDesktop}>
+        <StyledDropdownItem onClick={handleOnClick}>
           <h3>{title}</h3>
           <Text mb='12px'>{subTitle}</Text>
         </StyledDropdownItem>

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -24,18 +24,29 @@ import Footer from './footer';
 import Header from './header';
 
 // this is to set min width in windows resizing
-const StyledDiv = styled.main`
+const StyledDiv = styled.div`
   min-width: 380px;
 `;
 
 const StyledMain = styled.main`
-  margin-top: ${theme.spacingIncrements[1]};
-  padding-left: ${theme.spacingIncrements[2]};
-  padding-right: ${theme.spacingIncrements[2]};
-  @media (max-width: ${theme.breakpoints[0]}) {
-    padding-left: ${theme.spacingIncrements[0]};
-    padding-right: ${theme.spacingIncrements[0]};
-  }
+  margin-top: ${theme.navBar.desktopFixedHeight};
+  padding-top: ${theme.spacingIncrements[0]};
+  margin-left: ${theme.spacingIncrements[2]};
+  margin-right: ${theme.spacingIncrements[2]};
+  @media (max-width: ${theme.breakpoints[1]}) {
+    margin-left: ${theme.spacingIncrements[0]};
+    margin-right: ${theme.spacingIncrements[0]};
+  } 
+`;
+
+const StyledBackdrop = styled.div`
+  position:fixed;
+  z-index: ${theme.zIndices[2]};
+  top:0px;
+  left:0px;
+  width:100%;
+  height:100%;
+  background:rgba(0,0,0,0.5);
 `;
 
 interface ILayoutProps {
@@ -46,12 +57,28 @@ interface ILayoutProps {
 const Layout: React.FC<ILayoutProps> = props => {
   const { children, name } = props;
 
+  const [openBackdrop, setOpenBackdrop] = React.useState(false);
+
+  const openBackdropCB = () => {
+    setOpenBackdrop(true);
+  };
+
+  const closeBackdropCB = () => {
+    setOpenBackdrop(false);
+  };
+
   return (
     <StyledDiv>
       <ToastContainer style={{ width: "500px" }} />
+      {openBackdrop && (<StyledBackdrop />)}
       <Header name={name} />
       <StyledMain>
-        {children}
+        {React.Children.map(children, (child: any) => {
+          return React.cloneElement(child, {
+            closeBackdropCB: closeBackdropCB,
+            openBackdropCB: openBackdropCB
+          });
+        })}
       </StyledMain>
       <Footer />
     </StyledDiv>

--- a/web/src/components/SubFormPO.tsx
+++ b/web/src/components/SubFormPO.tsx
@@ -30,37 +30,37 @@ const SubformPO: React.FC = () => {
 
             <Field name="po-firstName" validate={validator.mustBeValidName}>
                 {({ input, meta }) => (
-                    <Flex flexDirection="column" pb="12px" style={{ position: "relative" }}>
-                        <Label htmlFor="po-first-name">First Name</Label>
-                        <Input {...input} id="po-first-name" placeholder="Jane" />
-                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "-1em" }} variant="errorLabel">{meta.error}</Label>}
+                    <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
+                        <Label m="0" htmlFor="po-first-name">First Name</Label>
+                        <Input mt="8px" {...input} id="po-first-name" placeholder="Jane" />
+                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
                     </Flex>
                 )}
             </Field>
             <Field name="po-lastName" validate={validator.mustBeValidName}>
                 {({ input, meta }) => (
-                    <Flex flexDirection="column" pb="12px" style={{ position: "relative" }}>
-                        <Label htmlFor="po-last-name">Last Name</Label>
-                        <Input {...input} id="po-last-name" placeholder="Doe" />
-                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "-1em" }} variant="errorLabel">{meta.error}</Label>}
+                    <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
+                        <Label m="0" htmlFor="po-last-name">Last Name</Label>
+                        <Input mt="8px" {...input} id="po-last-name" placeholder="Doe" />
+                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
                     </Flex>
                 )}
             </Field>
             <Field name="po-email" validate={validator.mustBeValidEmail}>
                 {({ input, meta }) => (
-                    <Flex flexDirection="column" pb="12px" style={{ position: "relative" }}>
-                        <Label htmlFor="po-email">eMail Address</Label>
-                        <Input {...input} id="po-email" placeholder="jane.doe@gov.bc.ca" />
-                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "-1em" }} variant="errorLabel">{meta.error}</Label>}
+                    <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
+                        <Label m="0" htmlFor="po-email">eMail Address</Label>
+                        <Input mt="8px" {...input} id="po-email" placeholder="jane.doe@gov.bc.ca" />
+                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
                     </Flex>
                 )}
             </Field>
             <Field name="po-githubId" validate={validator.mustBeValidGithubName}>
                 {({ input, meta }) => (
-                    <Flex flexDirection="column" pb="12px" style={{ position: "relative" }}>
-                        <Label htmlFor="po-github-id">GitHub ID</Label>
-                        <Input {...input} id="po-github-id" placeholder="jane1100" />
-                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "-1em" }} variant="errorLabel">{meta.error}</Label>}
+                    <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
+                        <Label m="0" htmlFor="po-github-id">GitHub ID</Label>
+                        <Input mt="8px" {...input} id="po-github-id" placeholder="jane1100" />
+                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
                     </Flex>
                 )}
             </Field>

--- a/web/src/components/SubFormProject.tsx
+++ b/web/src/components/SubFormProject.tsx
@@ -41,50 +41,47 @@ const SubFormProject: React.FC<ISubFormProjectProps> = (props) => {
             <SubFormTitle>Tell us about your project</SubFormTitle>
             <Field name="project-name" validate={validator.mustBeValidProfileName}>
                 {({ input, meta }) => (
-                    <Flex flexDirection="column" pb="12px" style={{ position: "relative" }}>
-                        <Label htmlFor="project-name">Name</Label>
-                        <Input {...input} id="project-name" placeholder="Project X" />
-                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "-1em" }} variant="errorLabel">{meta.error}</Label>}
+                    <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
+                        <Label m="0" htmlFor="project-name">Name</Label>
+                        <Input mt="8px" {...input} id="project-name" placeholder="Project X" />
+                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
                     </Flex>
                 )}
             </Field>
             <Field name="project-description" validate={validator.mustBeValidProfileDescription}>
                 {({ input, meta }) => (
-                    <Flex flexDirection="column" pb="12px" style={{ position: "relative" }}>
-                        <Label htmlFor="project-description">Description</Label>
-                        <Textarea {...input} id="project-description" placeholder="A cutting edge web platform that enables Citizens to ..." rows={5} />
-                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "-1em" }} variant="errorLabel">{meta.error}</Label>}
+                    <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
+                        <Label m="0" htmlFor="project-description">Description</Label>
+                        <Textarea mt="8px" {...input} id="project-description" placeholder="A cutting edge web platform that enables Citizens to ..." rows={5} />
+                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
                     </Flex>
                 )}
             </Field>
-            <Flex>
-                <Label variant="adjacentLabel">Is this a Priority Application?</Label>
+            <Flex pb="20px">
+                <Label m="0" variant="adjacentLabel">Is this a Priority Application?</Label>
                 <Flex flex="1 1 auto" justifyContent="flex-end">
-                    <Label width="initial" px="8px">
+                    <Label m="0" width="initial" px="8px">
                         <Field
                             name="project-prioritySystem"
                             component="input"
                             type="checkbox"
                             value="yes"
                         >
-                            {({ input, meta }) => (
-                                <>
-                                    <input
-                                        style={{ width: '35px', height: '35px' }}
-                                        name={input.name}
-                                        type="checkbox"
-                                        value="yes"
-                                        checked={input.checked}
-                                        onChange={input.onChange}
-                                    />
-                                    {meta.error && meta.modified && <Label as="span" style={{ position: "absolute", bottom: "-1em" }} variant="errorLabel">{meta.error}</Label>}
-                                </>
+                            {({ input }) => (
+                                <input
+                                    style={{ width: '35px', height: '35px' }}
+                                    name={input.name}
+                                    type="checkbox"
+                                    value="yes"
+                                    checked={input.checked}
+                                    onChange={input.onChange}
+                                />
                             )}
                         </Field>
                     </Label>
                 </Flex>
             </Flex>
-            <Flex>
+            <Flex pb="20px">
                 <Label variant="adjacentLabel">Ministry Sponsor</Label>
                 <Flex flex="1 1 auto" justifyContent="flex-end" name="project-busOrgId">
                     {/* using a className prop as react final form Field does
@@ -120,18 +117,15 @@ const SubFormProject: React.FC<ISubFormProjectProps> = (props) => {
                                 type="checkbox"
                                 value="yes"
                             >
-                                {({ input, meta }) => (
-                                    < >
-                                        <input
-                                            style={{ width: '35px', height: '35px' }}
-                                            name={input.name}
-                                            type="checkbox"
-                                            value="yes"
-                                            checked={input.checked}
-                                            onChange={input.onChange}
-                                        />
-                                        {meta.error && meta.modified && <Label as="span" style={{ position: "absolute", bottom: "-1em" }} variant="errorLabel">{meta.error}</Label>}
-                                    </>
+                                {({ input }) => (
+                                    <input
+                                        style={{ width: "35px", height: "35px" }}
+                                        name={input.name}
+                                        type="checkbox"
+                                        value="yes"
+                                        checked={input.checked}
+                                        onChange={input.onChange}
+                                    />
                                 )}
                             </Field>
                         </Label>
@@ -140,12 +134,12 @@ const SubFormProject: React.FC<ISubFormProjectProps> = (props) => {
             ))}
             <Field name="project-other" validate={validator.mustBeValidComponentOthers}>
                 {({ input, meta }) => (
-                    <Flex>
+                    <Flex pb="25px" style={{ position: "relative" }}>
                         <Label htmlFor="project-other">Other:</Label>
                         <Flex flex="1 1 auto" justifyContent="flex-end">
                             <Input {...input} id="project-other" />
                         </Flex>
-                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute" }} variant="errorLabel">{meta.error}</Label>}
+                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel" >{meta.error}</Label>}
                     </Flex>
                 )}
             </Field>

--- a/web/src/components/SubFormTC.tsx
+++ b/web/src/components/SubFormTC.tsx
@@ -53,37 +53,37 @@ const SubformTC: React.FC = () => {
 
             <Field name="tc-firstName" validate={validator.mustBeValidName}>
                 {({ input, meta }) => (
-                    <Flex flexDirection="column" pb="12px" style={{ position: "relative" }}>
-                        <Label htmlFor="tc-first-name">First Name</Label>
-                        <Input {...input} id="tc-first-name" placeholder="Jane" />
-                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "-1em" }} variant="errorLabel">{meta.error}</Label>}
+                    <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
+                        <Label m="0" htmlFor="tc-first-name">First Name</Label>
+                        <Input mt="8px" {...input} id="tc-first-name" placeholder="Jane" />
+                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
                     </Flex>
                 )}
             </Field>
             <Field name="tc-lastName" validate={validator.mustBeValidName}>
                 {({ input, meta }) => (
-                    <Flex flexDirection="column" pb="12px" style={{ position: "relative" }}>
-                        <Label htmlFor="tc-last-name">Last Name</Label>
-                        <Input {...input} id="tc-last-name" placeholder="Doe" />
-                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "-1em" }} variant="errorLabel">{meta.error}</Label>}
+                    <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
+                        <Label m="0" htmlFor="tc-last-name">Last Name</Label>
+                        <Input mt="8px" {...input} id="tc-last-name" placeholder="Doe" />
+                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
                     </Flex>
                 )}
             </Field>
             <Field name="tc-email" validate={validator.mustBeValidEmail}>
                 {({ input, meta }) => (
-                    <Flex flexDirection="column" pb="12px" style={{ position: "relative" }}>
-                        <Label htmlFor="tc-email">eMail Address</Label>
-                        <Input {...input} id="tc-email" placeholder="jane.doe@gov.bc.ca" />
-                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "-1em" }} variant="errorLabel">{meta.error}</Label>}
+                    <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
+                        <Label m="0" htmlFor="tc-email">eMail Address</Label>
+                        <Input mt="8px" {...input} id="tc-email" placeholder="jane.doe@gov.bc.ca" />
+                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
                     </Flex>
                 )}
             </Field>
             <Field name="tc-githubId" validate={validator.mustBeValidGithubName}>
                 {({ input, meta }) => (
-                    <Flex flexDirection="column" pb="12px" style={{ position: "relative" }}>
-                        <Label htmlFor="tc-github-id">GitHub ID</Label>
-                        <Input {...input} id="tc-github-id" placeholder="jane1100" />
-                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "-1em" }} variant="errorLabel">{meta.error}</Label>}
+                    <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
+                        <Label m="0" htmlFor="tc-github-id">GitHub ID</Label>
+                        <Input mt="8px" {...input} id="tc-github-id" placeholder="jane1100" />
+                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
                     </Flex>
                 )}
             </Field>
@@ -93,7 +93,7 @@ const SubformTC: React.FC = () => {
                 <Text px='20px'>By checking this box, i confirm that I have read and understood the roles and responsibilities as described in the {<a rel="noopener noreferrer" href="https://developer.gov.bc.ca/Welcome-to-our-Platform-Community!" target="_blank">Onboarding Guide</a>}.</Text>
             </Label>
 
-            {boxChecked ? (<StyledButton type="submit">Request</StyledButton>) : (<StyledDisabledButton disabled type="submit">Request</StyledDisabledButton>)}
+            {boxChecked ? (<StyledButton className="misc-class-m-form-submit-btn" type="submit">Request</StyledButton>) : (<StyledDisabledButton disabled type="submit">Request</StyledDisabledButton>)}
         </div >
     );
 };

--- a/web/src/components/footer.tsx
+++ b/web/src/components/footer.tsx
@@ -20,8 +20,10 @@
 
 import styled from '@emotion/styled';
 import React from 'react';
+import theme from '../theme';
 
 const StyledFooter = styled.footer`
+  z-index: ${theme.zIndices[1]};
   background-color: #036;
   border-top: 2px solid #fcba19;
   color: #fff;
@@ -31,6 +33,9 @@ const StyledFooter = styled.footer`
   position: fixed;
   bottom: 0px;
   height: 46px;
+  @media (max-width: ${theme.breakpoints[1]}) {
+    height: 55px;
+  };
   width: 100%;
 `;
 

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -20,7 +20,7 @@
 
 import styled from '@emotion/styled';
 import React, { useState } from 'react';
-import { LAYOUT_SET_AUTH, LAYOUT_SET_MIN } from '../constants';
+import { LAYOUT_SET_AUTH, LAYOUT_SET_MIN, ROUTE_PATHS } from '../constants';
 import theme from '../theme';
 import { LayoutSet, MenuItem } from '../types';
 import typography from '../typography';
@@ -129,7 +129,7 @@ const Header: React.FC<IHeaderProps> = props => {
   const dirs = [{
     title: "A new Openshift Project Set",
     subTitle: "Create 4 Project namespaces in Silver cluster",
-    href: "/namespaces/create",
+    href: ROUTE_PATHS.FORM,
     onClickCB: () => { }
   }];
 

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -35,11 +35,11 @@ import { ContainerDesktop, ContainerMobile } from './UI/responsiveContainer';
 
 const StyledHeader = styled.header`
   background-color: ${theme.colors.primary};
-  color: ${theme.colors.contrast}
+  color: ${theme.colors.contrast};
   position: fixed;
   top: 0;
   width: 100%;
-  z-index: ${theme.zIndices[4]};
+  z-index: ${theme.zIndices[1]};
 `;
 
 const StyledBanner = styled.div`
@@ -91,7 +91,7 @@ const Nav: React.FC<INavProps> = props => {
   const { ref, isComponentVisible, setIsComponentVisible } = useComponentVisible(false);
 
   const handleDDDesktop = () => {
-    setIsComponentVisible(true);
+    setIsComponentVisible(!isComponentVisible);
   };
 
   if (name === LAYOUT_SET_MIN) {
@@ -102,7 +102,7 @@ const Nav: React.FC<INavProps> = props => {
         <ContainerDesktop>
           {isAuthenticated && (<CreateButton onClick={handleDDDesktop}>Create</CreateButton>)}
           <Authbutton />
-          {isAuthenticated && isComponentVisible && (<DropdownMenu ref={ref} menuItems={dirs} />)}
+          {isAuthenticated && isComponentVisible && (<DropdownMenu handleDDDesktop={handleDDDesktop} ref={ref} menuItems={dirs} />)}
         </ContainerDesktop>
         <ContainerMobile>
           <Icon hover color={'contrast'} name={isDDMobileOpen ? 'close' : 'menuStack'}

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -20,7 +20,8 @@
 
 import styled from '@emotion/styled';
 import React, { useState } from 'react';
-import { LAYOUT_SET_AUTH, LAYOUT_SET_MIN, ROUTE_PATHS } from '../constants';
+import { Link as RouterLink } from 'react-router-dom';
+import { HOME_PAGE_URL, LAYOUT_SET_AUTH, LAYOUT_SET_MIN, ROUTE_PATHS } from '../constants';
 import theme from '../theme';
 import { LayoutSet, MenuItem } from '../types';
 import typography from '../typography';
@@ -71,6 +72,7 @@ const H2 = styled.h2`
   padding: 0px 4px;
   text-decoration: none;
   font-size: 1.54912em;
+  color: ${theme.colors.contrast};
   @media (max-width: ${theme.breakpoints[0]}) {
     font-size: 1em;
   }
@@ -136,8 +138,10 @@ const Header: React.FC<IHeaderProps> = props => {
   return (
     <StyledHeader>
       <StyledBanner>
-        <GovLogo />
-        <H2>Platform Services Registry</H2>
+        <RouterLink style={{ display: 'flex', alignItems: 'center' }} to={HOME_PAGE_URL}>
+          <GovLogo />
+          <H2>Platform Services Registry</H2>
+        </RouterLink>
         {(name !== LAYOUT_SET_MIN) && (<Nav name={name} dirs={dirs} handleDDMobile={handleDDMobile} isDDMobileOpen={isDDMobileOpen} />)}
       </StyledBanner>
       <ContainerMobile>

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -104,7 +104,7 @@ const Nav: React.FC<INavProps> = props => {
         <ContainerDesktop>
           {isAuthenticated && (<CreateButton onClick={handleDDDesktop}>Create</CreateButton>)}
           <Authbutton />
-          {isAuthenticated && isComponentVisible && (<DropdownMenu handleDDDesktop={handleDDDesktop} ref={ref} menuItems={dirs} />)}
+          {isAuthenticated && isComponentVisible && (<DropdownMenu handleOnClick={handleDDDesktop} ref={ref} menuItems={dirs} />)}
         </ContainerDesktop>
         <ContainerMobile>
           <Icon hover color={'contrast'} name={isDDMobileOpen ? 'close' : 'menuStack'}
@@ -151,7 +151,7 @@ const Header: React.FC<IHeaderProps> = props => {
             {(name === LAYOUT_SET_AUTH) && (<div>
               {dirs.map(
                 (item, index) =>
-                  <DropdownMenuItem key={index + item.title} href={item.href} title={item.title} subTitle={item.subTitle} onClickCB={item.onClickCB} />
+                  <DropdownMenuItem handleOnClick={handleDDMobile} key={index + item.title} href={item.href} title={item.title} subTitle={item.subTitle} onClickCB={item.onClickCB} />
               )} </div>
             )}
           </StyledDropdownMobile>

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -57,4 +57,11 @@ export const COMPONENT_METADATA = [
   { displayName: 'Identity Management: Active Directory', inputValue: 'idmActiveDir' }
 ]
 
-export const HOME_PAGE_URL = '/dashboard';
+export const ROUTE_PATHS = {
+  DASHBOARD: '/dashboard',
+  NOT_FOUND: '/page-not-found',
+  LANDING: '/public-landing',
+  FORM: '/projects/create'
+};
+
+export const HOME_PAGE_URL = ROUTE_PATHS.DASHBOARD;

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
+import theme from './theme';
 import typography from './typography';
 
 ReactDOM.render(
@@ -32,7 +33,12 @@ ReactDOM.render(
           }
           .misc-class-m-dropdown-link {
             text-decoration: none;
-            color: black;
+            color: ${theme.colors.bcblue};
+          }
+
+          .misc-class-m-form-submit-btn:active {
+            position:relative;
+            top:1px;
           }
           `}
     />

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -20,7 +20,6 @@ ReactDOM.render(
               -moz-osx-font-smoothing: grayscale;
             }
           #root {
-              height: 100vw;
             }
           code {
               font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;

--- a/web/src/types.tsx
+++ b/web/src/types.tsx
@@ -30,5 +30,5 @@ export interface MenuItem {
   subTitle: string;
   href?: string;
   onClickCB?: MouseEventHandler<React.ReactNode>;
-  handleDDDesktop?: MouseEventHandler<React.ReactNode>;
+  handleOnClick?: MouseEventHandler<React.ReactNode>;
 }

--- a/web/src/types.tsx
+++ b/web/src/types.tsx
@@ -30,4 +30,5 @@ export interface MenuItem {
   subTitle: string;
   href?: string;
   onClickCB?: MouseEventHandler<React.ReactNode>;
+  handleDDDesktop?: MouseEventHandler<React.ReactNode>;
 }

--- a/web/src/views/form.tsx
+++ b/web/src/views/form.tsx
@@ -25,6 +25,7 @@ import SubFormPO from '../components/SubFormPO';
 import SubFormProject from '../components/SubFormProject';
 import SubFormTC from '../components/SubFormTC';
 import { ShadowBox } from '../components/UI/shadowContainer';
+import { ROUTE_PATHS } from '../constants';
 import transformFormData from '../utils/transformFormData';
 import useRegistryApi from '../utils/useRegistryApi';
 
@@ -105,7 +106,7 @@ const MyForm: React.FC = (props: any) => {
     }, []);
 
     if (goBackToDashboard) {
-        return (<Redirect to={'/dashboard'} />);
+        return (<Redirect to={ROUTE_PATHS.DASHBOARD} />);
     }
     return (
         <Form

--- a/web/src/views/form.tsx
+++ b/web/src/views/form.tsx
@@ -31,7 +31,9 @@ const txtForPO = `Tell us about the Product Owner (PO). This is typically the bu
 
 const txtForTC = `Tell us about the Technical Contact (TC). This is typically the DevOps specialist; we will use this information to contact them with technical questions or notify them about platform events.`;
 
-const MyForm: React.FC = () => {
+const MyForm: React.FC = (props: any) => {
+    const { openBackdropCB, closeBackdropCB } = props;
+
     const api = useRegistryApi();
 
     const [ministry, setMinistry] = useState<any>([]);
@@ -44,7 +46,7 @@ const MyForm: React.FC = () => {
             alert("You need to select a Ministry Sponsor.");
             return;
         }
-
+        openBackdropCB();
         try {
             // 1. Create the project profile.
             const response: any = await api.createProfile(profile);
@@ -61,6 +63,7 @@ const MyForm: React.FC = () => {
             // 4. Trigger provisioning
             await api.createNamespaceByProfileId(profileId);
 
+            closeBackdropCB();
             // 5.All good? Tell the user.
             toast.success('🦄 Your namespace request was successful', {
                 position: "top-center",
@@ -72,6 +75,7 @@ const MyForm: React.FC = () => {
                 progress: undefined,
             });
         } catch (err) {
+            closeBackdropCB();
             toast.error('😥 Something went wrong', {
                 position: "top-center",
                 autoClose: 5000,
@@ -92,6 +96,7 @@ const MyForm: React.FC = () => {
             setMinistry(response.data);
         }
         wrap();
+
         // eslint-disable-next-line
     }, []);
 

--- a/web/src/views/form.tsx
+++ b/web/src/views/form.tsx
@@ -18,6 +18,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { Form } from 'react-final-form';
+import { Redirect } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { Box, Flex, Text } from 'rebass';
 import SubFormPO from '../components/SubFormPO';
@@ -37,6 +38,8 @@ const MyForm: React.FC = (props: any) => {
     const api = useRegistryApi();
 
     const [ministry, setMinistry] = useState<any>([]);
+
+    const [goBackToDashboard, setGoBackToDashboard] = useState(false);
 
     const onSubmit = async (formData: any) => {
         const { profile, productOwner, technicalContact } = transformFormData(formData);
@@ -64,6 +67,7 @@ const MyForm: React.FC = (props: any) => {
             await api.createNamespaceByProfileId(profileId);
 
             closeBackdropCB();
+            setGoBackToDashboard(true);
             // 5.All good? Tell the user.
             toast.success('🦄 Your namespace request was successful', {
                 position: "top-center",
@@ -100,6 +104,9 @@ const MyForm: React.FC = (props: any) => {
         // eslint-disable-next-line
     }, []);
 
+    if (goBackToDashboard) {
+        return (<Redirect to={'/dashboard'} />);
+    }
     return (
         <Form
             onSubmit={onSubmit}
@@ -138,7 +145,7 @@ const MyForm: React.FC = (props: any) => {
                 </form>
             )}
         </Form >
-    )
+    );
 };
 
 export default MyForm;


### PR DESCRIPTION
- fix related to "a new openshift project set" request form
  - making it more obvious the request button is clickable
  - redirecting users after a successful submission back to the dashboard where they will be seeing their newly requested projects when the dashboard view feature gets complete
  - letting users know their submission is currently being processed (sequential API calls in the background) by bringing up a backdrop
- fix related to dropdown menus
  - modifying the desktop dropdown menu from "create" button so it will close after a menu item is clicked
  - modifying the mobile dropdown menu so it will close after a menu item is clicked
- fix related to React paths
  - changing the path name "namespaces/create" to "projects/create" to be consistent with the view form
  - adding the home path to header logo
  - making code cleaner by centralizing all path names in one place
- CSS fix / improvements as per review comments from Patrick
- updating unit test snapshot

Fixes #119
Fixes #121