### PR TITLE
Enable edit capability for pre-populated PO form

### DIFF
--- a/web/src/__tests__/__snapshots__/form.test.tsx.snap
+++ b/web/src/__tests__/__snapshots__/form.test.tsx.snap
@@ -501,7 +501,6 @@ exports[`matches the snapshot 1`] = `
             </label>
             <input
               class="css-1f2jrlr"
-              disabled=""
               id="po-first-name"
               name="po-firstName"
               type="text"
@@ -520,7 +519,6 @@ exports[`matches the snapshot 1`] = `
             </label>
             <input
               class="css-1f2jrlr"
-              disabled=""
               id="po-last-name"
               name="po-lastName"
               type="text"
@@ -539,7 +537,6 @@ exports[`matches the snapshot 1`] = `
             </label>
             <input
               class="css-1f2jrlr"
-              disabled=""
               id="po-email"
               name="po-email"
               type="text"

--- a/web/src/components/SubFormPO.tsx
+++ b/web/src/components/SubFormPO.tsx
@@ -34,27 +34,30 @@ const SubformPO: React.FC = () => {
         <div>
             <SubFormTitle>Who is the product owner for this project?</SubFormTitle>
 
-            <Field name="po-firstName" defaultValue={''} initialValue={decodedToken.given_name} >
-                {({ input }) => (
+            <Field name="po-firstName" validate={validator.mustBeValidName} defaultValue={''} initialValue={decodedToken.given_name} >
+                {({ input, meta }) => (
                     <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
                         <Label m="0" htmlFor="po-first-name">First Name</Label>
                         <Input mt="8px" {...input} id="po-first-name" />
+                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
                         </Flex>
                 )}
             </Field>
-            <Field name="po-lastName" defaultValue={''} initialValue={decodedToken.family_name} >
-                {({ input }) => (
+            <Field name="po-lastName" validate={validator.mustBeValidName} defaultValue={''} initialValue={decodedToken.family_name} >
+                {({ input, meta }) => (
                     <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
                         <Label m="0" htmlFor="po-last-name">Last Name</Label>
                         <Input mt="8px" {...input} id="po-last-name" />
+                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
                         </Flex>
                 )}
             </Field>
-            <Field name="po-email" defaultValue={''} initialValue={decodedToken.email} >
-                {({ input }) => (
+            <Field name="po-email"  validate={validator.mustBeValidEmail} defaultValue={''} initialValue={decodedToken.email} >
+                {({ input, meta }) => (
                     <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
                         <Label m="0" htmlFor="po-email">eMail Address</Label>
                         <Input mt="8px" {...input} id="po-email" />
+                        {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
                         </Flex>
                 )}
             </Field>

--- a/web/src/components/SubFormPO.tsx
+++ b/web/src/components/SubFormPO.tsx
@@ -38,7 +38,7 @@ const SubformPO: React.FC = () => {
                 {({ input }) => (
                     <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
                         <Label m="0" htmlFor="po-first-name">First Name</Label>
-                        <Input mt="8px" {...input} id="po-first-name" disabled />
+                        <Input mt="8px" {...input} id="po-first-name" />
                         </Flex>
                 )}
             </Field>
@@ -46,7 +46,7 @@ const SubformPO: React.FC = () => {
                 {({ input }) => (
                     <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
                         <Label m="0" htmlFor="po-last-name">Last Name</Label>
-                        <Input mt="8px" {...input} id="po-last-name" disabled />
+                        <Input mt="8px" {...input} id="po-last-name" />
                         </Flex>
                 )}
             </Field>
@@ -54,7 +54,7 @@ const SubformPO: React.FC = () => {
                 {({ input }) => (
                     <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
                         <Label m="0" htmlFor="po-email">eMail Address</Label>
-                        <Input mt="8px" {...input} id="po-email" disabled />
+                        <Input mt="8px" {...input} id="po-email" />
                         </Flex>
                 )}
             </Field>


### PR DESCRIPTION
As a user, partners require ability to update both PO and TC to meet the workflow of different ministries.

This PR enables the ability for users to update the information within the pre-populated PO fields.

Fixes #186 