### PR TITLE
Set LastPage state false if user hits previous on last card

### DIFF
--- a/web/src/utils/Wizard.tsx
+++ b/web/src/utils/Wizard.tsx
@@ -21,6 +21,7 @@ const Wizard: React.FC<any> = ({ onSubmit, children }) => {
   // previous page
   const previous = () => {
     setPage(Math.max(page - 1, 0));
+    setLastPage(false)
   };
 
   const handleSubmit = (formData: any) => {

--- a/web/src/utils/Wizard.tsx
+++ b/web/src/utils/Wizard.tsx
@@ -21,7 +21,7 @@ const Wizard: React.FC<any> = ({ onSubmit, children }) => {
   // previous page
   const previous = () => {
     setPage(Math.max(page - 1, 0));
-    setLastPage(false)
+    setLastPage(false);
   };
 
   const handleSubmit = (formData: any) => {


### PR DESCRIPTION
This PR fixes a bug that resulted in the Request button within the project create process not switching back to Next if a user navigated to a previous card after reaching the final step. ﻿
