### PR TITLE
Clean up frontend state mgmt including ProfileEdit component

### DIFF
--- a/web/src/AppRouter.tsx
+++ b/web/src/AppRouter.tsx
@@ -19,8 +19,8 @@ import { createBrowserHistory } from 'history';
 import React from 'react';
 import { Redirect, Router, Switch } from 'react-router-dom';
 import { BackdropForProcessing } from './components/common/UI/Backdrop';
-import { HOME_PAGE_URL, LAYOUT_SET_AUTH, LAYOUT_SET_MIN, LAYOUT_SET_UNAUTH, ROUTE_PATHS } from './constants';
-import Layout from './layouts/Layout';
+import { HOME_PAGE_URL, ROUTE_PATHS } from './constants';
+import { AuthLayout, PublicLayout } from './layouts/Layout';
 import AppRoute from './utils/AppRoute';
 import { areQueryParamsForProfileValid } from './utils/checkQueryParamsHelper';
 import Dashboard from './views/Dashboard';
@@ -42,11 +42,11 @@ const AppRouter: React.FC = () => {
     <Router history={browserHistory}>
       <Switch>
         <Redirect exact from='/' to={ROUTE_PATHS.LANDING} />
-        <AppRoute path={ROUTE_PATHS.LANDING} component={PublicLanding} layout={Layout} layoutName={LAYOUT_SET_UNAUTH} />
-        <AppRoute exact path={ROUTE_PATHS.PROFILE_CREATE} component={ProfileCreate} layout={Layout} layoutName={LAYOUT_SET_AUTH} />
-        <AppRoute exact path={HOME_PAGE_URL} component={Dashboard} layout={Layout} layoutName={LAYOUT_SET_AUTH} />
-        <AppRoute exact path={ROUTE_PATHS.PROFILE_EDIT} component={ProfileEdit} layout={Layout} layoutName={LAYOUT_SET_AUTH} checkQueryParams={areQueryParamsForProfileValid} />
-        <AppRoute path={ROUTE_PATHS.NOT_FOUND} component={NotFound} layout={Layout} layoutName={LAYOUT_SET_MIN} />
+        <AppRoute path={ROUTE_PATHS.LANDING} component={PublicLanding} layout={PublicLayout} />
+        <AppRoute exact path={ROUTE_PATHS.PROFILE_CREATE} component={ProfileCreate} layout={AuthLayout} />
+        <AppRoute exact path={HOME_PAGE_URL} component={Dashboard} layout={AuthLayout} />
+        <AppRoute exact path={ROUTE_PATHS.PROFILE_EDIT} component={ProfileEdit} layout={AuthLayout} checkQueryParams={areQueryParamsForProfileValid} />
+        <AppRoute path={ROUTE_PATHS.NOT_FOUND} component={NotFound} layout={PublicLayout} />
         <Redirect to={ROUTE_PATHS.NOT_FOUND} />
       </Switch>
     </Router>

--- a/web/src/__tests__/ContactCard.test.tsx
+++ b/web/src/__tests__/ContactCard.test.tsx
@@ -26,10 +26,12 @@ test('matches the snapshot', () => {
 
   const { container } = render(
     <ContactCard
-      POName={stubPropPOName}
-      POEmail={stubPropPOEmail}
-      TCName={stubPropTCName}
-      TCEmail={stubPropTCEmail}
+      contactDetails={{
+        POName: stubPropPOName,
+        POEmail: stubPropPOEmail,
+        TCName: stubPropTCName,
+        TCEmail: stubPropTCEmail,
+      }}
     />
   );
 

--- a/web/src/__tests__/ProjectCard.test.tsx
+++ b/web/src/__tests__/ProjectCard.test.tsx
@@ -25,9 +25,11 @@ test('matches the snapshot', () => {
 
   const { container } = render(
     <ProjectCard
-      title={stubPropTitle}
-      textBody={stubPropTextBody}
-      ministry={stubPropMinistry}
+      projectDetails={{
+        name: stubPropTitle,
+        description: stubPropTextBody,
+        ministryName: stubPropMinistry,
+      }}
     />
   );
 

--- a/web/src/components/common/layout/Header.tsx
+++ b/web/src/components/common/layout/Header.tsx
@@ -18,10 +18,10 @@ import styled from '@emotion/styled';
 import React, { useState } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { Text } from 'rebass';
-import { HOME_PAGE_URL, LAYOUT_SET_AUTH, LAYOUT_SET_MIN, ROUTE_PATHS } from '../../../constants';
+import { HOME_PAGE_URL, ROUTE_PATHS } from '../../../constants';
 import useComponentVisible from '../../../hooks/useComponentVisible';
 import theme from '../../../theme';
-import { LayoutSet, MenuItem } from '../../../types';
+import { MenuItem } from '../../../types';
 import typography from '../../../typography';
 import Authbutton from '../UI/AuthButton';
 import CreateButton from '../UI/CreateButton';
@@ -71,16 +71,14 @@ const StyledText = styled(Text)`
 `;
 
 interface INavProps {
-  name: LayoutSet;
+  isAuthenticated: boolean;
   isDDMobileOpen: boolean;
   handleDDMobile: (e: any) => void;
   dirs: Array<MenuItem>;
 }
 
 const Nav: React.FC<INavProps> = props => {
-  const { name, handleDDMobile, isDDMobileOpen, dirs } = props;
-
-  const isAuthenticated = (name === LAYOUT_SET_AUTH);
+  const { isAuthenticated, handleDDMobile, isDDMobileOpen, dirs } = props;
 
   const { ref, isComponentVisible, setIsComponentVisible } = useComponentVisible(false);
 
@@ -88,31 +86,27 @@ const Nav: React.FC<INavProps> = props => {
     setIsComponentVisible(!isComponentVisible);
   };
 
-  if (name === LAYOUT_SET_MIN) {
-    return null;
-  } else {
-    return (
-      <StyledNav>
-        <ContainerDesktop>
-          {isAuthenticated && (<CreateButton onClick={handleDDDesktop}>Create</CreateButton>)}
-          <Authbutton />
-          {isAuthenticated && isComponentVisible && (<DropdownMenu handleOnClick={handleDDDesktop} ref={ref} menuItems={dirs} />)}
-        </ContainerDesktop>
-        <ContainerMobile>
-          <Icon hover color={'contrast'} name={isDDMobileOpen ? 'close' : 'menuStack'}
-            onClick={handleDDMobile} width={1.4} height={1.4} />
-        </ContainerMobile>
-      </StyledNav>
-    )
-  }
+  return (
+    <StyledNav>
+      <ContainerDesktop>
+        {isAuthenticated && (<CreateButton onClick={handleDDDesktop}>Create</CreateButton>)}
+        <Authbutton />
+        {isAuthenticated && isComponentVisible && (<DropdownMenu handleOnClick={handleDDDesktop} ref={ref} menuItems={dirs} />)}
+      </ContainerDesktop>
+      <ContainerMobile>
+        <Icon hover color={'contrast'} name={isDDMobileOpen ? 'close' : 'menuStack'}
+          onClick={handleDDMobile} width={1.4} height={1.4} />
+      </ContainerMobile>
+    </StyledNav>
+  );
 };
 
 interface IHeaderProps {
-  name: LayoutSet;
+  auth?: boolean;
 }
 
 const Header: React.FC<IHeaderProps> = props => {
-  const { name } = props;
+  const { auth: useAuthHeader } = props;
 
   const [isDDMobileOpen, setIsDDMobileOpen] = useState(false);
 
@@ -124,7 +118,7 @@ const Header: React.FC<IHeaderProps> = props => {
     title: "A new Openshift Project Set",
     subTitle: "Create 4 Project namespaces in Silver cluster",
     href: ROUTE_PATHS.PROFILE_CREATE,
-    onClickCB: () => { }
+    onClickCB: () => { },
   }];
 
   return (
@@ -141,15 +135,14 @@ const Header: React.FC<IHeaderProps> = props => {
           >
             Platform Services Registry
           </StyledText>
-          {/* <H2>Platform Services Registry</H2> */}
         </RouterLink>
-        {(name !== LAYOUT_SET_MIN) && (<Nav name={name} dirs={dirs} handleDDMobile={handleDDMobile} isDDMobileOpen={isDDMobileOpen} />)}
+        <Nav isAuthenticated={!!useAuthHeader} dirs={dirs} handleDDMobile={handleDDMobile} isDDMobileOpen={isDDMobileOpen} />
       </StyledBanner>
       <ContainerMobile>
         {isDDMobileOpen && (
           <StyledDropdownMobile >
             <Authbutton />
-            {(name === LAYOUT_SET_AUTH) && (<div>
+            {!!useAuthHeader && (<div>
               {dirs.map(
                 (item, index) =>
                   <DropdownMenuItem handleOnClick={handleDDMobile} key={index + item.title} href={item.href} title={item.title} subTitle={item.subTitle} onClickCB={item.onClickCB} />

--- a/web/src/components/profileEdit/ContactCard.tsx
+++ b/web/src/components/profileEdit/ContactCard.tsx
@@ -19,16 +19,26 @@ import { Box, Flex, Text } from 'rebass';
 import theme from '../../theme';
 
 interface IContactCardProps {
+    contactDetails: ContactDetails;
+}
+
+export interface ContactDetails {
+    POId?: string;
+    POFirstName?: string;
+    POLastName?: string;
     POName?: string;
     POEmail?: string;
     POGithubId?: string;
+    TCId?: string;
+    TCFirstName?: string;
+    TCLastName?: string;
     TCName?: string;
     TCEmail?: string;
     TCGithubId?: string;
-};
+}
 
 const ContactCard: React.FC<IContactCardProps> = (props) => {
-    const { POName = '', POEmail = '', POGithubId = '', TCName = '', TCEmail = '', TCGithubId = '' } = props;
+    const { contactDetails: { POName = '', POEmail = '', POGithubId = '', TCName = '', TCEmail = '', TCGithubId = '' } } = props;
 
     return (
         <Flex flexWrap='wrap'>

--- a/web/src/components/profileEdit/ContactCardEdit.tsx
+++ b/web/src/components/profileEdit/ContactCardEdit.tsx
@@ -20,6 +20,7 @@ import { Field, Form } from 'react-final-form';
 import { Redirect } from 'react-router-dom';
 import { Flex } from 'rebass';
 import { PROFILE_EDIT_VIEW_NAMES, ROUTE_PATHS } from '../../constants';
+import useCommonState from '../../hooks/useCommonState';
 import useRegistryApi from '../../hooks/useRegistryApi';
 import getValidator from '../../utils/getValidator';
 import { promptErrToastWithText, promptSuccessToastWithText } from '../../utils/promptToastHelper';
@@ -33,12 +34,11 @@ interface IContactCardEditProps {
     contactDetails: any;
     pendingEditRequest: boolean;
     setPendingEditRequest: any;
-    openBackdropCB: () => void;
-    closeBackdropCB: () => void;
 }
 
 const ContactCardEdit: React.FC<IContactCardEditProps> = (props) => {
-    const { profileId, isProvisioned, contactDetails, pendingEditRequest, setPendingEditRequest, openBackdropCB, closeBackdropCB } = props;
+    const { profileId, isProvisioned, contactDetails, pendingEditRequest, setPendingEditRequest } = props;
+    const { setOpenBackdrop } = useCommonState();
 
     const api = useRegistryApi();
 
@@ -49,7 +49,7 @@ const ContactCardEdit: React.FC<IContactCardEditProps> = (props) => {
     const onSubmit = async (formData: any) => {
         const { productOwner, technicalContact } = transformForm(formData);
         const updatedContacts = { productOwner, technicalContact };
-        openBackdropCB();
+        setOpenBackdrop(true);
 
         try {
             if (!profileId) {
@@ -60,12 +60,12 @@ const ContactCardEdit: React.FC<IContactCardEditProps> = (props) => {
             await api.requestContactEdit(profileId, updatedContacts);
 
             // 2. All good? Redirect back to overview and tell the user.
-            closeBackdropCB();
+            setOpenBackdrop(false);
             setGoBackToProfileEditable(true);
             setPendingEditRequest(true);
             promptSuccessToastWithText('Your profile update was successful');
         } catch (err) {
-            closeBackdropCB();
+            setOpenBackdrop(false);
             promptErrToastWithText('Something went wrong');
             console.log(err);
         }

--- a/web/src/components/profileEdit/ContactCardEdit.tsx
+++ b/web/src/components/profileEdit/ContactCardEdit.tsx
@@ -27,49 +27,51 @@ import { promptErrToastWithText, promptSuccessToastWithText } from '../../utils/
 import { transformForm } from '../../utils/transformDataHelper';
 import { StyledFormButton, StyledFormDisabledButton } from '../common/UI/Button';
 import FormTitle from '../common/UI/FormTitle';
+import { ContactDetails } from './ContactCard';
+
+const validator = getValidator();
 
 interface IContactCardEditProps {
     profileId?: string;
+    contactDetails: ContactDetails;
+    handleSubmitRefresh: any;
     isProvisioned?: boolean;
-    contactDetails: any;
-    pendingEditRequest: boolean;
-    setPendingEditRequest: any;
+    hasPendingEdit: boolean;
 }
 
 const ContactCardEdit: React.FC<IContactCardEditProps> = (props) => {
-    const { profileId, isProvisioned, contactDetails, pendingEditRequest, setPendingEditRequest } = props;
+    const { profileId, contactDetails, handleSubmitRefresh, isProvisioned, hasPendingEdit } = props;
+
     const { setOpenBackdrop } = useCommonState();
-
     const api = useRegistryApi();
-
-    const validator = getValidator();
 
     const [goBackToProfileEditable, setGoBackToProfileEditable] = useState<boolean>(false);
 
     const onSubmit = async (formData: any) => {
-        const { productOwner, technicalContact } = transformForm(formData);
-        const updatedContacts = { productOwner, technicalContact };
         setOpenBackdrop(true);
-
         try {
             if (!profileId) {
-                throw new Error(`'Unable to get profile id'`);
+                throw new Error('Unable to get profile id');
             }
 
-            // 1. Request the project contact edit.
+            // 1. Prepare contact edit request body.
+            const { productOwner, technicalContact } = transformForm(formData);
+            const updatedContacts = { productOwner, technicalContact };
+
+            // 2. Request the profile contact edit.
             await api.requestContactEdit(profileId, updatedContacts);
 
-            // 2. All good? Redirect back to overview and tell the user.
-            setOpenBackdrop(false);
+            // 3. All good? Redirect back to overview and tell the user.
             setGoBackToProfileEditable(true);
-            setPendingEditRequest(true);
+            handleSubmitRefresh();
             promptSuccessToastWithText('Your profile update was successful');
         } catch (err) {
-            setOpenBackdrop(false);
-            promptErrToastWithText('Something went wrong');
+            promptErrToastWithText(err.message);
             console.log(err);
         }
+        setOpenBackdrop(false);
     };
+
     if (goBackToProfileEditable && profileId) {
         return (<Redirect to={
             ROUTE_PATHS.PROFILE_EDIT.replace(':profileId', profileId).replace(':viewName', PROFILE_EDIT_VIEW_NAMES.OVERVIEW)
@@ -77,115 +79,113 @@ const ContactCardEdit: React.FC<IContactCardEditProps> = (props) => {
     }
 
     return (
-        <>
-            <Form
-                onSubmit={onSubmit}
-                validate={values => {
-                    const errors = {};
-                    return errors;
-                }}
-            >
-                {props => (
-                    <form onSubmit={props.handleSubmit} >
-                        <FormTitle>Who is the product owner for this project?</FormTitle>
-                        <Field name="po-id" initialValue={contactDetails.POId} >
-                            {({ input }) => (
-                                <input type="hidden" {...input} id="po-Id" />
-                            )}
-                        </Field>
-                        <Field name="po-firstName" validate={validator.mustBeValidName} initialValue={contactDetails.POFirstName}>
-                            {({ input, meta }) => (
-                                <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
-                                    <Label m="0" htmlFor="po-first-name">First Name</Label>
-                                    <Input mt="8px" {...input} id="po-first-name" />
-                                    {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
-                                </Flex>
-                            )}
-                        </Field>
-                        <Field name="po-lastName" validate={validator.mustBeValidName} initialValue={contactDetails.POLastName} >
-                            {({ input, meta }) => (
-                                <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
-                                    <Label m="0" htmlFor="po-last-name">Last Name</Label>
-                                    <Input mt="8px" {...input} id="po-last-name" />
-                                    {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
-                                </Flex>
-                            )}
-                        </Field>
-                        <Field name="po-email" validate={validator.mustBeValidEmail} initialValue={contactDetails.POEmail} >
-                            {({ input, meta }) => (
-                                <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
-                                    <Label m="0" htmlFor="po-email">eMail Address</Label>
-                                    <Input mt="8px" {...input} id="po-email" />
-                                    {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
-                                </Flex>
-                            )}
-                        </Field>
-                        <Field name="po-githubId" validate={validator.mustBeValidGithubName} initialValue={contactDetails.POGithubId} >
-                            {({ input, meta }) => (
-                                <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
-                                    <Label m="0" htmlFor="po-github-id">GitHub ID</Label>
-                                    <Input mt="8px" {...input} id="po-github-id" />
-                                    {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
-                                </Flex>
-                            )}
-                        </Field>
+        <Form
+            onSubmit={onSubmit}
+            validate={values => {
+                const errors = {};
+                return errors;
+            }}
+        >
+            {props => (
+                <form onSubmit={props.handleSubmit} >
+                    <FormTitle>Who is the product owner for this project?</FormTitle>
+                    <Field name="po-id" initialValue={contactDetails.POId} >
+                        {({ input }) => (
+                            <input type="hidden" {...input} id="po-Id" />
+                        )}
+                    </Field>
+                    <Field name="po-firstName" validate={validator.mustBeValidName} initialValue={contactDetails.POFirstName}>
+                        {({ input, meta }) => (
+                            <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
+                                <Label m="0" htmlFor="po-first-name">First Name</Label>
+                                <Input mt="8px" {...input} id="po-first-name" />
+                                {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
+                            </Flex>
+                        )}
+                    </Field>
+                    <Field name="po-lastName" validate={validator.mustBeValidName} initialValue={contactDetails.POLastName} >
+                        {({ input, meta }) => (
+                            <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
+                                <Label m="0" htmlFor="po-last-name">Last Name</Label>
+                                <Input mt="8px" {...input} id="po-last-name" />
+                                {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
+                            </Flex>
+                        )}
+                    </Field>
+                    <Field name="po-email" validate={validator.mustBeValidEmail} initialValue={contactDetails.POEmail} >
+                        {({ input, meta }) => (
+                            <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
+                                <Label m="0" htmlFor="po-email">eMail Address</Label>
+                                <Input mt="8px" {...input} id="po-email" />
+                                {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
+                            </Flex>
+                        )}
+                    </Field>
+                    <Field name="po-githubId" validate={validator.mustBeValidGithubName} initialValue={contactDetails.POGithubId} >
+                        {({ input, meta }) => (
+                            <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
+                                <Label m="0" htmlFor="po-github-id">GitHub ID</Label>
+                                <Input mt="8px" {...input} id="po-github-id" />
+                                {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
+                            </Flex>
+                        )}
+                    </Field>
 
-                        <FormTitle>Who is the technical contact for this project?</FormTitle>
-                        <Field name="tc-id" initialValue={contactDetails.TCId} >
-                            {({ input }) => (
-                                <Input type="hidden" {...input} id="tc-Id" />
-                            )}
-                        </Field>
-                        <Field name="tc-firstName" validate={validator.mustBeValidName} initialValue={contactDetails.TCFirstName} >
-                            {({ input, meta }) => (
-                                <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
-                                    <Label m="0" htmlFor="tc-first-name">First Name</Label>
-                                    <Input mt="8px" {...input} id="tc-first-name" />
-                                    {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
-                                </Flex>
-                            )}
-                        </Field>
-                        <Field name="tc-lastName" validate={validator.mustBeValidName} initialValue={contactDetails.TCLastName} >
-                            {({ input, meta }) => (
-                                <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
-                                    <Label m="0" htmlFor="tc-last-name">Last Name</Label>
-                                    <Input mt="8px" {...input} id="tc-last-name" />
-                                    {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
-                                </Flex>
-                            )}
-                        </Field>
-                        <Field name="tc-email" validate={validator.mustBeValidEmail} initialValue={contactDetails.TCEmail} >
-                            {({ input, meta }) => (
-                                <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
-                                    <Label m="0" htmlFor="tc-email">eMail Address</Label>
-                                    <Input mt="8px" {...input} id="tc-email" />
-                                    {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
-                                </Flex>
-                            )}
-                        </Field>
-                        <Field name="tc-githubId" validate={validator.mustBeValidGithubName} initialValue={contactDetails.TCGithubId} >
-                            {({ input, meta }) => (
-                                <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
-                                    <Label m="0" htmlFor="tc-github-id">GitHub ID</Label>
-                                    <Input mt="8px" {...input} id="tc-github-id" />
-                                    {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
-                                </Flex>
-                            )}
-                        </Field>
-                        {!pendingEditRequest && isProvisioned ? (
-                            //@ts-ignore
-                            <StyledFormButton style={{ display: 'block' }} >Request Update</StyledFormButton>
-                        ) : (
-                                <>
-                                    {/* @ts-ignore */}
-                                    <StyledFormDisabledButton style={{ display: 'block' }}>Request Update</StyledFormDisabledButton>
-                                    <Label as="span" variant="errorLabel" >Not available due to a {isProvisioned ? 'Update' : 'Provision'} Request</Label>
-                                </>
-                            )}
-                    </form>
-                )}
-            </Form>
-        </>
+                    <FormTitle>Who is the technical contact for this project?</FormTitle>
+                    <Field name="tc-id" initialValue={contactDetails.TCId} >
+                        {({ input }) => (
+                            <Input type="hidden" {...input} id="tc-Id" />
+                        )}
+                    </Field>
+                    <Field name="tc-firstName" validate={validator.mustBeValidName} initialValue={contactDetails.TCFirstName} >
+                        {({ input, meta }) => (
+                            <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
+                                <Label m="0" htmlFor="tc-first-name">First Name</Label>
+                                <Input mt="8px" {...input} id="tc-first-name" />
+                                {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
+                            </Flex>
+                        )}
+                    </Field>
+                    <Field name="tc-lastName" validate={validator.mustBeValidName} initialValue={contactDetails.TCLastName} >
+                        {({ input, meta }) => (
+                            <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
+                                <Label m="0" htmlFor="tc-last-name">Last Name</Label>
+                                <Input mt="8px" {...input} id="tc-last-name" />
+                                {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
+                            </Flex>
+                        )}
+                    </Field>
+                    <Field name="tc-email" validate={validator.mustBeValidEmail} initialValue={contactDetails.TCEmail} >
+                        {({ input, meta }) => (
+                            <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
+                                <Label m="0" htmlFor="tc-email">eMail Address</Label>
+                                <Input mt="8px" {...input} id="tc-email" />
+                                {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
+                            </Flex>
+                        )}
+                    </Field>
+                    <Field name="tc-githubId" validate={validator.mustBeValidGithubName} initialValue={contactDetails.TCGithubId} >
+                        {({ input, meta }) => (
+                            <Flex flexDirection="column" pb="25px" style={{ position: "relative" }}>
+                                <Label m="0" htmlFor="tc-github-id">GitHub ID</Label>
+                                <Input mt="8px" {...input} id="tc-github-id" />
+                                {meta.error && meta.touched && <Label as="span" style={{ position: "absolute", bottom: "0" }} variant="errorLabel">{meta.error}</Label>}
+                            </Flex>
+                        )}
+                    </Field>
+                    {!hasPendingEdit && isProvisioned ? (
+                        //@ts-ignore
+                        <StyledFormButton style={{ display: 'block' }} >Request Update</StyledFormButton>
+                    ) : (
+                            <>
+                                {/* @ts-ignore */}
+                                <StyledFormDisabledButton style={{ display: 'block' }}>Request Update</StyledFormDisabledButton>
+                                <Label as="span" variant="errorLabel" >Not available due to a {isProvisioned ? 'Update' : 'Provision'} Request</Label>
+                            </>
+                        )}
+                </form>
+            )}
+        </Form>
     );
 };
 

--- a/web/src/components/profileEdit/ProjectCard.tsx
+++ b/web/src/components/profileEdit/ProjectCard.tsx
@@ -19,13 +19,21 @@ import { Box, Flex, Text } from 'rebass';
 import theme from '../../theme';
 
 interface IProjectCardProps {
-    title?: string;
-    textBody?: string
-    ministry?: string;
-};
+    projectDetails: ProjectDetails;
+}
+
+export interface ProjectDetails {
+    id?: string;
+    name?: string;
+    description?: string;
+    prioritySystem?: string;
+    busOrgId?: string;
+    ministryName?: string;
+    other?: string;
+}
 
 const ProjectCard: React.FC<IProjectCardProps> = (props) => {
-    const { title = '', textBody = '', ministry = '', } = props;
+    const { projectDetails: { name = '', description = '', ministryName = '' } } = props;
 
     return (
         <Flex flexWrap='wrap'>
@@ -39,7 +47,7 @@ const ProjectCard: React.FC<IProjectCardProps> = (props) => {
             </Box>
             <Box width={1 / 2} px={2} mt={3}>
                 <Text as="p" color={theme.colors.grey} fontSize={[2, 3, 3]} mt={1}>
-                    {title}
+                    {name}
                 </Text>
             </Box>
             <Box width={1 / 2} px={2} mt={3}>
@@ -52,7 +60,7 @@ const ProjectCard: React.FC<IProjectCardProps> = (props) => {
             </Box>
             <Box width={1 / 2} px={2} mt={3}>
                 <Text as="p" color={theme.colors.grey} fontSize={[2, 3, 3]} mt={1}>
-                    {textBody}
+                    {description}
                 </Text>
             </Box>
             <Box width={1 / 2} px={2} mt={3}>
@@ -65,7 +73,7 @@ const ProjectCard: React.FC<IProjectCardProps> = (props) => {
             </Box>
             <Box width={1 / 2} px={2} mt={3}>
                 <Text as="p" color={theme.colors.grey} fontSize={[2, 3, 3]} mt={1}>
-                    {ministry}
+                    {ministryName}
                 </Text>
             </Box>
 

--- a/web/src/components/profileEdit/ProjectCardEdit.tsx
+++ b/web/src/components/profileEdit/ProjectCardEdit.tsx
@@ -63,7 +63,11 @@ const ProjectCardEdit: React.FC<IProjectCardEditProps> = (props) => {
             const { profile } = transformForm(formData);
 
             // 2. Request the profile project edit.
-            await api.updateProfile(projectDetails.id, profile);
+            if (projectDetails.description !== profile.description) {
+                await api.requestProfileEdit(projectDetails.id, profile);
+            } else {
+                await api.updateProfile(projectDetails.id, profile);
+            }
 
             // 3. All good? Redirect back to overview and tell the user.
             setGoBackToProfileEditable(true);

--- a/web/src/components/profileEdit/QuotaCard.tsx
+++ b/web/src/components/profileEdit/QuotaCard.tsx
@@ -16,23 +16,30 @@
 
 import React from 'react';
 import { Box, Flex, Text } from 'rebass';
+import Aux from '../../hoc/auxillary';
 import theme from '../../theme';
+import { QuotaSizeSet } from '../../types';
 
 interface IQuotaCardProps {
-    licensePlate: string;
-    quotaSize: string
-};
+    quotaDetails: QuotaDetails;
+}
+
+export interface QuotaDetails {
+    licensePlate?: string;
+    quotaSize?: string;
+    quotaOptions?: QuotaSizeSet[];
+}
 
 const QuotaCard: React.FC<IQuotaCardProps> = (props) => {
-    const { licensePlate, quotaSize } = props;
+    const { quotaDetails: { licensePlate = '', quotaSize = '' } } = props;
 
     const namespaceTexts = [['Production', 'prod'], ['Test', 'test'], ['Development', 'dev'], ['Tools', 'tools']];
     const specTexts = ['CPU', 'Memory', 'Storage'];
 
     return (
         <Flex flexWrap='wrap'>
-            {namespaceTexts.map((namespaceText: string[]) =>
-                <>
+            {namespaceTexts.map((namespaceText: string[], index: number) =>
+                <Aux key={index}>
                     <Box width={1 / 2} px={2} mt={3}>
                         <Text as="h3">{namespaceText[0]} Namespace</Text>
                         <Text as="p" color={theme.colors.grey} fontSize={[1, 2, 2]} mt={1}>
@@ -40,13 +47,13 @@ const QuotaCard: React.FC<IQuotaCardProps> = (props) => {
                         </Text>
                     </Box>
                     <Box width={1 / 2} px={2} mt={3}>
-                        {specTexts.map((specText: string) =>
-                            <Text as="p" color={theme.colors.grey} fontSize={[2, 3, 3]} mt={1}>
+                        {specTexts.map((specText: string, index: number) =>
+                            <Text key={index} as="p" color={theme.colors.grey} fontSize={[2, 3, 3]} mt={1}>
                                 {specText}: {quotaSize}
                             </Text>
                         )}
                     </Box>
-                </>
+                </Aux>
             )}
         </Flex>
     );

--- a/web/src/components/profileEdit/QuotaCard.tsx
+++ b/web/src/components/profileEdit/QuotaCard.tsx
@@ -38,8 +38,8 @@ const QuotaCard: React.FC<IQuotaCardProps> = (props) => {
 
     return (
         <Flex flexWrap='wrap'>
-            {namespaceTexts.map((namespaceText: string[], index: number) =>
-                <Aux key={index}>
+            {namespaceTexts.map((namespaceText: string[], index0: number) =>
+                <Aux key={index0}>
                     <Box width={1 / 2} px={2} mt={3}>
                         <Text as="h3">{namespaceText[0]} Namespace</Text>
                         <Text as="p" color={theme.colors.grey} fontSize={[1, 2, 2]} mt={1}>
@@ -47,8 +47,8 @@ const QuotaCard: React.FC<IQuotaCardProps> = (props) => {
                         </Text>
                     </Box>
                     <Box width={1 / 2} px={2} mt={3}>
-                        {specTexts.map((specText: string, index: number) =>
-                            <Text key={index} as="p" color={theme.colors.grey} fontSize={[2, 3, 3]} mt={1}>
+                        {specTexts.map((specText: string, index1: number) =>
+                            <Text key={index1} as="p" color={theme.colors.grey} fontSize={[2, 3, 3]} mt={1}>
                                 {specText}: {quotaSize}
                             </Text>
                         )}

--- a/web/src/components/profileEdit/QuotaCardEdit.tsx
+++ b/web/src/components/profileEdit/QuotaCardEdit.tsx
@@ -19,6 +19,7 @@ import React, { useState } from 'react';
 import { Redirect } from 'react-router-dom';
 import { Text } from 'rebass';
 import { PROFILE_EDIT_VIEW_NAMES, QUOTA_SIZES, ROUTE_PATHS } from '../../constants';
+import useCommonState from '../../hooks/useCommonState';
 import useRegistryApi from '../../hooks/useRegistryApi';
 import theme from '../../theme';
 import { CNQuotaOptions, QuotaSizeSet } from '../../types';
@@ -33,16 +34,15 @@ interface IQuotaCardEditProps {
     profileId?: string;
     quotaOptions: any[];
     cnQuotaOptionsJson: CNQuotaOptions[];
-    openBackdropCB: () => void;
-    closeBackdropCB: () => void;
     handleQuotaSubmitRefresh: any;
     isProvisioned: boolean;
 }
 
 const QuotaCardEdit: React.FC<IQuotaCardEditProps> = (props) => {
     const api = useRegistryApi();
+    const { setOpenBackdrop } = useCommonState();
 
-    const { licensePlate, quotaSize, profileId, quotaOptions, cnQuotaOptionsJson, openBackdropCB, closeBackdropCB, handleQuotaSubmitRefresh, isProvisioned } = props;
+    const { licensePlate, quotaSize, profileId, quotaOptions, cnQuotaOptionsJson, handleQuotaSubmitRefresh, isProvisioned } = props;
 
     const [goBackToProfileEditable, setGoBackToProfileEditable] = useState<boolean>(false);
     const [selectedSize, setSelectedSize] = useState('');
@@ -54,7 +54,7 @@ const QuotaCardEdit: React.FC<IQuotaCardEditProps> = (props) => {
     };
 
     const handleSubmit = async () => {
-        openBackdropCB();
+        setOpenBackdrop(true);
         try {
             if (!profileId || !quotaSize) {
                 throw new Error(`'Unable to get profile id'`);
@@ -67,14 +67,14 @@ const QuotaCardEdit: React.FC<IQuotaCardEditProps> = (props) => {
             // 2. Trigger quota request call
             await api.requestCNQuotasByProfileId(profileId, requestBody);
 
-            closeBackdropCB();
+            setOpenBackdrop(false);
             handleQuotaSubmitRefresh();
             setGoBackToProfileEditable(true);
 
             // 3.All good? Tell the user.
             promptSuccessToastWithText('Your quota request was successful');
         } catch (err) {
-            closeBackdropCB();
+            setOpenBackdrop(false);
             promptErrToastWithText('Something went wrong');
             console.log(err);
         }

--- a/web/src/components/profileEdit/QuotaCardEdit.tsx
+++ b/web/src/components/profileEdit/QuotaCardEdit.tsx
@@ -64,7 +64,7 @@ const QuotaCardEdit: React.FC<IQuotaCardEditProps> = (props) => {
             // 1. Prepare quota edit request body.
             const requestBody = composeRequestBodyForQuotaEdit(selectedSize, cnQuotaOptionsJson);
 
-            // 2. Request the profile contact edit.
+            // 2. Request the profile quota edit.
             await api.requestCNQuotasByProfileId(profileId, requestBody);
 
             // 3. All good? Redirect back to overview and tell the user.

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -37,10 +37,6 @@ export const ROLES = {
 
 export const DEFAULT_MINISTRY = 'CITZ';
 
-export const LAYOUT_SET_MIN = 'min';
-export const LAYOUT_SET_AUTH = 'auth';
-export const LAYOUT_SET_UNAUTH = 'unauth';
-
 export const COMPONENT_METADATA = [
   { displayName: 'Notification: Email', inputValue: 'notificationEmail' },
   { displayName: 'Notification: SMS', inputValue: 'notificationSms' },

--- a/web/src/contexts/commonStateContext.tsx
+++ b/web/src/contexts/commonStateContext.tsx
@@ -1,0 +1,27 @@
+//
+// Copyright © 2020 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { createContext } from 'react';
+
+export interface ICommonState {
+    setOpenBackdrop: any;
+}
+
+const CommonStateContext = createContext<ICommonState>({
+    setOpenBackdrop: () => { },
+});
+
+export default CommonStateContext;

--- a/web/src/hooks/useCommonState.tsx
+++ b/web/src/hooks/useCommonState.tsx
@@ -19,4 +19,4 @@ import CommonStateContext from '../contexts/commonStateContext';
 
 export default function useCommonState() {
     return useContext(CommonStateContext);
-};
+}

--- a/web/src/hooks/useCommonState.tsx
+++ b/web/src/hooks/useCommonState.tsx
@@ -1,0 +1,22 @@
+//
+// Copyright © 2020 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { useContext } from 'react';
+import CommonStateContext from '../contexts/commonStateContext';
+
+export default function useCommonState() {
+    return useContext(CommonStateContext);
+};

--- a/web/src/layouts/Layout.tsx
+++ b/web/src/layouts/Layout.tsx
@@ -15,14 +15,14 @@
 //
 
 import styled from '@emotion/styled';
-import React from 'react';
+import React, { useState } from 'react';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import Footer from '../components/common/layout/Footer';
 import Header from '../components/common/layout/Header';
 import { BackdropForProcessing } from '../components/common/UI/Backdrop';
+import CommonStateContext from '../contexts/commonStateContext';
 import theme from '../theme';
-import { LayoutSet } from '../types';
 
 // this is to set min width in windows resizing
 const StyledDiv = styled.div`
@@ -43,38 +43,38 @@ const StyledMain = styled.main`
 
 interface ILayoutProps {
   children: React.ReactNode;
-  name: LayoutSet;
 }
 
-const Layout: React.FC<ILayoutProps> = props => {
-  const { children, name } = props;
+export const AuthLayout: React.FC<ILayoutProps> = props => {
+  const { children } = props;
 
-  const [openBackdrop, setOpenBackdrop] = React.useState(false);
-
-  const openBackdropCB = () => {
-    setOpenBackdrop(true);
-  };
-
-  const closeBackdropCB = () => {
-    setOpenBackdrop(false);
-  };
+  const [openBackdrop, setOpenBackdrop] = useState(false);
 
   return (
     <StyledDiv>
       <ToastContainer style={{ width: "500px" }} />
       {openBackdrop && (<BackdropForProcessing />)}
-      <Header name={name} />
-      <StyledMain>
-        {React.Children.map(children, (child: any) => {
-          return React.cloneElement(child, {
-            closeBackdropCB: closeBackdropCB,
-            openBackdropCB: openBackdropCB
-          });
-        })}
-      </StyledMain>
+      <Header auth />
+      <CommonStateContext.Provider value={{ setOpenBackdrop }}>
+        <StyledMain>
+          {children}
+        </StyledMain>
+      </CommonStateContext.Provider>
       <Footer />
     </StyledDiv>
   );
 };
 
-export default Layout;
+export const PublicLayout: React.FC<ILayoutProps> = props => {
+  const { children } = props;
+
+  return (
+    <StyledDiv>
+      <Header />
+      <StyledMain>
+        {children}
+      </StyledMain>
+      <Footer />
+    </StyledDiv>
+  );
+};

--- a/web/src/types.tsx
+++ b/web/src/types.tsx
@@ -20,11 +20,6 @@ export type ColorSet
   = 'contrast'
   | 'primary'
 
-export type LayoutSet
-  = 'unauth'
-  | 'auth'
-  | 'min'
-
 export interface MenuItem {
   title: string;
   subTitle: string;

--- a/web/src/utils/AppRoute.tsx
+++ b/web/src/utils/AppRoute.tsx
@@ -14,23 +14,23 @@
 // limitations under the License.
 //
 
+import { useKeycloak } from '@react-keycloak/web';
 import React from 'react';
 import { Route, RouteProps } from 'react-router-dom';
-import { LAYOUT_SET_AUTH } from '../constants';
-import { LayoutSet } from '../types';
 import PrivateRoute from './PrivateRoute';
 
 interface IAppRouteProps extends RouteProps {
   component: React.ComponentType<any>;
   layout: React.ComponentType<any>;
-  layoutName: LayoutSet;
   checkQueryParams?: (props: any) => boolean;
 };
 
 const AppRoute: React.FC<IAppRouteProps> = (props) => {
-  let { component: Component, layout: Layout, layoutName, checkQueryParams, ...rest } = props;
+  let { component: Component, layout: Layout, checkQueryParams, ...rest } = props;
 
-  const usePrivateRoute: boolean = (layoutName === LAYOUT_SET_AUTH);
+  const { keycloak } = useKeycloak();
+
+  const usePrivateRoute: boolean = !!(keycloak && keycloak.authenticated);
 
   if (usePrivateRoute) {
     return <PrivateRoute component={Component} layout={Layout} {...rest} checkQueryParams={checkQueryParams} />;
@@ -39,7 +39,7 @@ const AppRoute: React.FC<IAppRouteProps> = (props) => {
       <Route
         {...rest}
         render={(props) => (
-          <Layout name={layoutName} >
+          <Layout>
             <Component {...props} />
           </Layout>
         )}
@@ -49,4 +49,3 @@ const AppRoute: React.FC<IAppRouteProps> = (props) => {
 };
 
 export default AppRoute;
-

--- a/web/src/utils/PrivateRoute.tsx
+++ b/web/src/utils/PrivateRoute.tsx
@@ -17,7 +17,7 @@
 import { useKeycloak } from '@react-keycloak/web';
 import React from 'react';
 import { Redirect, Route, RouteProps, useLocation } from 'react-router-dom';
-import { LAYOUT_SET_AUTH, ROUTE_PATHS } from '../constants';
+import { ROUTE_PATHS } from '../constants';
 
 interface IPrivateRouteProps extends RouteProps {
   component: React.ComponentType<any>;
@@ -45,14 +45,14 @@ const PrivateRoute: React.FC<IPrivateRouteProps> = (props) => {
         }
         if (!!keycloak.authenticated) {
           return (
-            <Layout name={LAYOUT_SET_AUTH} {...rest}>
+            <Layout {...rest}>
               <Component {...props} {...rest.componentProps} />
             </Layout>
           );
         } else {
-          if (props.location.pathname !== '/public-landing') {
+          if (props.location.pathname !== ROUTE_PATHS.LANDING) {
             const redirectTo = encodeURI(`${location.pathname}${location.search}`);
-            return <Redirect to={`/public-landing?redirect=${redirectTo}`} />;
+            return <Redirect to={`${ROUTE_PATHS.LANDING}?redirect=${redirectTo}`} />;
           }
         }
       }}

--- a/web/src/utils/getProfileStatus.tsx
+++ b/web/src/utils/getProfileStatus.tsx
@@ -14,13 +14,13 @@
 // limitations under the License.
 //
 
-
 export default function getProfileStatus() {
-    const getPendingEditRequest = async (api: any, profileId: string): Promise<any> => {
+    const hasPendingEditRequest = async (api: any, profileId: string): Promise<any> => {
         const editRequest = await api.getEditRequestStatus(profileId);
         return !(editRequest.data.length === 0);
-    }
+    };
+
     return {
-        getPendingEditRequest
-    }
-};
+        hasPendingEditRequest,
+    };
+}

--- a/web/src/utils/transformDataHelper.tsx
+++ b/web/src/utils/transformDataHelper.tsx
@@ -166,10 +166,10 @@ export function transformJsonToCsv(objArray: any) {
   return str;
 };
 
-export function getProfileMinistry(ministrySet: any[], profileDetails: any): object {
+export function getProfileMinistry(ministrySet: any[], projectDetails: any): object {
   let ministryDetails: any = {};
   ministrySet.forEach((ministry: any) => {
-    if (ministry.id === profileDetails.busOrgId) {
+    if (ministry.id === projectDetails.busOrgId) {
       ministryDetails.ministryName = ministry.name;
     }
   });

--- a/web/src/views/Dashboard.tsx
+++ b/web/src/views/Dashboard.tsx
@@ -23,28 +23,23 @@ import { Button } from '../components/common/UI/Button';
 import { ShadowBox } from '../components/common/UI/ShadowContainer';
 import ProfileCard from '../components/dashboard/ProfileCard';
 import { COMPONENT_METADATA, CSV_PROFILE_ATTRIBUTES } from '../constants';
+import useCommonState from '../hooks/useCommonState';
 import useInterval from '../hooks/useInterval';
 import useRegistryApi from '../hooks/useRegistryApi';
 import theme from '../theme';
 import { promptErrToastWithText } from '../utils/promptToastHelper';
 import { getProfileContacts, isProfileProvisioned, sortProfileByDatetime, transformJsonToCsv } from '../utils/transformDataHelper';
 
-interface IDashboardProps {
-  openBackdropCB: () => void;
-  closeBackdropCB: () => void;
-};
-
-const Dashboard: React.FC<IDashboardProps> = (props) => {
-  const { openBackdropCB, closeBackdropCB } = props;
-
+const Dashboard: React.FC = () => {
   const api = useRegistryApi();
   const { keycloak } = useKeycloak();
+  const { setOpenBackdrop } = useCommonState();
 
   const [profile, setProfile] = useState<any>([]);
 
   useEffect(() => {
     async function wrap() {
-      openBackdropCB();
+      setOpenBackdrop(true);
       try {
         // 1. First fetch the list of profiles the user is entitled to see
         const response = await api.getProfile();
@@ -72,7 +67,7 @@ const Dashboard: React.FC<IDashboardProps> = (props) => {
         promptErrToastWithText('Something went wrong');
         console.log(err);
       }
-      closeBackdropCB();
+      setOpenBackdrop(false);
     }
     wrap();
     // eslint-disable-next-line
@@ -94,7 +89,7 @@ const Dashboard: React.FC<IDashboardProps> = (props) => {
   }, 1000 * 30);
 
   const downloadCSV = () => {
-    openBackdropCB();
+    setOpenBackdrop(true);
     try {
       const metadataAttributes: Array<string> = [];
       COMPONENT_METADATA.forEach(m => {
@@ -114,7 +109,7 @@ const Dashboard: React.FC<IDashboardProps> = (props) => {
       promptErrToastWithText('Something went wrong');
       console.log(err);
     }
-    closeBackdropCB();
+    setOpenBackdrop(false);
   };
 
   return (

--- a/web/src/views/ProfileCreate.tsx
+++ b/web/src/views/ProfileCreate.tsx
@@ -37,8 +37,8 @@ const ProfileCreate: React.FC = () => {
     const api = useRegistryApi();
     const { keycloak } = useKeycloak();
     const { setOpenBackdrop } = useCommonState();
-    const [ministry, setMinistry] = useState<any>([]);
 
+    const [ministry, setMinistry] = useState<any>([]);
     const [goBackToDashboard, setGoBackToDashboard] = useState(false);
 
     const onSubmit = async (formData: any) => {

--- a/web/src/views/ProfileCreate.tsx
+++ b/web/src/views/ProfileCreate.tsx
@@ -24,6 +24,7 @@ import CreateFormPO from '../components/profileCreate/CreateFormPO';
 import CreateFormProject from '../components/profileCreate/CreateFormProject';
 import CreateFormTC from '../components/profileCreate/CreateFormTC';
 import { ROUTE_PATHS } from '../constants';
+import useCommonState from '../hooks/useCommonState';
 import useRegistryApi from '../hooks/useRegistryApi';
 import { promptErrToastWithText, promptSuccessToastWithText } from '../utils/promptToastHelper';
 import { transformForm } from '../utils/transformDataHelper';
@@ -32,16 +33,10 @@ const txtForPO = `Tell us about the Product Owner (PO). This is typically the bu
 const txtForPO2 = `Although not required, we strongly recommend the requestor be the product owner so that this record appears on their dashboard when logging on to the registry; only the requestor will be able to edit this project in the future.`;
 const txtForTC = `Tell us about the Technical Contact (TC). This is typically the DevOps specialist; we will use this information to contact them with technical questions or notify them about platform events.`;
 
-interface IProfileCreateProps {
-    openBackdropCB: () => void;
-    closeBackdropCB: () => void;
-};
-
-const ProfileCreate: React.FC<IProfileCreateProps> = (props: any) => {
+const ProfileCreate: React.FC = () => {
     const api = useRegistryApi();
     const { keycloak } = useKeycloak();
-
-    const { openBackdropCB, closeBackdropCB } = props;
+    const { setOpenBackdrop } = useCommonState();
     const [ministry, setMinistry] = useState<any>([]);
 
     const [goBackToDashboard, setGoBackToDashboard] = useState(false);
@@ -54,7 +49,7 @@ const ProfileCreate: React.FC<IProfileCreateProps> = (props: any) => {
             alert("You need to select a Ministry Sponsor.");
             return;
         }
-        openBackdropCB();
+        setOpenBackdrop(true);
         try {
             // 1. Create the project profile.
             const response: any = await api.createProfile(profile);
@@ -71,12 +66,12 @@ const ProfileCreate: React.FC<IProfileCreateProps> = (props: any) => {
             // 4. Trigger provisioning
             await api.createNamespaceByProfileId(profileId);
 
-            closeBackdropCB();
+            setOpenBackdrop(false);
             setGoBackToDashboard(true);
             // 5.All good? Tell the user.
             promptSuccessToastWithText('Your namespace request was successful');
         } catch (err) {
-            closeBackdropCB();
+            setOpenBackdrop(false);
             const msg = `Unable to submit request at this time, reason = ${err.message}`;
             promptErrToastWithText(msg);
             console.log(err);

--- a/web/src/views/ProfileEdit.tsx
+++ b/web/src/views/ProfileEdit.tsx
@@ -27,6 +27,7 @@ import ProjectCardEdit from '../components/profileEdit/ProjectCardEdit';
 import QuotaCard from '../components/profileEdit/QuotaCard';
 import QuotaCardEdit from '../components/profileEdit/QuotaCardEdit';
 import { PROFILE_EDIT_VIEW_NAMES, RESPONSE_STATUS_CODE, ROUTE_PATHS } from '../constants';
+import useCommonState from '../hooks/useCommonState';
 import useInterval from '../hooks/useInterval';
 import useRegistryApi from '../hooks/useRegistryApi';
 import theme from '../theme';
@@ -34,21 +35,17 @@ import { CNQuotaOptions, Namespace, QuotaSizeSet } from '../types';
 import getProfileStatus from '../utils/getProfileStatus';
 import { promptErrToastWithText } from '../utils/promptToastHelper';
 import { getCurrentQuotaOptions, getCurrentQuotaSize, getLicensePlate, getProfileContacts, getProfileMinistry, isProfileProvisioned } from '../utils/transformDataHelper';
+
 const txtForQuotaEdit = `All quota increase requests require Platform Services Team's approval. Please contact the Platform Admins (@cailey.jones, @patrick.simonian or @shelly.han) in RocketChat BEFORE submitting the request to provide justification for the increased need of Platform resources (i.e. historic data showing increased CPU/RAM consumption).`;
 
-interface IProfileEditProps {
-    openBackdropCB: () => void;
-    closeBackdropCB: () => void;
-};
+const ProfileEdit: React.FC = (props: any) => {
+    // @ts-ignore
+    const { match: { params: { profileId, viewName } }, } = props;
 
-const ProfileEdit: React.FC<IProfileEditProps> = (props) => {
     const api = useRegistryApi();
     const { keycloak } = useKeycloak();
-
+    const { setOpenBackdrop } = useCommonState();
     const profileStatus = getProfileStatus();
-
-    // @ts-ignore
-    const { match: { params: { profileId, viewName } }, openBackdropCB, closeBackdropCB } = props;
 
     const [initialRender, setInitialRender] = useState(true);
     const [unauthorizedToAccess, setUnauthorizedToAccess] = useState(false);
@@ -73,7 +70,7 @@ const ProfileEdit: React.FC<IProfileEditProps> = (props) => {
 
     useEffect(() => {
         async function wrap() {
-            openBackdropCB();
+            setOpenBackdrop(true);
             try {
                 const profileDetails = await api.getProfileByProfileId(profileId);
                 const ministryDetails = await api.getMinistry();
@@ -109,7 +106,7 @@ const ProfileEdit: React.FC<IProfileEditProps> = (props) => {
                 }
             }
             setInitialRender(false);
-            closeBackdropCB();
+            setOpenBackdrop(false);
         }
         wrap();
         // eslint-disable-next-line
@@ -229,8 +226,6 @@ const ProfileEdit: React.FC<IProfileEditProps> = (props) => {
                                     isProvisioned={provisionedStatus}
                                     pendingEditRequest={pendingEditRequest}
                                     setPendingEditRequest={setPendingEditRequest}
-                                    openBackdropCB={openBackdropCB}
-                                    closeBackdropCB={closeBackdropCB}
                                 />
                             }
                             {(viewName === PROFILE_EDIT_VIEW_NAMES.CONTACT) &&
@@ -240,8 +235,6 @@ const ProfileEdit: React.FC<IProfileEditProps> = (props) => {
                                     pendingEditRequest={pendingEditRequest}
                                     isProvisioned={provisionedStatus}
                                     setPendingEditRequest={setPendingEditRequest}
-                                    openBackdropCB={openBackdropCB}
-                                    closeBackdropCB={closeBackdropCB}
                                 />
                             }
                             {(viewName === PROFILE_EDIT_VIEW_NAMES.QUOTA) &&
@@ -251,8 +244,6 @@ const ProfileEdit: React.FC<IProfileEditProps> = (props) => {
                                     profileId={profileId}
                                     quotaOptions={quotaOptions}
                                     cnQuotaOptionsJson={cnQuotaOptionsJson}
-                                    openBackdropCB={openBackdropCB}
-                                    closeBackdropCB={closeBackdropCB}
                                     handleQuotaSubmitRefresh={handleQuotaSubmitRefresh}
                                     isProvisioned={isProvisioned}
                                 />

--- a/web/src/views/ProfileEdit.tsx
+++ b/web/src/views/ProfileEdit.tsx
@@ -40,7 +40,7 @@ const txtForQuotaEdit = `All quota increase requests require Platform Services T
 
 const ProfileEdit: React.FC = (props: any) => {
     // @ts-ignore
-    const { match: { params: { profileId, viewName } }, } = props;
+    const { match: { params: { profileId, viewName } } } = props;
 
     const api = useRegistryApi();
     const { keycloak } = useKeycloak();

--- a/web/src/views/ProfileEdit.tsx
+++ b/web/src/views/ProfileEdit.tsx
@@ -98,8 +98,8 @@ const ProfileEdit: React.FC = (props: any) => {
         // @ts-ignore
         const quotaOptions = getCurrentQuotaOptions(cnQuotaOptions.data, quotaSize);
 
-        setProfileState((profileState: any) => ({
-            ...profileState,
+        setProfileState((profileState0: any) => ({
+            ...profileState0,
             baseData: {
                 namespacesJson: namespaces.data,
                 ministryJson: ministry.data,
@@ -180,8 +180,8 @@ const ProfileEdit: React.FC = (props: any) => {
                     <Text as="h1">
                         {profileState.projectDetails.name}
                     </Text>
-                    {(cards.length > 0) && cards.map((c: any) => (
-                        <Box>
+                    {(cards.length > 0) && cards.map((c: any, index: number) => (
+                        <Box key={index}>
                             <Flex p={3} mt={4} bg={theme.colors.bcblue} style={{ position: 'relative' }}>
                                 <Text as="h3" color={theme.colors.contrast} mx={2} >
                                     {c.title}


### PR DESCRIPTION
- [x] cleanup around auth state-related props on Layout, AppRoute, PrivateRoute
- [x] add context and hook so backdrop (when data are being processed in the background) state can be reached across components
- [x] cleanup around ProfileEdit

Fixes #276 

Due to refactor volume:
/bot-ignore-length