### PR TITLE
Update updateProjectProfile to include migratingLicenseplate

### DIFF
--- a/api/src/controllers/project-profile.ts
+++ b/api/src/controllers/project-profile.ts
@@ -165,6 +165,7 @@ export const updateProjectProfile = async (
     idmKeycloak,
     idmActiveDir,
     other,
+    migratingLicenseplate,
   } = body;
 
   try {
@@ -192,6 +193,7 @@ export const updateProjectProfile = async (
       idmActiveDir,
       other,
       primaryClusterName: currentProjectDetails.primaryClusterName,
+      migratingLicenseplate,
     };
 
     const isAuthorized = getAuthorization(profileId, user, currentProjectDetails);


### PR DESCRIPTION
This is a fix that enables users to update the migrating application licenseplate information from the project edit page.