### PR TITLE
Move project approvals to Dashboard

### DIFF
--- a/api/src/controllers/namespace.ts
+++ b/api/src/controllers/namespace.ts
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Created by Jason Leach on 2020-04-27.
-//
 
 'use strict';
 

--- a/api/src/controllers/request.ts
+++ b/api/src/controllers/request.ts
@@ -1,0 +1,50 @@
+//
+// Copyright © 2020 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+import { errorWithCode, logger } from '@bcgov/common-nodejs-utils';
+import { Response } from 'express';
+import DataManager from '../db';
+import { RequestType } from '../db/model/request';
+import { AuthenticatedUser } from '../libs/authmware';
+import shared from '../libs/shared';
+
+const dm = new DataManager(shared.pgPool);
+
+export const requestProjectProfileUpdate = async (
+  { params, body, user }: { params: any, body: any, user: AuthenticatedUser }, res: Response
+): Promise<void> => {
+  const { RequestModel } = dm;
+  const { profileId } = params;
+
+  try {
+    // create Request record for project-profile edit
+    await RequestModel.create({
+      profileId,
+      type: RequestType.Create,
+      requiresHumanAction: true,
+      isActive: true,
+      userId: user.id,
+    });
+
+    res.status(204).end();
+  } catch (err) {
+    const message = `Unable to update profile`;
+    logger.error(`${message}, err = ${err.message}`);
+
+    throw errorWithCode(message, 500);
+  }
+};

--- a/api/src/controllers/sync.ts
+++ b/api/src/controllers/sync.ts
@@ -118,11 +118,11 @@ export const getProfileBotJsonUnderPending = async (
     // if the queried profile is under pending edit
     if (requests.length > 0) {
       const request = requests.pop();
-      if (!request || !request.natsContext) {
-        const errmsg = `No nats context retrieved for request ${request?.id}`;
+      if (!request || !request.editObject) {
+        const errmsg = `No edit object retrieved for request ${request?.id}`;
         throw new Error(errmsg);
       }
-      context = JSON.parse(request.natsContext);
+      context = JSON.parse(request.editObject);
     } else {
       // if the queried profile is under pending create
       context = await contextForProvisioning(profileId, FulfillmentContextAction.Create);
@@ -142,7 +142,7 @@ const getIdsForProfilesUnderPendingEditOrCreate = async (): Promise<number[]> =>
   const { RequestModel, ProfileModel } = dm;
   try {
     // process those profiles that are under pending EDIT
-    const requests = await RequestModel.findAll();
+    const requests = await RequestModel.findAllActive();
     const profileIds = requests.map((request: Request) => request.profileId);
 
     // process those profiles that are under pending CREATE

--- a/api/src/db/model/model.ts
+++ b/api/src/db/model/model.ts
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Created by Jason Leach on 2020-04-28.
-//
+
 
 import { logger } from '@bcgov/common-nodejs-utils';
 import { Pool } from 'pg';
@@ -36,9 +35,9 @@ export abstract class Model {
   abstract requiredFields: string[];
   abstract pool: Pool;
 
-  abstract async create(data: any): Promise<any>;
-  abstract async update(profileId: number, data: any): Promise<any>;
-  abstract async delete(profileId: number): Promise<any>;
+  abstract create(data: any): Promise<any>;
+  abstract update(profileId: number, data: any): Promise<any>;
+  abstract delete(profileId: number): Promise<any>;
 
   async findAll(): Promise<any[]> {
     const query = {

--- a/api/src/db/model/namespace.ts
+++ b/api/src/db/model/namespace.ts
@@ -21,8 +21,6 @@ import { projectSetNames } from '../../constants';
 import { CommonFields, Model } from './model';
 import { QuotaSize } from './quota';
 
-// TODO:(yh) make quota_cpu_size, quota_memory_size, quota_storage_size NOT NULL
-// and to delete quota_cpu, quota_memory and quota_storage from ref_quota table
 export interface ClusterNamespace extends CommonFields {
   namespaceId: number;
   clusterId: number;

--- a/api/src/db/model/profile.ts
+++ b/api/src/db/model/profile.ts
@@ -19,7 +19,6 @@ import { logger } from '@bcgov/common-nodejs-utils';
 import { Pool } from 'pg';
 import { CommonFields, Model } from './model';
 
-// TODO:(yh) make primary_cluster_name from profile table NOT NULL
 export interface ProjectProfile extends CommonFields {
   name: string;
   description: string;

--- a/api/src/db/model/request.ts
+++ b/api/src/db/model/request.ts
@@ -16,6 +16,11 @@ import { logger } from '@bcgov/common-nodejs-utils';
 import { Pool } from 'pg';
 import { CommonFields, Model } from './model';
 
+export const enum RequestType {
+    Create = 'create',
+    Edit = 'edit',
+}
+
 // TODO: change value 'description' to 'project profile'
 export const enum RequestEditType {
     Contacts = 'contacts',
@@ -30,16 +35,26 @@ export enum RequestEditContacts {
 
 export interface Request extends CommonFields {
     profileId: number;
-    editType: RequestEditType;
-    editObject: string;
-    natsSubject?: string;
-    natsContext?: string;
+    editType?: RequestEditType;
+    editObject?: string;
+    type: RequestType;
+    requiresHumanAction: boolean;
+    isActive: boolean;
+    userId: number;
+}
+
+export interface BotMessage extends CommonFields {
+    requestId: number;
+    natsSubject: string;
+    natsContext: string;
+    clusterName: string;
+    receivedCallback: boolean;
 }
 
 export default class RequestModel extends Model {
     table: string = 'request';
     requiredFields: string[] = [
-        'profileId', 'editType', 'editObject',
+        'profileId', 'type', 'requires_human_action', 'is_active', 'user_id',
     ];
     pool: Pool;
 
@@ -51,14 +66,16 @@ export default class RequestModel extends Model {
     async create(data: Request): Promise<Request> {
         const query = {
             text: `INSERT INTO ${this.table}
-            (profile_id, edit_type, edit_object, nats_subject, nats_context)
-            VALUES ($1, $2, $3, $4, $5) RETURNING *;`,
+            (profile_id, edit_type, edit_object, type, requires_human_action, is_active, user_id)
+            VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *;`,
             values: [
                 data.profileId,
                 data.editType,
                 data.editObject,
-                data.natsSubject,
-                data.natsContext,
+                data.type,
+                data.requiresHumanAction,
+                data.isActive,
+                data.userId,
             ],
         };
 
@@ -78,7 +95,7 @@ export default class RequestModel extends Model {
         const query = {
             text: `UPDATE ${this.table}
             SET
-            profile_id = $1, edit_type = $2, edit_object = $3, nats_subject = $4, nats_context = $5
+            profile_id = $1, edit_type = $2, edit_object = $3, type = $4, requires_human_action = $5,is_active = $6, user_id = $7
             WHERE id = ${requestId}
             RETURNING *;`,
             values,
@@ -91,8 +108,10 @@ export default class RequestModel extends Model {
                 aData.profileId,
                 aData.editType,
                 aData.editObject,
-                aData.natsSubject,
-                aData.natsContext,
+                aData.type,
+                aData.requiresHumanAction,
+                aData.isActive,
+                aData.userId,
             ];
 
             const results = await this.runQuery(query);
@@ -130,7 +149,7 @@ export default class RequestModel extends Model {
         const query = {
             text: `
                 SELECT * FROM ${this.table}
-                    WHERE profile_id = ${profileId} AND archived = false;
+                    WHERE profile_id = ${profileId} AND is_active = true AND archived = false;
             `,
         };
 
@@ -138,6 +157,121 @@ export default class RequestModel extends Model {
             return await this.runQuery(query);
         } catch (err) {
             const message = `Unable to fetch Request(s) with Profile Id ${profileId}`;
+            logger.error(`${message}, err = ${err.message}`);
+
+            throw err;
+        }
+    }
+
+    async findAllActive(): Promise<Request[]> {
+        const query = {
+            text: `
+                SELECT * FROM ${this.table}
+                    is_active = true AND archived = false;
+            `,
+        };
+
+        try {
+            return await this.runQuery(query);
+        } catch (err) {
+            const message = `Unable to fetch all active Request(s)`;
+            logger.error(`${message}, err = ${err.message}`);
+
+            throw err;
+        }
+    }
+
+    async isComplete(requestId: number): Promise<Request> {
+        const query = {
+            text: `UPDATE ${this.table}
+            SET
+            is_active = false
+            WHERE id = ${requestId}
+            RETURNING *;
+        `,
+        };
+
+        try {
+            const results = await this.runQuery(query);
+            return results.pop();
+        } catch (err) {
+            const message = `Unable to complete request`;
+            logger.error(`${message}, err = ${err.message}`);
+
+            throw err;
+        }
+    }
+
+    async createBotMessage(data: BotMessage): Promise<BotMessage> {
+        const query = {
+            text: `INSERT INTO bot_message
+            (request_id, nats_subject, nats_context, cluster_name, received_callback)
+            VALUES ($1, $2, $3, $4, $5) RETURNING *;`,
+            values: [
+                data.requestId,
+                data.natsSubject,
+                data.natsContext,
+                data.clusterName,
+                data.receivedCallback,
+            ],
+        };
+
+        try {
+            const results = await this.runQuery(query);
+            return results.pop();
+        } catch (err) {
+            const message = `Unable to create request`;
+            logger.error(`${message}, err = ${err.message}`);
+
+            throw err;
+        }
+    }
+
+
+    async updateCallbackStatus(botMessageId: number): Promise<BotMessage> {
+        const values: any[] = [];
+        const query = {
+            text: `UPDATE bot_message
+            SET
+            request_id = $1, nats_subject = $2, nats_context = $3, cluster_name = $4, received_callback = $5
+            WHERE id = ${botMessageId}
+            RETURNING *;`,
+            values,
+        };
+
+        try {
+            const record = await this.findById(botMessageId);
+            const aData = { ...record};
+            query.values = [
+                aData.requestId,
+                aData.natsSubject,
+                aData.natsContext,
+                aData.clusterName,
+                aData.receivedCallback ? aData.receivedCallback : true,
+            ];
+
+            const results = await this.runQuery(query);
+            return results.pop();
+        } catch (err) {
+            const message = `Unable to update request ID ${botMessageId}`;
+            logger.error(`${message}, err = ${err.message}`);
+
+            throw err;
+        }
+    }
+
+    async findForRequest(requestId: number): Promise<BotMessage[]> {
+        const query = {
+            text: `
+                SELECT * FROM bot_message
+                    WHERE request_id = ${requestId} AND received_callback = false AND archived = false;
+            `,
+        };
+
+        try {
+            return await this.runQuery(query);
+        } catch (err) {
+            const message = `Unable to fetch Request(s) with Request Id ${requestId}`;
             logger.error(`${message}, err = ${err.message}`);
 
             throw err;

--- a/api/src/libs/bot-message.ts
+++ b/api/src/libs/bot-message.ts
@@ -1,0 +1,89 @@
+//
+// Copyright © 2020 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+'use strict';
+
+import { logger } from '@bcgov/common-nodejs-utils';
+import config from '../config';
+import DataManager from '../db';
+import { BotMessage, Request, RequestEditContacts, RequestEditType } from '../db/model/request';
+import { contextForProvisioning, FulfillmentContextAction } from './fulfillment';
+import shared from './shared';
+
+const dm = new DataManager(shared.pgPool);
+const { RequestModel } = dm;
+
+export const createBotMessageSet = async ( profileId: number, request: Request ): Promise<any> => {
+  if (!profileId) {
+      throw new Error('Cant get profile id');
+  }
+
+  const natsSubject = config.get('nats:subject');
+  const natsContext = await createNatsContext(profileId, String(request.editType), request.editObject);
+  const clusters = natsContext.namespaces[0].clusters;
+
+  const promises: any = [];
+  clusters.forEach(cluster => {
+    // create Bot Message record for each cluster project-profile edit
+    promises.push(RequestModel.createBotMessage({
+      requestId: Number(request.id),
+      natsSubject,
+      natsContext,
+      clusterName: cluster.name,
+      receivedCallback: false,
+    }));
+  })
+
+  await Promise.all(promises);
+};
+
+const createNatsContext = async ( profileId: number, requestType: string, requestEditObject: any ): Promise<any> => {
+  const context = await contextForProvisioning(profileId, FulfillmentContextAction.Edit);
+
+  if (!context) {
+    const errmsg = `No context for ${profileId}`;
+    throw new Error(errmsg);
+  }
+
+  switch (requestType) {
+    case RequestEditType.QuotaSize:
+      context.quota = requestEditObject.quota;
+      context.quotas = requestEditObject.quotas;
+      break;
+    case RequestEditType.Contacts:
+      Object.values(RequestEditContacts).forEach(contact => {
+        context[contact] = requestEditObject[contact];
+      });
+      break;
+    case RequestEditType.ProjectProfile:
+      context.description = requestEditObject.description;
+      break;
+    default:
+      const errmsg = `Invalid edit type for request ${requestType}`;
+      throw new Error(errmsg);
+  }
+}
+
+export const fetchBotMessageRequests = async (requestId: number): Promise<BotMessage[]> => {
+  try {
+      return await RequestModel.findForRequest(requestId);
+  } catch (err) {
+      const message = `Unable to fetch existing bot message requests for request ${requestId}`;
+      logger.error(`${message}, err = ${err.message}`);
+
+      throw err;
+  }
+};

--- a/db/sql/V2.1__multi_cluster.sql
+++ b/db/sql/V2.1__multi_cluster.sql
@@ -1,0 +1,16 @@
+BEGIN TRANSACTION;
+
+ALTER TABLE profile ALTER COLUMN primary_cluster_name SET NOT NULL;
+
+ALTER TABLE cluster_namespace
+ALTER COLUMN quota_cpu_size SET NOT NULL,
+ALTER COLUMN quota_memory_size SET NOT NULL,
+ALTER COLUMN quota_storage_size SET NOT NULL,
+DROP COLUMN IF EXISTS quota_cpu,
+DROP COLUMN IF EXISTS quota_memory,
+DROP COLUMN IF EXISTS quota_storage;
+
+ALTER TABLE ref_cluster ADD COLUMN IF NOT EXISTS is_prod BOOLEAN NOT NULL DEFAULT true;
+UPDATE ref_cluster SET is_prod = false WHERE name = 'clab' OR name = 'klab';
+
+END TRANSACTION;

--- a/db/sql/V2.2__dashboard_approval_auto_merge.sql
+++ b/db/sql/V2.2__dashboard_approval_auto_merge.sql
@@ -1,0 +1,47 @@
+BEGIN TRANSACTION;
+
+CREATE TYPE request_type AS ENUM ('create', 'edit');
+
+ALTER TABLE request
+ALTER COLUMN edit_type DROP NOT NULL,
+ADD COLUMN IF NOT EXISTS type request_type,
+ADD COLUMN IF NOT EXISTS requires_human_action BOOLEAN,
+ADD COLUMN IF NOT EXISTS is_active BOOLEAN DEFAULT true,
+ADD COLUMN IF NOT EXISTS user_id INTEGER REFERENCES user_profile(id);
+
+CREATE TYPE action_type AS ENUM ('comment_only', 'reject', 'approve');
+
+CREATE TABLE IF NOT EXISTS human_action (
+    id               SERIAL PRIMARY KEY,
+    request_id       INTEGER REFERENCES request(id) NOT NULL,
+    type             action_type NOT NULL,
+    comment          VARCHAR(512),
+    user_id          INTEGER REFERENCES user_profile(id) NOT NULL,
+    archived         BOOLEAN NOT NULL DEFAULT false,
+    created_at       timestamp DEFAULT CURRENT_TIMESTAMP(3),
+    updated_at       timestamp DEFAULT CURRENT_TIMESTAMP(3)
+);
+
+DROP TRIGGER IF EXISTS update_human_action_changetimestamp on human_action;
+CREATE TRIGGER update_human_action_changetimestamp BEFORE UPDATE
+ON human_action FOR EACH ROW EXECUTE PROCEDURE 
+update_changetimestamp_column();
+
+CREATE TABLE IF NOT EXISTS bot_message (
+    id                  SERIAL PRIMARY KEY,
+    request_id          INTEGER REFERENCES request(id) NOT NULL,
+    nats_subject        VARCHAR(512) NOT NULL,
+    nats_context        VARCHAR(4096) NOT NULL,
+    cluster_name        VARCHAR(32) REFERENCES ref_cluster(name) NOT NULL,
+    received_callback   BOOLEAN NOT NULL DEFAULT false,
+    archived            BOOLEAN NOT NULL DEFAULT false,
+    created_at          timestamp DEFAULT CURRENT_TIMESTAMP(3),
+    updated_at          timestamp DEFAULT CURRENT_TIMESTAMP(3)
+);
+
+DROP TRIGGER IF EXISTS update_bot_message_changetimestamp on bot_message;
+CREATE TRIGGER update_bot_message_changetimestamp BEFORE UPDATE
+ON bot_message FOR EACH ROW EXECUTE PROCEDURE 
+update_changetimestamp_column();
+
+END TRANSACTION;

--- a/db/sql/afterMigrate__99_assign_permissions.sql
+++ b/db/sql/afterMigrate__99_assign_permissions.sql
@@ -40,3 +40,13 @@ GRANT USAGE ON SEQUENCE request_id_seq
 TO ${username};
 
 GRANT SELECT ON TABLE ref_quota TO ${username};
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE human_action
+TO ${username};
+GRANT USAGE ON SEQUENCE human_action_id_seq
+TO ${username};
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE bot_message
+TO ${username};
+GRANT USAGE ON SEQUENCE bot_message_id_seq
+TO ${username};


### PR DESCRIPTION
This PR implements the API auto-merge capability and dashboard approval logic for all project create and edit requests.

This is a required step to introducing multi-cluster support and moving approvals within the dashboard.

Project Edit:
- Determine if it requires provisioner:
  - ADD Edit Request
  - Email PO/TC edit request has been successfully received and awaiting approval
  - Await callback from Registry
  - IF callback approved:
    - ADD bot_message
    - Send NATS 
    - Await callback from GH
    - Upon callback:
      - Update project
      - Mark request as is_active = false
      - Mark bot_message as received_callback = true
      - Email PO/TC edit request has been successfully completed
    - IF callback rejected:
      - Mark request as is_active = false
      - Communicate rejection to PO/TC with reason why.
- If no provisioner is required:
  - Update project DB records accordingly

Project Create:
- ADD Create Request
-  Populate DB with project details
- Mark project as pending
- Email PO/TC create request has been successfully received and awaiting approval
- Await callback from Registry
- Upon callback:
  - ADD bot_message
  - Send NATS message
  - Await callback from GH
  - Upon callback:
    - Update project to provisioned
    - Mark request as is_active = false
    - Mark bot_message as received_callback = true
    - Email PO/TC create request has been successfully completed

Make auto-merge API work by treating all requests as "trivial"

- [X] Update Project Edit Controller
- [X] Update Project Create Controller
- [X] Update Request Model
- [X] Update Request Controller
- [X] Update Request Util function
- [X] Add Bot Message Util function
- [ ] Create Email template for Edit
- [ ] Unit tests + testing


/bot-ignore-length