### PR TITLE
Convert github id to lowercase string

### DIFF
--- a/api/src/db/model/contact.ts
+++ b/api/src/db/model/contact.ts
@@ -52,7 +52,7 @@ export default class ContactModel extends Model {
         data.firstName,
         data.lastName,
         data.email,
-        data.githubId,
+        data.githubId.toLowerCase(),
         data.roleId,
       ],
     };


### PR DESCRIPTION
Rectifies Issue #129 . As KeyCloak SSO requires the stored userId to be entirely lowercase, it is necessary to convert user input GitHub id's to lowercase to avoid configuration issues.﻿
