### PR TITLE
Refactor pendingEditRequest

### DIFF
--- a/web/src/utils/getProfileStatus.tsx
+++ b/web/src/utils/getProfileStatus.tsx
@@ -18,11 +18,7 @@
 export default function getProfileStatus() {
     const getPendingEditRequest = async (api: any, profileId: string): Promise<any> => {
         const editRequest = await api.getEditRequestStatus(profileId);
-        if (editRequest.data.length === 0){
-            return false;
-        } else {
-            return true;
-        };
+        return !(editRequest.data.length === 0);
     }
     return {
         getPendingEditRequest

--- a/web/src/utils/getProfileStatus.tsx
+++ b/web/src/utils/getProfileStatus.tsx
@@ -1,0 +1,30 @@
+//
+// Copyright © 2020 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+export default function getProfileStatus() {
+    const getPendingEditRequest = async (api: any, profileId: string): Promise<any> => {
+        const editRequest = await api.getEditRequestStatus(profileId);
+        if (editRequest.data.length === 0){
+            return false;
+        } else {
+            return true;
+        };
+    }
+    return {
+        getPendingEditRequest
+    }
+};


### PR DESCRIPTION
The initial method for determining if there was a pending edit request involved too much duplication. This is a simple refactor to improve future use.