### PR TITLE
Update large cpu_request and cpu_limits to correct value

### DIFF
--- a/db/sql/V1.11__update_large_quota_values.sql
+++ b/db/sql/V1.11__update_large_quota_values.sql
@@ -1,0 +1,7 @@
+BEGIN TRANSACTION;
+
+UPDATE ref_quota
+SET cpu_requests = 16, cpu_limits = 32
+WHERE id = 'large';
+
+END TRANSACTION;


### PR DESCRIPTION
This PR fixes the discovery that the current CPU_request and CPU_limit size for a 'large' tshirt size is double the expected value. According to [here](https://app.zenhub.com/workspaces/platform-experience-5bb7c5ab4b5806bc2beb9d15/issues/bcdevops/openshift4-rollout/254), the values should be 16, and 32 respectively.

Fixes #375 

**This PR will require a sync from the provisioner system to take full effect**