### PR TITLE
Add ocp3 migration status to csv extract

### DIFF
--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -59,6 +59,8 @@ export const CSV_PROFILE_ATTRIBUTES = [
   'description',
   'busOrgId',
   'prioritySystem',
+  'migratingLicenseplate',
+  'namespacePrefix',
   'quotaSize',
   'createdAt',
   'updatedAt',


### PR DESCRIPTION
This is to add the following additional attributes to the csv extract:
- ocp3 migration status
- license plate

Fixes #325