### PR TITLE
Remove double quote from descriptions

### DIFF
--- a/web/src/utils/getValidator.tsx
+++ b/web/src/utils/getValidator.tsx
@@ -41,7 +41,7 @@ const schema = {
       maximum: 512,
       tooLong: 'Max 512 characters'
     },
-    format: { pattern: `^[A-Za-z0-9\n ,)(.!?"']+`, flags: 'i', message: 'No special characters allowed' }
+    format: { pattern: `^[A-Za-z0-9\n ,)(.!?']+`, flags: 'i', message: 'No special characters allowed' }
   },
   componenentOthers: {
     length: {


### PR DESCRIPTION
To avoid an issue discovered in ArgoCD from unescaped double quotes, they have been temporarily disabled until a proper solution can be implemented.