### PR TITLE
Bugfix to address the unescaped double quote issue in manifest yaml

### DIFF
--- a/api/__tests__/__snapshots__/sync.spec.ts.snap
+++ b/api/__tests__/__snapshots__/sync.spec.ts.snap
@@ -16,6 +16,18 @@ Array [
 ]
 `;
 
+exports[`Sync event handlers Bot json object for a queried profile under pending edit / create is returned 1`] = `200`;
+
+exports[`Sync event handlers Bot json object for a queried profile under pending edit / create is returned 2`] = `""`;
+
+exports[`Sync event handlers Bot json object for a queried provisioned profile is returned 1`] = `200`;
+
+exports[`Sync event handlers Bot json object for a queried provisioned profile is returned 2`] = `""`;
+
+exports[`Sync event handlers Bot json object for a queried provisioned profile should throw 1`] = `"Unable get provisioned profile bot json for profile ID 1"`;
+
 exports[`Sync event handlers Fetch all ids of profiles under pending edit / create should throw 1`] = `"Unable fetch all profile ids that are under pending edit"`;
+
+exports[`Sync event handlers Fetch all ids of profiles under pending edit / create should throw 2`] = `"Unable fetch all profile ids that are under pending edit"`;
 
 exports[`Sync event handlers Fetch all provisioned profile ids should throw 1`] = `"Unable fetch all provisioned profile ids"`;

--- a/api/__tests__/sync.spec.ts
+++ b/api/__tests__/sync.spec.ts
@@ -17,7 +17,7 @@
 import fs from 'fs';
 import path from 'path';
 import { Pool } from 'pg';
-import { getAllProfileIdsUnderPending, getAllProvisionedProfileIds } from '../src/controllers/sync';
+import { getAllProfileIdsUnderPending, getAllProvisionedProfileIds, getProfileBotJsonUnderPending, getProvisionedProfileBotJson } from '../src/controllers/sync';
 import FauxExpress from './src/fauxexpress';
 
 const p0 = path.join(__dirname, 'fixtures/select-profile.json');
@@ -28,7 +28,6 @@ const selectProfileNamespaces = JSON.parse(fs.readFileSync(p1, 'utf8'));
 
 const p4 = path.join(__dirname, 'fixtures/select-request.json');
 const selectRequest = JSON.parse(fs.readFileSync(p4, 'utf8'));
-
 
 const client = new Pool().connect();
 
@@ -48,6 +47,12 @@ jest.mock('../src/libs/fulfillment', () => {
 
   return {
     contextForProvisioning: jest.fn().mockReturnValue(selectProvisioningContext),
+  };
+});
+
+jest.mock('../src/libs/utils', () => {
+  return {
+    replaceForDescription: jest.fn().mockReturnValue(''),
   };
 });
 
@@ -85,35 +90,35 @@ describe('Sync event handlers', () => {
     expect(ex.responseData).toBeUndefined();
   });
 
-  // it('Bot json object for a queried provisioned profile is returned', async () => {
-  //   const req = {
-  //     params: {
-  //       profileId: 1,
-  //     },
-  //   };
-  //   client.query.mockReturnValueOnce({ rows: selectProfile });
-  //   client.query.mockReturnValueOnce({ rows: selectProfileNamespaces });
+  it('Bot json object for a queried provisioned profile is returned', async () => {
+    const req = {
+      params: {
+        profileId: 1,
+      },
+    };
+    client.query.mockReturnValueOnce({ rows: selectProfile });
+    client.query.mockReturnValueOnce({ rows: selectProfileNamespaces });
 
-  //   // @ts-ignore
-  //   await getProvisionedProfileBotJson(req, ex.res);
+    // @ts-ignore
+    await getProvisionedProfileBotJson(req, ex.res);
 
-  //   expect(ex.res.statusCode).toMatchSnapshot();
-  //   expect(ex.responseData).toMatchSnapshot();
-  //   expect(ex.res.status).toBeCalled();
-  //   expect(ex.res.json).toBeCalled();
-  // });
+    expect(ex.res.statusCode).toMatchSnapshot();
+    expect(ex.responseData).toMatchSnapshot();
+    expect(ex.res.status).toBeCalled();
+    expect(ex.res.json).toBeCalled();
+  });
 
-  // it('Bot json object for a queried provisioned profile should throw', async () => {
-  //   const req = {
-  //     params: { profileId: 1 },
-  //   };
-  //   client.query.mockImplementation(() => { throw new Error() });
+  it('Bot json object for a queried provisioned profile should throw', async () => {
+    const req = {
+      params: { profileId: 1 },
+    };
+    client.query.mockImplementation(() => { throw new Error() });
 
-  //   // @ts-ignore
-  //   await expect(getProvisionedProfileBotJson(req, ex.res)).rejects.toThrowErrorMatchingSnapshot();
+    // @ts-ignore
+    await expect(getProvisionedProfileBotJson(req, ex.res)).rejects.toThrowErrorMatchingSnapshot();
 
-  //   expect(ex.responseData).toBeUndefined();
-  // });
+    expect(ex.responseData).toBeUndefined();
+  });
 
   it('All ids of profiles under pending edit / create are returned', async () => {
     const req = {};
@@ -142,43 +147,43 @@ describe('Sync event handlers', () => {
     expect(ex.responseData).toBeUndefined();
   });
 
-  // it('Bot json object for a queried profile under pending edit / create is returned', async () => {
-  //   jest.mock('../src/libs/namespace-set', () => {
-  //     const p2 = path.join(__dirname, 'fixtures/select-default-cluster.json');
-  //     const selectDefaultCluster = JSON.parse(fs.readFileSync(p2, 'utf8'));
+  it('Bot json object for a queried profile under pending edit / create is returned', async () => {
+    jest.mock('../src/libs/namespace-set', () => {
+      const p2 = path.join(__dirname, 'fixtures/select-default-cluster.json');
+      const selectDefaultCluster = JSON.parse(fs.readFileSync(p2, 'utf8'));
 
-  //     return {
-  //       isNamespaceSetProvisioned: jest.fn().mockReturnValue(false),
-  //       getDefaultCluster: jest.fn().mockReturnValue(selectDefaultCluster),
-  //     };
-  //   });
+      return {
+        isNamespaceSetProvisioned: jest.fn().mockReturnValue(false),
+        getDefaultCluster: jest.fn().mockReturnValue(selectDefaultCluster),
+      };
+    });
 
-  //   const req = {
-  //     params: { profileId: 118 },
-  //   };
-  //   client.query.mockReturnValueOnce({ rows: selectRequest });
-  //   client.query.mockReturnValueOnce({ rows: selectProfile });
-  //   client.query.mockReturnValueOnce({ rows: selectProfileNamespaces });
-  //   client.query.mockReturnValueOnce({ rows: [] });
+    const req = {
+      params: { profileId: 118 },
+    };
+    client.query.mockReturnValueOnce({ rows: selectRequest });
+    client.query.mockReturnValueOnce({ rows: selectProfile });
+    client.query.mockReturnValueOnce({ rows: selectProfileNamespaces });
+    client.query.mockReturnValueOnce({ rows: [] });
 
-  //   // @ts-ignore
-  //   await getProfileBotJsonUnderPending(req, ex.res);
+    // @ts-ignore
+    await getProfileBotJsonUnderPending(req, ex.res);
 
-  //   expect(ex.res.statusCode).toMatchSnapshot();
-  //   expect(ex.responseData).toMatchSnapshot();
-  //   expect(ex.res.status).toBeCalled();
-  //   expect(ex.res.json).toBeCalled();
-  // });
+    expect(ex.res.statusCode).toMatchSnapshot();
+    expect(ex.responseData).toMatchSnapshot();
+    expect(ex.res.status).toBeCalled();
+    expect(ex.res.json).toBeCalled();
+  });
 
-  // it('Fetch all ids of profiles under pending edit / create should throw', async () => {
-  //   const req = {
-  //     params: {},
-  //   };
-  //   client.query.mockImplementation(() => { throw new Error() });
+  it('Fetch all ids of profiles under pending edit / create should throw', async () => {
+    const req = {
+      params: {},
+    };
+    client.query.mockImplementation(() => { throw new Error() });
 
-  //   // @ts-ignore
-  //   await expect(getAllProfileIdsUnderPending(req, ex.res)).rejects.toThrowErrorMatchingSnapshot();
+    // @ts-ignore
+    await expect(getAllProfileIdsUnderPending(req, ex.res)).rejects.toThrowErrorMatchingSnapshot();
 
-  //   expect(ex.responseData).toBeUndefined();
-  // });
+    expect(ex.responseData).toBeUndefined();
+  });
 });

--- a/api/__tests__/utils.spec.ts
+++ b/api/__tests__/utils.spec.ts
@@ -18,7 +18,7 @@ import { replaceForDescription } from '../src/libs/utils';
 
 describe('Utils', () => {
   it('replaceForDescription works correctly', async () => {
-    const natsContext = {
+    const contextJson = {
       profileId: 118,
       displayName: 'Project X',
       description: 'test some "double quotes"',
@@ -30,6 +30,6 @@ describe('Utils', () => {
       description: 'test some  double quotes ',
     };
 
-    expect(replaceForDescription(natsContext)).toEqual(result);
+    expect(replaceForDescription(contextJson)).toEqual(result);
   });
 });

--- a/api/__tests__/utils.spec.ts
+++ b/api/__tests__/utils.spec.ts
@@ -1,0 +1,35 @@
+//
+// Copyright © 2020 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { replaceForDescription } from '../src/libs/utils';
+
+describe('Utils', () => {
+  it('replaceForDescription works correctly', async () => {
+    const natsContext = {
+      profileId: 118,
+      displayName: 'Project X',
+      description: 'test some "double quotes"',
+    };
+
+    const result = {
+      profileId: 118,
+      displayName: 'Project X',
+      description: 'test some  double quotes ',
+    };
+
+    expect(replaceForDescription(natsContext)).toEqual(result);
+  });
+});

--- a/api/src/controllers/sync.ts
+++ b/api/src/controllers/sync.ts
@@ -93,11 +93,8 @@ export const getProvisionedProfileBotJson = async (
     }
 
     const context = await contextForProvisioning(profileId, FulfillmentContextAction.Sync);
-    const stringifiedMsg = JSON.stringify(replaceForDescription(context));
 
-    logger.info(`\n\nstringified JSON msg for ${profileId}`, stringifiedMsg, '\n\n');
-    // serve bot the stringified nats/json message to avoid not escaped double quotes issue
-    res.status(200).send(stringifiedMsg);
+    res.status(200).json(replaceForDescription(context));
   } catch (err) {
     const message = `Unable get provisioned profile bot json for profile ID ${profileId}`;
     logger.error(`${message}, err = ${err.message}`);
@@ -150,11 +147,8 @@ export const getProfileBotJsonUnderPending = async (
       // if the queried profile is under pending create
       context = await contextForProvisioning(profileId, FulfillmentContextAction.Create);
     }
-    const stringifiedMsg = JSON.stringify(replaceForDescription(context));
 
-    logger.info(`\n\nstringified JSON msg for ${profileId}`, stringifiedMsg, '\n\n');
-    // serve bot the stringified nats/json message to avoid not escaped double quotes issue
-    res.status(200).send(stringifiedMsg);
+    res.status(200).json(replaceForDescription(context));
   } catch (err) {
     const message = `Unable get profile (currently under pending edit / create) bot json for profile ID ${profileId}`;
     logger.error(`${message}, err = ${err.message}`);

--- a/api/src/libs/fulfillment.ts
+++ b/api/src/libs/fulfillment.ts
@@ -99,11 +99,9 @@ const sendNatsMessage = async (profileId: number, natsObject: NatsObject): Promi
       throw new Error(errmsg);
     });
 
-    const stringifiedMsg = JSON.stringify(replaceForDescription(natsContext));
     logger.info(`Sending NATS message for ${profileId}`);
-    logger.info(`\n\nstringified JSON msg for ${profileId}`,
-      JSON.stringify(stringifiedMsg), '\n\n');
-    nc.publish(natsSubject, stringifiedMsg);
+
+    nc.publish(natsSubject, replaceForDescription(natsContext));
     logger.info(`NATS Message sent for ${profileId}`);
 
     nc.flush(() => {

--- a/api/src/libs/utils.ts
+++ b/api/src/libs/utils.ts
@@ -55,8 +55,14 @@ export const isNotAuthorized = (results: any, user: any): Error | undefined => {
   return;
 }
 
-// TODO:(yf) refactor here
+// when we pass the nats/json message through nats / sync endpoints
+// there is an inconsistent double quote issue in profile description
+
+// the function BELOW is to address such issue
+// in order to make sure the final manifest yaml file is valid to ocp
 export const replaceForDescription = (contextJson: any) => {
-  contextJson.description = contextJson.description.replace(/"/g, '\\"');
+  const doubleQuoteReplaced = contextJson.description.replace(/"/g, ' ').replace(/\\/g, '');
+
+  contextJson.description = doubleQuoteReplaced;
   return contextJson;
 };


### PR DESCRIPTION
- replace double quote character with whitespace when sending nats / json message
- revert back to serving json oppose to string
- update unit tests

The proposed changes should resolve the following issue:
Ansible json decodes the json message when converting it to a var which would unescape the " and then it wouldn't be valid yaml for OpenShift.

Fixes #213

/bot-ignore-length