### PR TITLE
Update flyway docker build

### DIFF
--- a/db/flyway.Dockerfile
+++ b/db/flyway.Dockerfile
@@ -1,6 +1,6 @@
-FROM openjdk:12-alpine
+FROM adoptopenjdk/openjdk11:alpine-jre
 
-RUN apk --no-cache add --update bash=4.4.19-r1 openssl=1.1.1g-r0
+RUN apk --no-cache add --update bash openssl
 
 # Add the flyway user and step in the directory
 RUN addgroup flyway \
@@ -10,7 +10,7 @@ WORKDIR /flyway
 # Change to the flyway user
 USER flyway
 
-ENV FLYWAY_VERSION 7.4.0
+ENV FLYWAY_VERSION 7.5.3
 
 RUN wget https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz \
   && tar -xzf flyway-commandline-${FLYWAY_VERSION}.tar.gz \
@@ -18,7 +18,6 @@ RUN wget https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY
   && rm flyway-commandline-${FLYWAY_VERSION}.tar.gz
 
 ENV PATH="/flyway:${PATH}"
-
 COPY sql/*.sql /flyway/sql/
 
 RUN chmod -R 777 .


### PR DESCRIPTION
The pre-hook pod container fails to start with flyway v 7.4.0. Upgrading the version seems to have resolved this issue.