### PR TITLE
Trim leading and trailing whitespace from project name

### DIFF
--- a/api/src/db/model/profile.ts
+++ b/api/src/db/model/profile.ts
@@ -76,7 +76,7 @@ export default class ProfileModel extends Model {
           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
             $13, $14, $15, $16, $17, $18, $19, $20, $21, $22) RETURNING *;`,
       values: [
-        data.name,
+        data.name.trim(),
         data.description,
         data.busOrgId,
         data.prioritySystem ? data.prioritySystem : false,


### PR DESCRIPTION
It was recognised that trailing whitespaces included in the Project name input resulted in an unnecessary underscore being appended to the project repo during provisioning. 

This fix ensures that all namespaces do not have leading or trailing whitespaces in their name.﻿
