### PR TITLE
Update description of  migration status note

### DIFF
--- a/web/src/__tests__/__snapshots__/ProfileCreate.test.tsx.snap
+++ b/web/src/__tests__/__snapshots__/ProfileCreate.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`matches the snapshot 1`] = `
               <br />
                b) have short 2-3 week migration timelines starting from when the namespaces are provisioned.
             </blockquote>
-            Please, indicate in the project description field if your project meets the 2 criteria above
+            Please indicate in the project description field if your project meets the two criteria above and include the license plate number for the OCP3 project set.
           </h3>
           <div
             class="css-j2gbad"

--- a/web/src/components/profileCreate/CreateFormProject.tsx
+++ b/web/src/components/profileCreate/CreateFormProject.tsx
@@ -48,8 +48,8 @@ const CreateFormProject: React.FC<ICreateFormProjectProps> = (props) => {
                     <br /> b) have short 2-3 week migration timelines starting from when the 
                     namespaces are provisioned. 
                 </blockquote>
-                Please, indicate in the project description field if your project 
-                meets the 2 criteria above
+                Please indicate in the project description field if your project 
+                meets the two criteria above and include the license plate number for the OCP3 project set.
             </FormSubtitle>
             <Field name="project-name" validate={validator.mustBeValidProfileName}>
                 {({ input, meta }) => (


### PR DESCRIPTION
Adjustments to the migration status note to include clarifying details of OCP 3.11 namespace name.

Fixes #282 