### PR TITLE
Project Registry Description field 'Invalid Format' when return key is used

### DIFF
--- a/web/src/__tests__/__snapshots__/ProfileCard.test.tsx.snap
+++ b/web/src/__tests__/__snapshots__/ProfileCard.test.tsx.snap
@@ -32,7 +32,9 @@ exports[`matches the snapshot 1`] = `
     <h2
       class="css-16ht1ln"
     >
-      This is a test description for health gateway app
+      <p>
+        This is a test description for health gateway app
+      </p>
     </h2>
     <p
       class="css-xz2idv"

--- a/web/src/components/ProfileCard.tsx
+++ b/web/src/components/ProfileCard.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import { Box, Flex, Text } from 'rebass';
+import NewlineText from '../components/UI/newLineText';
 import PendingLable from '../components/UI/pendingLabel';
 import theme from '../theme';
 
@@ -70,7 +71,7 @@ const ProfileCard: React.FC<IProfileCardProps> = (props) => {
         fontWeight={500}
         mb={3}
       >
-        {textBody}
+        <NewlineText text={textBody} />
       </Text>
       <Text mb={3} as="p" color={theme.colors.grey} fontSize={[2, 3, 3]} mt={1}>
         {ministry}

--- a/web/src/components/SubFormPO.tsx
+++ b/web/src/components/SubFormPO.tsx
@@ -19,12 +19,12 @@ import { Input, Label } from '@rebass/forms';
 import React from 'react';
 import { Field } from 'react-final-form';
 import { Flex } from 'rebass';
+import getValidator from '../utils/getValidator';
 import getDecodedToken from '../utils/TokenDecoder';
-import useValidator from '../utils/useValidator';
 import SubFormTitle from './UI/subFormTitle';
 
 const SubformPO: React.FC = () => {
-    const validator = useValidator();
+    const validator = getValidator();
 
     const { keycloak } = useKeycloak();
 
@@ -40,7 +40,7 @@ const SubformPO: React.FC = () => {
                         <Label m="0" htmlFor="po-first-name">First Name</Label>
                         <Input mt="8px" {...input} id="po-first-name" />
                         {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
-                        </Flex>
+                    </Flex>
                 )}
             </Field>
             <Field name="po-lastName" validate={validator.mustBeValidName} defaultValue={''} initialValue={decodedToken.family_name} >
@@ -49,16 +49,16 @@ const SubformPO: React.FC = () => {
                         <Label m="0" htmlFor="po-last-name">Last Name</Label>
                         <Input mt="8px" {...input} id="po-last-name" />
                         {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
-                        </Flex>
+                    </Flex>
                 )}
             </Field>
-            <Field name="po-email"  validate={validator.mustBeValidEmail} defaultValue={''} initialValue={decodedToken.email} >
+            <Field name="po-email" validate={validator.mustBeValidEmail} defaultValue={''} initialValue={decodedToken.email} >
                 {({ input, meta }) => (
                     <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
                         <Label m="0" htmlFor="po-email">eMail Address</Label>
                         <Input mt="8px" {...input} id="po-email" />
                         {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
-                        </Flex>
+                    </Flex>
                 )}
             </Field>
             <Field name="po-githubId" validate={validator.mustBeValidGithubName}>

--- a/web/src/components/SubFormProject.tsx
+++ b/web/src/components/SubFormProject.tsx
@@ -19,7 +19,7 @@ import React from 'react';
 import { Field } from 'react-final-form';
 import { Flex } from 'rebass';
 import { COMPONENT_METADATA } from '../constants';
-import useValidator from '../utils/useValidator';
+import getValidator from '../utils/getValidator';
 import SubFormTitle from './UI/subFormTitle';
 
 interface MinistryItem {
@@ -32,7 +32,7 @@ interface ISubFormProjectProps {
 }
 
 const SubFormProject: React.FC<ISubFormProjectProps> = (props) => {
-    const validator = useValidator();
+    const validator = getValidator();
 
     const { ministry } = props;
 

--- a/web/src/components/SubFormTC.tsx
+++ b/web/src/components/SubFormTC.tsx
@@ -19,7 +19,7 @@ import { Checkbox, Input, Label } from '@rebass/forms';
 import React, { useState } from 'react';
 import { Field } from 'react-final-form';
 import { Flex, Text } from 'rebass';
-import useValidator from '../utils/useValidator';
+import getValidator from '../utils/getValidator';
 import SubFormTitle from './UI/subFormTitle';
 
 const StyledButton = styled.button`
@@ -43,7 +43,7 @@ const StyledDisabledButton = styled.button`
 `;
 
 const SubformTC: React.FC = () => {
-    const validator = useValidator();
+    const validator = getValidator();
 
     const [boxChecked, setBoxChecked] = useState(false);
 

--- a/web/src/components/UI/newLineText.tsx
+++ b/web/src/components/UI/newLineText.tsx
@@ -1,0 +1,29 @@
+//
+// Copyright © 2020 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import React from 'react';
+
+const NewlineText = (props: any) => {
+    const text = props.text;
+
+    if (!text) {
+        return null;
+    }
+
+    return text.split('\n\n').map((str: string, index: number) => <p key={index} >{str}</p>);
+}
+
+export default NewlineText;

--- a/web/src/components/UI/newLineText.tsx
+++ b/web/src/components/UI/newLineText.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 
+// TODO: sort out a way to declare ts returned value to be null | array of react components
 const NewlineText = (props: any) => {
     const text = props.text;
 

--- a/web/src/utils/getValidator.tsx
+++ b/web/src/utils/getValidator.tsx
@@ -41,7 +41,7 @@ const schema = {
       maximum: 512,
       tooLong: 'Max 512 characters'
     },
-    format: { pattern: `^(?! ).+[A-Za-z0-9 ,)(.!?"']+`, flags: 'i', message: 'Invalid format' }
+    format: { pattern: `^[A-Za-z0-9\n ,)(.!?"']+`, flags: 'i', message: 'No special characters allowed' }
   },
   componenentOthers: {
     length: {

--- a/web/src/utils/getValidator.tsx
+++ b/web/src/utils/getValidator.tsx
@@ -33,7 +33,7 @@ const schema = {
       maximum: 40,
       tooLong: 'Max 40 characters'
     },
-    format: { pattern: '^[a-zA-Z][A-Za-z0-9 ]+', flags: 'i', message: 'Must be alphanumetic starting with a letter' }
+    format: { pattern: '^[a-zA-Z][A-Za-z0-9 ]+(?<! )$', flags: 'i', message: 'Must be alphanumetic starting with a letter' }
   },
   profileDescription: {
     presence: { allowEmpty: false, message: 'Required' },
@@ -69,7 +69,7 @@ const schema = {
 };
 
 // TODO: the code below can be DRYer
-export default function useValidator() {
+export default function getValidator() {
   const mustBeValidEmail = (value: any) => {
     const errors = validate({ email: value }, schema, { fullMessages: false });
     if (errors && errors.email) {


### PR DESCRIPTION
- providing a fix so the return key is accepted by profile form submission - description field
- updating the dashboard profile card so description can read return key and render new line
- updating snapshots
- renaming useValidator to getValidator to follow the naming conventions where useXXX is only for react state / hooks related stuff

Fixes #166 