### PR TITLE
Disable Project Name input field

### DIFF
--- a/web/src/components/profileEdit/ProjectCardEdit.tsx
+++ b/web/src/components/profileEdit/ProjectCardEdit.tsx
@@ -116,6 +116,7 @@ const ProjectCardEdit: React.FC<IProjectCardEditProps> = (props) => {
               validate={validator.mustBeValidProfileName}
               defaultValue=""
               initialValue={projectDetails.name}
+              disabled
             />
           </Flex>
           <Flex flexDirection="column">


### PR DESCRIPTION
This PR was necessary to disable the project name field within the edit capability﻿
