### PR TITLE
Bugfix for profile description containing unescaped quote in it

### DIFF
--- a/api/src/libs/fulfillment.ts
+++ b/api/src/libs/fulfillment.ts
@@ -92,13 +92,16 @@ const sendNatsMessage = async (profileId: number, natsObject: NatsObject): Promi
     const nc = shared.nats;
     const { natsSubject, natsContext } = natsObject;
 
+    // this is to fix the double quotes not being escaped issue
+    natsContext.description = JSON.stringify(natsContext.description);
+
     nc.on('error', () => {
       const errmsg = `NATS error sending order ${profileId} to ${natsSubject}`;
       throw new Error(errmsg);
     });
 
     logger.info(`Sending NATS message for ${profileId}`);
-    nc.publish(natsSubject, JSON.stringify(natsContext));
+    nc.publish(natsSubject, natsContext);
     logger.info(`NATS Message sent for ${profileId}`);
 
     nc.flush(() => {

--- a/api/src/libs/fulfillment.ts
+++ b/api/src/libs/fulfillment.ts
@@ -92,16 +92,13 @@ const sendNatsMessage = async (profileId: number, natsObject: NatsObject): Promi
     const nc = shared.nats;
     const { natsSubject, natsContext } = natsObject;
 
-    // this is to fix the double quotes not being escaped issue
-    natsContext.description = JSON.stringify(natsContext.description);
-
     nc.on('error', () => {
       const errmsg = `NATS error sending order ${profileId} to ${natsSubject}`;
       throw new Error(errmsg);
     });
 
     logger.info(`Sending NATS message for ${profileId}`);
-    nc.publish(natsSubject, natsContext);
+    nc.publish(natsSubject, JSON.stringify(natsContext));
     logger.info(`NATS Message sent for ${profileId}`);
 
     nc.flush(() => {

--- a/api/src/libs/fulfillment.ts
+++ b/api/src/libs/fulfillment.ts
@@ -98,7 +98,7 @@ const sendNatsMessage = async (profileId: number, natsObject: NatsObject): Promi
     });
 
     logger.info(`Sending NATS message for ${profileId}`);
-    nc.publish(natsSubject, natsContext);
+    nc.publish(natsSubject, JSON.stringify(natsContext));
     logger.info(`NATS Message sent for ${profileId}`);
 
     nc.flush(() => {

--- a/web/src/utils/getValidator.tsx
+++ b/web/src/utils/getValidator.tsx
@@ -41,7 +41,7 @@ const schema = {
       maximum: 512,
       tooLong: 'Max 512 characters'
     },
-    format: { pattern: `^[A-Za-z0-9\n ,)(.!?']+`, flags: 'i', message: 'No special characters allowed' }
+    format: { pattern: `^[A-Za-z0-9\n ,)(.!?"']+`, flags: 'i', message: 'No special characters allowed' }
   },
   componenentOthers: {
     length: {


### PR DESCRIPTION
- on the api side, stringify nats message before sending
- on the web side, allow double quote in profile description

Some notes:
It turns out that the double quotes have been properly escaped when they are collected from the web and stored in DB.
It's just when we send structured data through nats, without JSON.stringify, they won't be escaped properly.
Since the ansible side has already got the step to parse the nats msg, the solution is to JSON.stringify it first.

Fixes #213 