### PR TITLE
Bugfix for unescaped quote issue for endpoint getProfileBotJsonUnderPending

### DIFF
--- a/api/src/controllers/sync.ts
+++ b/api/src/controllers/sync.ts
@@ -96,7 +96,6 @@ export const getProvisionedProfileBotJson = async (
     const stringifiedMsg = JSON.stringify(replaceForDescription(context));
 
     logger.info(`\n\nstringified JSON msg for ${profileId}`, stringifiedMsg, '\n\n');
-    // serve bot the stringified nats/json message to avoid not escaped double quotes issue
     res.status(200).send(stringifiedMsg);
   } catch (err) {
     const message = `Unable get provisioned profile bot json for profile ID ${profileId}`;
@@ -150,10 +149,9 @@ export const getProfileBotJsonUnderPending = async (
       // if the queried profile is under pending create
       context = await contextForProvisioning(profileId, FulfillmentContextAction.Create);
     }
-    const stringifiedMsg = JSON.stringify(replaceForDescription(context));
+    const stringifiedMsg = JSON.stringify(context);
 
     logger.info(`\n\nstringified JSON msg for ${profileId}`, stringifiedMsg, '\n\n');
-    // serve bot the stringified nats/json message to avoid not escaped double quotes issue
     res.status(200).send(stringifiedMsg);
   } catch (err) {
     const message = `Unable get profile (currently under pending edit / create) bot json for profile ID ${profileId}`;

--- a/api/src/controllers/sync.ts
+++ b/api/src/controllers/sync.ts
@@ -24,7 +24,7 @@ import { Request } from '../db/model/request';
 import { contextForProvisioning, FulfillmentContextAction } from '../libs/fulfillment';
 import { getDefaultCluster, isNamespaceSetProvisioned } from '../libs/namespace-set';
 import shared from '../libs/shared';
-import { replaceForDescription } from '../libs/utils';
+import { replaceForDescription0, replaceForDescription1 } from '../libs/utils';
 
 const dm = new DataManager(shared.pgPool);
 
@@ -93,7 +93,7 @@ export const getProvisionedProfileBotJson = async (
     }
 
     const context = await contextForProvisioning(profileId, FulfillmentContextAction.Sync);
-    const stringifiedMsg = JSON.stringify(replaceForDescription(context));
+    const stringifiedMsg = JSON.stringify(replaceForDescription0(context));
 
     logger.info(`\n\nstringified JSON msg for ${profileId}`, stringifiedMsg, '\n\n');
     res.status(200).send(stringifiedMsg);
@@ -149,7 +149,7 @@ export const getProfileBotJsonUnderPending = async (
       // if the queried profile is under pending create
       context = await contextForProvisioning(profileId, FulfillmentContextAction.Create);
     }
-    const stringifiedMsg = JSON.stringify(context);
+    const stringifiedMsg = JSON.stringify(replaceForDescription1(context));
 
     logger.info(`\n\nstringified JSON msg for ${profileId}`, stringifiedMsg, '\n\n');
     res.status(200).send(stringifiedMsg);

--- a/api/src/libs/fulfillment.ts
+++ b/api/src/libs/fulfillment.ts
@@ -23,7 +23,7 @@ import DataManager from '../db';
 import { Contact } from '../db/model/contact';
 import { ProjectProfile } from '../db/model/profile';
 import { RequestEditType } from '../db/model/request';
-import { replaceForDescription } from '../libs/utils';
+import { replaceForDescription0 } from '../libs/utils';
 import { MessageType, sendProvisioningMessage } from './messaging';
 import shared from './shared';
 
@@ -100,7 +100,7 @@ const sendNatsMessage = async (profileId: number, natsObject: NatsObject):
       throw new Error(errmsg);
     });
 
-    const stringifiedMsg = JSON.stringify(replaceForDescription(natsContext));
+    const stringifiedMsg = JSON.stringify(replaceForDescription0(natsContext));
 
     logger.info(`Sending NATS message for ${profileId}`);
     logger.info(`\n\nstringified JSON msg for ${profileId}`,

--- a/api/src/libs/utils.ts
+++ b/api/src/libs/utils.ts
@@ -55,7 +55,18 @@ export const isNotAuthorized = (results: any, user: any): Error | undefined => {
   return;
 }
 
-// TODO:(yf) refactor here
+// when we pass the nats/json message through nats / sync endpoints
+// there is an inconsistent double quote issue in profile description
+// that occur ONLY in create and sync, NOT edit (action type)
+
+// the function BELOW is to address such issue
+// so we are confident that the final manifest yaml file is valid
+// for example:
+
+// Action: create
+// DisplayName: Double quote Test
+// Description: A description that contains \"double quotes\"
+// ProfileID: 1
 export const replaceForDescription = (contextJson: any) => {
   contextJson.description = contextJson.description.replace(/"/g, '\\"');
   return contextJson;

--- a/api/src/libs/utils.ts
+++ b/api/src/libs/utils.ts
@@ -57,17 +57,21 @@ export const isNotAuthorized = (results: any, user: any): Error | undefined => {
 
 // when we pass the nats/json message through nats / sync endpoints
 // there is an inconsistent double quote issue in profile description
-// that occur ONLY in create and sync, NOT edit (action type)
 
-// the function BELOW is to address such issue
-// so we are confident that the final manifest yaml file is valid
-// for example:
+// the functions BELOW are to address such inconsistency
+// in order to make surethe final manifest yaml file is valid e.g.
 
 // Action: create
 // DisplayName: Double quote Test
 // Description: A description that contains \"double quotes\"
 // ProfileID: 1
-export const replaceForDescription = (contextJson: any) => {
+export const replaceForDescription0 = (contextJson: any) => {
   contextJson.description = contextJson.description.replace(/"/g, '\\"');
   return contextJson;
 };
+
+export const replaceForDescription1 = (contextJson: any) => {
+  contextJson.description = contextJson.description.replace(/"/g, '\"');
+  return contextJson;
+};
+


### PR DESCRIPTION
This is to resolve an issue that still persists after the bugfix PR #252.

Bugfix PR #252 didn't solve the last case from the list below:
> Actions from Web UI (NATS Used)
> - Create : Quotes are escaped as expected with \\\" in the JSON/NATS message
> - Edit: Quotes are escaped as expected with \\\" in the JSON/NATS message
> 
> Actions from Sync Workflow (API Used) - provisioned-profile-bot-json
> - Create: No Result as Expected (Not Approved/Provisioned Yet)
> - Sync (Provisioned Create or Edit): Quotes are escaped as expected \\\" in the JSON/NATS message
> - Sync (Pending Edit PR Open): Create (Provisioned) JSON/NATS message returned with expected \\\"
> 
> Actions from Sync Pending Workflow (API Used) - under-pending-profile-bot-json
> - Create: Quotes are escaped as expected \\\" in the JSON/NATS message
> - **Edit: Quotes are not escaped properly \\\\\" in the JSON/NATS message**

Therefore, this PR is to accommodate the last case.

Fixes #213 