### PR TITLE
Bugfix: ensure TCEmail is not undefined

### DIFF
--- a/api/src/libs/messaging.ts
+++ b/api/src/libs/messaging.ts
@@ -70,7 +70,7 @@ export const updateEmailContent = async (buff: string, to: string[], profileName
       POName: contactNames[0],
       TCName: contactNames[1],
       POEmail: to[0],
-      TCEmail: to[1],
+      TCEmail: (typeof to[1] === 'undefined') ? to[0] : to[1],
       projectName: profileName,
     };
 


### PR DESCRIPTION
It was discovered if the PO and TC had the same email address, the provisioning email would show the TC Email as `undefined`. This PR checks if the PO and TC have the same address and provisioning the namespace email accordingly.

Fixes #203 