### PR TITLE
Update namespace provisioning email

### DIFF
--- a/api/__tests__/__snapshots__/messaging.spec.ts.snap
+++ b/api/__tests__/__snapshots__/messaging.spec.ts.snap
@@ -1,13 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Services Contact email addresses are returned 1`] = `
+exports[`Services Contact details are returned 1`] = `
 Array [
-  "jane@example.com",
-  "jim@example.com",
+  Object {
+    "archived": false,
+    "createdAt": "2020-09-10T18:14:13.436Z",
+    "email": "jane@example.com",
+    "firstName": "Jane",
+    "githubId": "jane1100",
+    "id": 233,
+    "lastName": "Doe",
+    "roleId": 1,
+    "updatedAt": "2020-09-10T18:14:13.436Z",
+  },
+  Object {
+    "archived": false,
+    "createdAt": "2020-09-10T18:14:13.436Z",
+    "email": "jim@example.com",
+    "firstName": "Jim",
+    "githubId": "jim1100",
+    "id": 234,
+    "lastName": "Doe",
+    "roleId": 2,
+    "updatedAt": "2020-09-10T18:14:13.436Z",
+  },
 ]
 `;
 
-exports[`Services Contact email addresses are returned 2`] = `
+exports[`Services Contact details are returned 2`] = `
 Array [
   Array [
     Object {
@@ -25,9 +45,9 @@ Array [
 ]
 `;
 
-exports[`Services Contact email addresses not returned 1`] = `Array []`;
+exports[`Services Contact details not returned 1`] = `Array []`;
 
-exports[`Services Contact email addresses not returned 2`] = `
+exports[`Services Contact details not returned 2`] = `
 Array [
   Array [
     Object {

--- a/api/__tests__/messaging.spec.ts
+++ b/api/__tests__/messaging.spec.ts
@@ -35,7 +35,7 @@ describe('Services', () => {
     jest.clearAllMocks();
   });
 
-  it('Contact email addresses are returned', async () => {
+  it('Contact details are returned', async () => {
 
     client.query.mockReturnValue({ rows: contacts });
 
@@ -46,7 +46,7 @@ describe('Services', () => {
     expect(client.query.mock.calls).toMatchSnapshot();
   });
 
-  it('Contact email addresses not returned', async () => {
+  it('Contact details not returned', async () => {
 
     client.query.mockImplementation(() => { throw new Error() });
 

--- a/api/src/libs/messaging.ts
+++ b/api/src/libs/messaging.ts
@@ -29,15 +29,14 @@ export const enum MessageType {
   ProvisioningCompleted,
 }
 
-export const contactsForProfile = async (profileId: number): Promise<string[]> => {
+export const contactsForProfile = async (profileId: number): Promise<Contact[]> => {
 
   try {
     const dm = new DataManager(shared.pgPool);
     const { ContactModel } = dm;
     const contacts: Contact[] = await ContactModel.findForProject(profileId);
-    const to = [...new Set(contacts.map(c => c.email))];
 
-    return to;
+    return contacts;
   } catch (err) {
     const message = `Unable to fetch contacts for profile ${profileId}`;
     logger.error(`${message}, err = ${err.message}`);
@@ -46,10 +45,38 @@ export const contactsForProfile = async (profileId: number): Promise<string[]> =
   }
 }
 
+export const profileDetails = async (profileId: number): Promise<string> => {
+
+  try {
+    const dm = new DataManager(shared.pgPool);
+    const { ProfileModel } = dm;
+    const profiles = await ProfileModel.findById(profileId);
+    const profileName = profiles.name;
+    return profileName;
+  } catch (err) {
+    const message = `Unable to fetch profile ${profileId}`;
+    logger.error(`${message}, err = ${err.message}`);
+
+    return '';
+  }
+}
+
+export const inputVariables = async (buff: string, to: string[], profileName: string, names: string[]): Promise<any> => {
+  buff = buff.replace('${POName}', names[0]);
+  buff = buff.replace('${TCName}', names[1]);
+  buff = buff.replace('${POEmail}', to[0]);
+  buff = buff.replace('${TCEmail}', to[1]);
+  buff = buff.replace('${NamespaceName}', profileName);
+  return buff;
+}
+
 export const sendProvisioningMessage = async (profileId: number, messageType: MessageType): Promise<SendReceipt | undefined> => {
 
   try {
-    const to = await contactsForProfile(profileId);
+    const contacts = await contactsForProfile(profileId);
+    const names = contacts.map(c => c.firstName + ' ' + c.lastName);
+    const to = [...new Set(contacts.map(c => c.email))];
+    const profileName = await profileDetails(profileId);
     let buff;
 
     if (to.length === 0) {
@@ -58,7 +85,8 @@ export const sendProvisioningMessage = async (profileId: number, messageType: Me
 
     switch (messageType) {
       case MessageType.ProvisioningStarted:
-        buff = fs.readFileSync(path.join(__dirname, '../../', 'templates/provisioning-request-received.txt'));
+        // tslint:disable-next-line: max-line-length
+        buff = fs.readFileSync(path.join(__dirname, '../../', 'templates/provisioning-request-received.txt')).toString();
         break;
       case MessageType.ProvisioningCompleted:
         buff = fs.readFileSync(path.join(__dirname, '../../', 'templates/provisioning-request-done.txt'));
@@ -72,13 +100,14 @@ export const sendProvisioningMessage = async (profileId: number, messageType: Me
       return;
     }
 
+    const bodyContent = await inputVariables(buff, to, profileName, names);
 
     const message: Message = {
       bodyType: BodyType.Text,
-      body: buff.toString('utf8'),
+      body: bodyContent,
       to,
       from: 'Registry <pathfinder@gov.bc.ca>',
-      subject: 'Namespace Provisioning',
+      subject: `${profileName} Namespace`,
     }
 
     const receipt = await shared.ches.send(message);

--- a/api/src/libs/messaging.ts
+++ b/api/src/libs/messaging.ts
@@ -45,23 +45,24 @@ export const contactsForProfile = async (profileId: number): Promise<Contact[]> 
   }
 }
 
-export const profileDetails = async (profileId: number): Promise<string> => {
+export const profileDetails = async (profileId: number): Promise<string | undefined> => {
 
   try {
     const dm = new DataManager(shared.pgPool);
     const { ProfileModel } = dm;
     const profiles = await ProfileModel.findById(profileId);
     const profileName = profiles.name;
+
     return profileName;
   } catch (err) {
     const message = `Unable to fetch profile ${profileId}`;
     logger.error(`${message}, err = ${err.message}`);
 
-    return '';
+    return;
   }
 }
 
-export const updateEmailContent = async (buff: string, to: string[], profileName: string, contactNames: string[]): Promise<string> => {
+export const updateEmailContent = async (buff: string, to: string[], profileName: string | undefined, contactNames: string[]): Promise<string> => {
   try {
     let emailContent: string;
 

--- a/api/templates/provisioning-request-done.txt
+++ b/api/templates/provisioning-request-done.txt
@@ -14,9 +14,9 @@ https://console.apps.silver.devops.gov.bc.ca/
 
 Project Details
 
-- Project Name: ${NamespaceName}
-- Product Owner: ${POName} (${POEmail})
-- Technical Contact: ${TCName} (${TCEmail})
+- Project Name: projectName
+- Product Owner: POName (POEmail)
+- Technical Contact: TCName (TCEmail)
 
 Thanks Again,
 

--- a/api/templates/provisioning-request-done.txt
+++ b/api/templates/provisioning-request-done.txt
@@ -12,7 +12,11 @@ Workflow Steps
 You can access the Silver cluster console by copying this URL into your browser window:
 https://console.apps.silver.devops.gov.bc.ca/
 
+Project Details
 
+- Project Name: ${NamespaceName}
+- Product Owner: ${POName} (${POEmail})
+- Technical Contact: ${TCName} (${TCEmail})
 
 Thanks Again,
 

--- a/api/templates/provisioning-request-received.txt
+++ b/api/templates/provisioning-request-received.txt
@@ -8,7 +8,11 @@ Workflow Steps
 - Approval      <-- You are here.
 - Provisioning
 
+Project Details
 
+- Project Name: ${NamespaceName}
+- Product Owner: ${POName} (${POEmail})
+- Technical Contact: ${TCName} (${TCEmail})
 
 Thanks Again,
 

--- a/api/templates/provisioning-request-received.txt
+++ b/api/templates/provisioning-request-received.txt
@@ -10,9 +10,9 @@ Workflow Steps
 
 Project Details
 
-- Project Name: ${NamespaceName}
-- Product Owner: ${POName} (${POEmail})
-- Technical Contact: ${TCName} (${TCEmail})
+- Project Name: projectName
+- Product Owner: POName (POEmail)
+- Technical Contact: TCName (TCEmail)
 
 Thanks Again,
 


### PR DESCRIPTION
Users reported concerns regarding a lack of project specific information within the provisioning email. This PR ensures provisioning emails contain the project name, and PO and TC contact details.

This PR includes: 
- [X] Add project name in the email subject
- [X] Add PO and TC details submitted with the project
- [x] Refactor and clean up code
- [x] Update tests to reflect changes

Fixes #185 