### PR TITLE
Current quote edit feature will work well with future profile edits

### DIFF
--- a/api/__tests__/fulfillment.spec.ts
+++ b/api/__tests__/fulfillment.spec.ts
@@ -17,7 +17,8 @@
 import fs from 'fs';
 import path from 'path';
 import { Pool } from 'pg';
-import { contextForProvisioning, fulfillNamespaceEdit, fulfillNamespaceProvisioning, RequestEditType } from '../src/libs/fulfillment';
+import { RequestEditType } from '../src/db/model/request';
+import { contextForProvisioning, FulfillmentContextAction, fulfillNamespaceEdit, fulfillNamespaceProvisioning } from '../src/libs/fulfillment';
 
 const p1 = path.join(__dirname, 'fixtures/select-profile.json');
 const profile = JSON.parse(fs.readFileSync(p1, 'utf8'));
@@ -42,7 +43,7 @@ describe('Services', () => {
     client.query.mockReturnValueOnce({ rows: contacts });
     client.query.mockReturnValueOnce({ rows: namespaces });
 
-    const result = await contextForProvisioning(12345);
+    const result = await contextForProvisioning(12345, FulfillmentContextAction.Create);
 
     expect(result).toBeDefined();
     expect(result).toMatchSnapshot();
@@ -54,7 +55,7 @@ describe('Services', () => {
     client.query.mockReturnValueOnce({ rows: [] });
     client.query.mockReturnValueOnce({ rows: namespaces });
 
-    const result = await contextForProvisioning(12345);
+    const result = await contextForProvisioning(12345, FulfillmentContextAction.Create);
 
     expect(result).not.toBeDefined();
   });
@@ -63,7 +64,7 @@ describe('Services', () => {
 
     client.query.mockImplementation(() => { throw new Error() });
 
-    await expect(contextForProvisioning(12345)).rejects.toThrow();
+    await expect(contextForProvisioning(12345, FulfillmentContextAction.Create)).rejects.toThrow();
   });
 
   it('Namespace provisioning succeeds', async () => {

--- a/api/__tests__/namespace.spec.ts
+++ b/api/__tests__/namespace.spec.ts
@@ -260,7 +260,6 @@ describe('Namespace event handlers', () => {
     const req = {
       params: { profileId: 1 },
     }
-
     client.query.mockReturnValueOnce({ rows: selectedNamespaces });
     client.query.mockReturnValueOnce({ rows: selectDefaultCluster });
     client.query.mockReturnValueOnce({ rows: [selectClusterNamespaces[0]] });

--- a/api/doc/api.yaml
+++ b/api/doc/api.yaml
@@ -403,7 +403,8 @@ paths:
       summary: Fetch a list of quota-edit options for given clusternamespaces
       description: |-
         Use this endpoint to fetch a list of quota-edit options
-        given the project and default cluster. A list will be returned
+        given the project and cluster name. If cluster name is not provided,
+        the default cluster will be used. A list will be returned
         providing it is not archived. A empty list will be returned if the
         project is yet to be provisioned OR there is an
         ongoing quota-edit request for this project.
@@ -435,7 +436,8 @@ paths:
       summary: Create a new namespace for the given project
       description: |-
         Use this endpoint to request new quotas for cluster namespaces
-        under the given profile and default cluster.
+        under the given profile and cluster name. If cluster name is not provided,
+        the default cluster will be used.
       tags:
         - QuotaEdit
       parameters:

--- a/api/public/doc/api/index.html
+++ b/api/public/doc/api/index.html
@@ -3427,7 +3427,8 @@ fetch(<span class="hljs-string">'http://localhost:8100/api/v1/profile/{profileId
 <p><code>GET /api/v1/profile/{profileId}/quota-edit</code></p>
 <p><em>Fetch a list of quota-edit options for given clusternamespaces</em></p>
 <p>Use this endpoint to fetch a list of quota-edit options
-given the project and default cluster. A list will be returned
+given the project and cluster name. If cluster name is not provided,
+the default cluster will be used. A list will be returned
 providing it is not archived. A empty list will be returned if the
 project is yet to be provisioned OR there is an
 ongoing quota-edit request for this project.</p>
@@ -3527,7 +3528,8 @@ fetch(<span class="hljs-string">'http://localhost:8100/api/v1/profile/{profileId
 <p><code>POST /api/v1/profile/{profileId}/quota-edit</code></p>
 <p><em>Create a new namespace for the given project</em></p>
 <p>Use this endpoint to request new quotas for cluster namespaces
-under the given profile and default cluster.</p>
+under the given profile and cluster name. If cluster name is not provided,
+the default cluster will be used.</p>
 <h3 id="requestprofilequotaedit-parameters">Parameters</h3>
 <table>
 <thead>

--- a/api/src/constants.ts
+++ b/api/src/constants.ts
@@ -28,24 +28,6 @@ export const projectSetNames = [
   'prod',
 ];
 
-export const quotaSizeNames = [
-  'small',
-  'medium',
-  'large',
-];
-
-export const DEFAULT_QUOTA_SIZE_NAME = quotaSizeNames[0];
-
-export const FULFILLMENT_CONTEXT = {
-  ACTIONS: {
-    CREATE: 'create',
-    EDIT: 'edit',
-  },
-  TYPES: {
-    STANDARD: 'standard',
-  },
-};
-
 export const ROLE_IDS = {
   PRODUCT_OWNER: 1,
   TECHNICAL_CONTACT: 2,

--- a/api/src/db/model/cluster.ts
+++ b/api/src/db/model/cluster.ts
@@ -20,12 +20,12 @@ import { Pool } from 'pg';
 import { CommonFields, Model } from './model';
 
 export interface Cluster extends CommonFields {
-  name: string,
-  description: string,
-  disasterRecovery: boolean,
-  onPrem: boolean
-  onHardware: boolean
-  isDefault: boolean
+  name: string;
+  description: string;
+  disasterRecovery: boolean;
+  onPrem: boolean;
+  onHardware: boolean;
+  isDefault: boolean;
 }
 
 export default class CusterModel extends Model {
@@ -90,7 +90,7 @@ export default class CusterModel extends Model {
 
       throw err;
     }
-  };
+  }
 
   async update(clusterId: number, data: Cluster): Promise<Cluster> {
     const query = {
@@ -121,7 +121,7 @@ export default class CusterModel extends Model {
 
       throw err;
     }
-  };
+  }
 
   async delete(clusterId: number): Promise<Cluster> {
     const query = {
@@ -147,5 +147,5 @@ export default class CusterModel extends Model {
 
       throw err;
     }
-  };
+  }
 }

--- a/api/src/db/model/contact.ts
+++ b/api/src/db/model/contact.ts
@@ -20,11 +20,11 @@ import { Pool } from 'pg';
 import { CommonFields, Model } from './model';
 
 export interface Contact extends CommonFields {
-  firstName: string,
-  lastName: string,
-  email: string,
-  githubId: string,
-  roleId: number,
+  firstName: string;
+  lastName: string;
+  email: string;
+  githubId: string;
+  roleId: number;
 }
 
 export default class ContactModel extends Model {
@@ -123,7 +123,7 @@ export default class ContactModel extends Model {
 
       throw err;
     }
-  };
+  }
 
   async delete(contactId: number): Promise<Contact> {
     const query = {
@@ -145,5 +145,5 @@ export default class ContactModel extends Model {
 
       throw err;
     }
-  };
+  }
 }

--- a/api/src/db/model/ministry.ts
+++ b/api/src/db/model/ministry.ts
@@ -17,7 +17,7 @@ import { Pool } from 'pg';
 import { CommonFields, Model } from './model';
 
 export interface Ministry extends CommonFields {
-  name: string,
+  name: string;
 }
 
 export default class MinistryModel extends Model {
@@ -81,7 +81,7 @@ export default class MinistryModel extends Model {
 
       throw err;
     }
-  };
+  }
 
   async delete(ministryId: number): Promise<Ministry> {
     const query = {
@@ -103,5 +103,5 @@ export default class MinistryModel extends Model {
 
       throw err;
     }
-  };
+  }
 }

--- a/api/src/db/model/model.ts
+++ b/api/src/db/model/model.ts
@@ -23,11 +23,12 @@ export interface Query {
   text: string;
   values?: any[];
 }
+
 export interface CommonFields {
-  id?: number,
-  archived?: boolean,
-  createdAt?: object,
-  updatedAt?: object,
+  id?: number;
+  archived?: boolean;
+  createdAt?: object;
+  updatedAt?: object;
 }
 
 export abstract class Model {

--- a/api/src/db/model/namespace.ts
+++ b/api/src/db/model/namespace.ts
@@ -17,16 +17,22 @@
 
 import { logger } from '@bcgov/common-nodejs-utils';
 import { Pool } from 'pg';
-import { DEFAULT_QUOTA_SIZE_NAME, projectSetNames } from '../../constants';
+import { projectSetNames } from '../../constants';
 import { CommonFields, Model } from './model';
+
+export const enum QuotaSize {
+  Small = 'small',
+  Medium = 'medium',
+  Large = 'large',
+};
 
 export interface ClusterNamespace extends CommonFields {
   namespaceId: number;
   clusterId: number;
   provisioned: boolean;
-  quotaCpu?: string;
-  quotaMemory?: string;
-  quotaStorage?: string;
+  quotaCpu?: QuotaSize;
+  quotaMemory?: QuotaSize;
+  quotaStorage?: QuotaSize;
 }
 
 export interface ProjectNamespace extends CommonFields {
@@ -87,7 +93,8 @@ export default class NamespaceModel extends Model {
       }));
 
       const nsResults = await Promise.all(nsPromises);
-      const clPromises = nsResults.map(nr => this.runQuery({ ...query, values: [nr.id, clusterId, DEFAULT_QUOTA_SIZE_NAME] }));
+      // default quota size set to QuotaSize.Small
+      const clPromises = nsResults.map(nr => this.runQuery({ ...query, values: [nr.id, clusterId, QuotaSize.Small] }));
       await Promise.all(clPromises);
 
       return nsResults;

--- a/api/src/db/model/namespace.ts
+++ b/api/src/db/model/namespace.ts
@@ -21,18 +21,18 @@ import { DEFAULT_QUOTA_SIZE_NAME, projectSetNames } from '../../constants';
 import { CommonFields, Model } from './model';
 
 export interface ClusterNamespace extends CommonFields {
-  namespaceId: number,
-  clusterId: number,
-  provisioned: boolean,
-  quotaCpu?: string,
-  quotaMemory?: string,
-  quotaStorage?: string,
+  namespaceId: number;
+  clusterId: number;
+  provisioned: boolean;
+  quotaCpu?: string;
+  quotaMemory?: string;
+  quotaStorage?: string;
 }
 
 export interface ProjectNamespace extends CommonFields {
-  name: string,
-  profileId: number,
-  clusters?: ClusterNamespace[],
+  name: string;
+  profileId: number;
+  clusters?: ClusterNamespace[];
 }
 
 export default class NamespaceModel extends Model {
@@ -247,7 +247,7 @@ export default class NamespaceModel extends Model {
 
       throw err;
     }
-  };
+  }
 
   async delete(namespaceId: number): Promise<ProjectNamespace> {
     const query = {
@@ -269,5 +269,5 @@ export default class NamespaceModel extends Model {
 
       throw err;
     }
-  };
+  }
 }

--- a/api/src/db/model/profile.ts
+++ b/api/src/db/model/profile.ts
@@ -20,28 +20,28 @@ import { Pool } from 'pg';
 import { CommonFields, Model } from './model';
 
 export interface ProjectProfile extends CommonFields {
-  name: string,
-  description: string,
-  busOrgId: number,
-  userId: number,
-  namespacePrefix: string,
-  prioritySystem?: boolean,
-  criticalSystem?: boolean,
-  notificationEmail?: boolean,
-  notificationSms?: boolean,
-  notificationMsTeams?: boolean,
-  paymentBambora?: boolean,
-  paymentPayBc?: boolean,
-  fileTransfer?: boolean,
-  fileStorage?: boolean,
-  geoMappingWeb?: boolean,
-  geoMappingLocation?: boolean,
-  schedulingCalendar?: boolean,
-  schedulingAppointments?: boolean,
-  idmSiteMinder?: boolean,
-  idmKeycloak?: boolean,
-  idmActiveDir?: boolean,
-  other: string,
+  name: string;
+  description: string;
+  busOrgId: number;
+  userId: number;
+  namespacePrefix: string;
+  prioritySystem?: boolean;
+  criticalSystem?: boolean;
+  notificationEmail?: boolean;
+  notificationSms?: boolean;
+  notificationMsTeams?: boolean;
+  paymentBambora?: boolean;
+  paymentPayBc?: boolean;
+  fileTransfer?: boolean;
+  fileStorage?: boolean;
+  geoMappingWeb?: boolean;
+  geoMappingLocation?: boolean;
+  schedulingCalendar?: boolean;
+  schedulingAppointments?: boolean;
+  idmSiteMinder?: boolean;
+  idmKeycloak?: boolean;
+  idmActiveDir?: boolean;
+  other: string;
 }
 
 export default class ProfileModel extends Model {
@@ -185,7 +185,7 @@ export default class ProfileModel extends Model {
 
       throw err;
     }
-  };
+  }
 
   async delete(profileId): Promise<ProjectProfile> {
     const query = {
@@ -207,7 +207,7 @@ export default class ProfileModel extends Model {
 
       throw err;
     }
-  };
+  }
 
   async addContactToProfile(profileId: number, contactId: number): Promise<void> {
     const values: any[] = [];

--- a/api/src/db/model/request.ts
+++ b/api/src/db/model/request.ts
@@ -17,11 +17,11 @@ import { Pool } from 'pg';
 import { CommonFields, Model } from './model';
 
 export interface Request extends CommonFields {
-    profileId: number,
-    editType: string,
-    editObject: string,
-    natsSubject?: string,
-    natsContext?: string,
+    profileId: number;
+    editType: string;
+    editObject: string;
+    natsSubject?: string;
+    natsContext?: string;
 }
 
 export default class RequestModel extends Model {
@@ -91,7 +91,7 @@ export default class RequestModel extends Model {
 
             throw err;
         }
-    };
+    }
 
     async delete(requestId: number): Promise<Request> {
         const query = {
@@ -112,7 +112,7 @@ export default class RequestModel extends Model {
 
             throw err;
         }
-    };
+    }
 
     async findForProfile(profileId: number): Promise<Request[]> {
         const query = {
@@ -130,5 +130,5 @@ export default class RequestModel extends Model {
 
             throw err;
         }
-    };
+    }
 }

--- a/api/src/db/model/request.ts
+++ b/api/src/db/model/request.ts
@@ -16,9 +16,15 @@ import { logger } from '@bcgov/common-nodejs-utils';
 import { Pool } from 'pg';
 import { CommonFields, Model } from './model';
 
+export const enum RequestEditType {
+    ProductOwner = 'productOwner',
+    TechnicalContact = 'technicalContact',
+    Namespaces = 'namespaces',
+};
+
 export interface Request extends CommonFields {
     profileId: number;
-    editType: string;
+    editType: RequestEditType;
     editObject: string;
     natsSubject?: string;
     natsContext?: string;
@@ -46,7 +52,7 @@ export default class RequestModel extends Model {
                 data.editType,
                 data.editObject,
                 data.natsSubject,
-                data.natsContext
+                data.natsContext,
             ],
         };
 
@@ -80,7 +86,7 @@ export default class RequestModel extends Model {
                 aData.editType,
                 aData.editObject,
                 aData.natsSubject,
-                aData.natsContext
+                aData.natsContext,
             ];
 
             const results = await this.runQuery(query);

--- a/api/src/db/model/userprofile.ts
+++ b/api/src/db/model/userprofile.ts
@@ -130,5 +130,5 @@ export default class UserProfileModel extends Model {
 
       throw err;
     }
-  };
+  }
 }


### PR DESCRIPTION
- ts linting
- refactor work around quota edit
- refactor work so there are reusable components that aren't just specific to quota edit but all edits
- refactor work so clusterName is read as optional request param as bot is currently passing to provision endpoint

Fixes #222 

/bot-ignore-length