### PR TITLE
Pre Populate PO information in Project Registry

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1774,6 +1774,13 @@
         "jwt-decode": "^2.2.0",
         "lodash": "^4.17.11",
         "moment": "^2.24.0"
+      },
+      "dependencies": {
+        "jwt-decode": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+          "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
+        }
       }
     },
     "@cnakazawa/watch": {
@@ -3048,6 +3055,12 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
       "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw=="
+    },
+    "@types/jwt-decode": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/jwt-decode/-/jwt-decode-2.2.1.tgz",
+      "integrity": "sha512-aWw2YTtAdT7CskFyxEX2K21/zSDStuf/ikI3yBqmwpwJF0pS+/IX5DWv+1UFffZIbruP6cnT9/LAJV1gFwAT1A==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -10791,9 +10804,9 @@
       }
     },
     "jwt-decode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
-      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.0.0.tgz",
+      "integrity": "sha512-RBQv2MTm3FNKQkdzhEyQwh5MbdNgMa+FyIJIK5RMWEn6hRgRHr7j55cRxGhRe6vGJDElyi6f6u/yfkP7AoXddA=="
     },
     "keycloak-js": {
       "version": "9.0.3",

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "axios": "^0.19.2",
     "emotion-theming": "^10.0.27",
     "final-form": "^4.20.1",
+    "jwt-decode": "^3.0.0",
     "keycloak-js": "^9.0.3",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
@@ -51,6 +52,7 @@
   },
   "devDependencies": {
     "@types/jest": "^25.2.3",
+    "@types/jwt-decode": "^2.2.1",
     "@types/node": "^14.11.2",
     "@types/react": "^16.9.50",
     "@types/react-dom": "^16.9.8",

--- a/web/src/__tests__/__snapshots__/form.test.tsx.snap
+++ b/web/src/__tests__/__snapshots__/form.test.tsx.snap
@@ -501,11 +501,11 @@ exports[`matches the snapshot 1`] = `
             </label>
             <input
               class="css-1f2jrlr"
+              disabled=""
               id="po-first-name"
               name="po-firstName"
-              placeholder="Jane"
               type="text"
-              value=""
+              value="Doe"
             />
           </div>
           <div
@@ -520,11 +520,11 @@ exports[`matches the snapshot 1`] = `
             </label>
             <input
               class="css-1f2jrlr"
+              disabled=""
               id="po-last-name"
               name="po-lastName"
-              placeholder="Doe"
               type="text"
-              value=""
+              value="Jane"
             />
           </div>
           <div
@@ -539,11 +539,11 @@ exports[`matches the snapshot 1`] = `
             </label>
             <input
               class="css-1f2jrlr"
+              disabled=""
               id="po-email"
               name="po-email"
-              placeholder="jane.doe@gov.bc.ca"
               type="text"
-              value=""
+              value="test@example.com"
             />
           </div>
           <div

--- a/web/src/__tests__/form.test.tsx
+++ b/web/src/__tests__/form.test.tsx
@@ -18,8 +18,8 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import Form from '../views/form';
 
-jest.mock('../utils/useDecoder', () => {
-  return function useDecoder() {
+jest.mock('../utils/TokenDecoder', () => {
+  return function getDecodedToken() {
     return (
       {
         email: "test@example.com",

--- a/web/src/__tests__/form.test.tsx
+++ b/web/src/__tests__/form.test.tsx
@@ -18,6 +18,20 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import Form from '../views/form';
 
+jest.mock('../utils/useDecoder', () => {
+  return function useDecoder() {
+    return (
+      {
+        email: "test@example.com",
+        family_name: "Jane",
+        given_name: "Doe",
+        name: "Jane Doe",
+        preferred_username: "janedoe@idir"
+      }
+    );
+  }
+});
+
 test('matches the snapshot', () => {
   const { container } = render(
     <Form />

--- a/web/src/components/SubFormPO.tsx
+++ b/web/src/components/SubFormPO.tsx
@@ -14,18 +14,21 @@
 // limitations under the License.
 //
 
+import { useKeycloak } from '@react-keycloak/web';
 import { Input, Label } from '@rebass/forms';
 import React from 'react';
 import { Field } from 'react-final-form';
 import { Flex } from 'rebass';
-import useDecoder from '../utils/useDecoder';
+import getDecodedToken from '../utils/TokenDecoder';
 import useValidator from '../utils/useValidator';
 import SubFormTitle from './UI/subFormTitle';
 
 const SubformPO: React.FC = () => {
     const validator = useValidator();
 
-    const decodedToken = useDecoder();
+    const { keycloak } = useKeycloak();
+
+    const decodedToken = getDecodedToken(`${keycloak?.token}`);
 
     return (
         <div>

--- a/web/src/components/SubFormPO.tsx
+++ b/web/src/components/SubFormPO.tsx
@@ -18,11 +18,14 @@ import { Input, Label } from '@rebass/forms';
 import React from 'react';
 import { Field } from 'react-final-form';
 import { Flex } from 'rebass';
+import useDecoder from '../utils/useDecoder';
 import useValidator from '../utils/useValidator';
 import SubFormTitle from './UI/subFormTitle';
 
 const SubformPO: React.FC = () => {
     const validator = useValidator();
+
+    const decodedToken = useDecoder();
 
     return (
         <div>
@@ -32,7 +35,7 @@ const SubformPO: React.FC = () => {
                 {({ input, meta }) => (
                     <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
                         <Label m="0" htmlFor="po-first-name">First Name</Label>
-                        <Input mt="8px" {...input} id="po-first-name" placeholder="Jane" />
+                        <Input mt="8px" {...input} id="po-first-name" value={decodedToken.given_name} disabled />
                         {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
                     </Flex>
                 )}
@@ -41,7 +44,7 @@ const SubformPO: React.FC = () => {
                 {({ input, meta }) => (
                     <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
                         <Label m="0" htmlFor="po-last-name">Last Name</Label>
-                        <Input mt="8px" {...input} id="po-last-name" placeholder="Doe" />
+                        <Input mt="8px" {...input} id="po-last-name" value={decodedToken.family_name} disabled />
                         {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
                     </Flex>
                 )}
@@ -50,7 +53,7 @@ const SubformPO: React.FC = () => {
                 {({ input, meta }) => (
                     <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
                         <Label m="0" htmlFor="po-email">eMail Address</Label>
-                        <Input mt="8px" {...input} id="po-email" placeholder="jane.doe@gov.bc.ca" />
+                        <Input mt="8px" {...input} id="po-email" value={decodedToken.email} disabled />
                         {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
                     </Flex>
                 )}

--- a/web/src/utils/TokenDecoder.tsx
+++ b/web/src/utils/TokenDecoder.tsx
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 
-import { useKeycloak } from '@react-keycloak/web';
 import jwt_decode from "jwt-decode";
 
 interface UserProperties {
@@ -25,9 +24,8 @@ interface UserProperties {
     preferred_username: string;
 }
 
-export default function useDecoder() {
-    const { keycloak } = useKeycloak();
-    const decodedJWT = jwt_decode<UserProperties>(`${keycloak?.token}`);
+export default function getDecodedToken(token: string) {
+    const decodedJWT = jwt_decode<UserProperties>(token);
     return decodedJWT;
 };
 

--- a/web/src/utils/useDecoder.tsx
+++ b/web/src/utils/useDecoder.tsx
@@ -1,0 +1,33 @@
+//
+// Copyright © 2020 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { useKeycloak } from '@react-keycloak/web';
+import jwt_decode from "jwt-decode";
+
+interface DecodedToken {
+    email: string;
+    family_name: string;
+    given_name: string;
+    name: string;
+    preferred_username: string;
+}
+
+export default function useDecoder() {
+    const { keycloak } = useKeycloak();
+    const decodedJWT = jwt_decode<DecodedToken>(`${keycloak?.token}`);
+    return decodedJWT;
+};
+

--- a/web/src/utils/useDecoder.tsx
+++ b/web/src/utils/useDecoder.tsx
@@ -17,7 +17,7 @@
 import { useKeycloak } from '@react-keycloak/web';
 import jwt_decode from "jwt-decode";
 
-interface DecodedToken {
+interface UserProperties {
     email: string;
     family_name: string;
     given_name: string;
@@ -27,7 +27,7 @@ interface DecodedToken {
 
 export default function useDecoder() {
     const { keycloak } = useKeycloak();
-    const decodedJWT = jwt_decode<DecodedToken>(`${keycloak?.token}`);
+    const decodedJWT = jwt_decode<UserProperties>(`${keycloak?.token}`);
     return decodedJWT;
 };
 


### PR DESCRIPTION
Resolves issue #75 , to encourage PO's to initialize project provisioning, the project creation form now pre-populates the PO first name, last name and email from information contained within the JWT.

- [X] Implement JWT decode function
- [X] Pre-populate and disable first name, last name and email input fields for PO
- [x] Update web tests to include new capability