### PR TITLE
Enable users to edit profile names

### DIFF
--- a/api/__tests__/__snapshots__/project-profile.spec.ts.snap
+++ b/api/__tests__/__snapshots__/project-profile.spec.ts.snap
@@ -240,34 +240,6 @@ Object {
 }
 `;
 
-exports[`Project-profile event handlers A project-profiles does not allow updating name 1`] = `
-Array [
-  Array [
-    Object {
-      "text": "
-        SELECT * FROM profile
-          WHERE id = $1 AND archived = false;",
-      "values": Array [
-        4,
-      ],
-    },
-  ],
-  Array [
-    Object {
-      "text": "
-                UPDATE request
-                SET is_active = false
-                WHERE id = 2
-                RETURNING *;",
-    },
-  ],
-]
-`;
-
-exports[`Project-profile event handlers A project-profiles does not allow updating name 2`] = `204`;
-
-exports[`Project-profile event handlers A project-profiles does not allow updating name 3`] = `undefined`;
-
 exports[`Project-profile event handlers A project-profiles fails to archive 1`] = `
 Array [
   Array [
@@ -443,25 +415,6 @@ Array [
 ]
 `;
 
-exports[`Project-profile event handlers Request project-profile edit with provisioner-related changes 1`] = `
-Array [
-  Array [
-    Object {
-      "text": "
-        SELECT * FROM profile
-          WHERE id = $1 AND archived = false;",
-      "values": Array [
-        4,
-      ],
-    },
-  ],
-]
-`;
-
-exports[`Project-profile event handlers Request project-profile edit with provisioner-related changes 2`] = `202`;
-
-exports[`Project-profile event handlers Request project-profile edit with provisioner-related changes 3`] = `undefined`;
-
 exports[`Project-profile event handlers Unique project-profiles names are derived 1`] = `
 Array [
   Array [
@@ -526,3 +479,41 @@ Array [
 exports[`Project-profile event handlers Update a project-profile with non provisioner-related changes 2`] = `204`;
 
 exports[`Project-profile event handlers Update a project-profile with non provisioner-related changes 3`] = `undefined`;
+
+exports[`Project-profile event handlers request project-profile edit with provisioner-related description changes 1`] = `
+Array [
+  Array [
+    Object {
+      "text": "
+        SELECT * FROM profile
+          WHERE id = $1 AND archived = false;",
+      "values": Array [
+        4,
+      ],
+    },
+  ],
+]
+`;
+
+exports[`Project-profile event handlers request project-profile edit with provisioner-related description changes 2`] = `202`;
+
+exports[`Project-profile event handlers request project-profile edit with provisioner-related description changes 3`] = `undefined`;
+
+exports[`Project-profile event handlers request project-profile edit with provisioner-related name changes 1`] = `
+Array [
+  Array [
+    Object {
+      "text": "
+        SELECT * FROM profile
+          WHERE id = $1 AND archived = false;",
+      "values": Array [
+        4,
+      ],
+    },
+  ],
+]
+`;
+
+exports[`Project-profile event handlers request project-profile edit with provisioner-related name changes 2`] = `202`;
+
+exports[`Project-profile event handlers request project-profile edit with provisioner-related name changes 3`] = `undefined`;

--- a/api/__tests__/project-profile.spec.ts
+++ b/api/__tests__/project-profile.spec.ts
@@ -277,7 +277,40 @@ describe('Project-profile event handlers', () => {
     expect(ex.res.status).toBeCalled();
   });
 
-  it('Request project-profile edit with provisioner-related changes', async () => {
+  it('request project-profile edit with provisioner-related name changes', async () => {
+    const body = {
+      id: 4,
+      name: "Project X ATTEMPTED NAME CHANGE",
+      description: "This is a cool project.",
+      criticalSystem: false,
+      prioritySystem: false,
+      busOrgId: "CITZ",
+      notificationEmail: true,
+      notificationSms: true,
+    };
+    const req = {
+      params: { profileId: 4 },
+      body,
+      user: authenticatedUser,
+    };
+
+    client.query.mockReturnValueOnce({ rows: selectProfile });
+
+    const update = ProfileModel.prototype.update = jest.fn();
+
+    await updateProjectProfile(req, ex.res);
+
+    expect(update).toHaveBeenCalledTimes(0);
+    expect(requestProjectProfileEdit).toHaveBeenCalledTimes(1);
+    expect(ex.res.statusCode).toBe(202);
+
+    expect(client.query.mock.calls).toMatchSnapshot();
+    expect(ex.res.statusCode).toMatchSnapshot();
+    expect(ex.responseData).toMatchSnapshot();
+    expect(ex.res.status).toBeCalled();
+  });
+
+  it('request project-profile edit with provisioner-related description changes', async () => {
     const body = {
       id: 4,
       name: "Project X",
@@ -327,39 +360,6 @@ describe('Project-profile event handlers', () => {
 
     expect(ex.res.status).not.toBeCalled();
     expect(ex.res.json).not.toBeCalled();
-  });
-
-  it('A project-profiles does not allow updating name', async () => {
-    const body = {
-      id: 4,
-      name: "Project X ATTEMPTED NAME CHANGE",
-      description: "This is a cool project.",
-      criticalSystem: false,
-      prioritySystem: false,
-      busOrgId: "CITZ",
-      notificationEmail: true,
-      notificationSms: true,
-    };
-    const req = {
-      params: { profileId: 4 },
-      body,
-      user: authenticatedUser,
-    };
-
-    client.query.mockReturnValueOnce({ rows: selectProfile });
-    client.query.mockReturnValueOnce({ rows: [] });
-
-    const update = ProfileModel.prototype.update = jest.fn();
-
-    await updateProjectProfile(req, ex.res);
-
-    expect(update).toHaveBeenCalledTimes(1);
-    expect(requestProjectProfileEdit).toHaveBeenCalledTimes(1);
-
-    expect(client.query.mock.calls).toMatchSnapshot();
-    expect(ex.res.statusCode).toMatchSnapshot();
-    expect(ex.responseData).toMatchSnapshot();
-    expect(ex.res.status).toBeCalled();
   });
 
   it('A project-profiles is archived', async () => {

--- a/api/src/controllers/project-profile.ts
+++ b/api/src/controllers/project-profile.ts
@@ -158,6 +158,7 @@ export const updateProjectProfile = async (
   }
 
   const {
+    name,
     description,
     busOrgId,
     prioritySystem,
@@ -182,6 +183,7 @@ export const updateProjectProfile = async (
   try {
     const currentProjectProfile: ProjectProfile = await ProfileModel.findById(profileId);
     const aBody = {
+      name,
       description,
       busOrgId,
       prioritySystem,
@@ -201,13 +203,13 @@ export const updateProjectProfile = async (
       idmActiveDir,
       other,
       migratingLicenseplate,
-      name: currentProjectProfile.name,
       userId: currentProjectProfile.userId,
       namespacePrefix: currentProjectProfile.namespacePrefix,
       primaryClusterName: currentProjectProfile.primaryClusterName,
     };
 
     const editCompares = [
+      currentProjectProfile.name !== name,
       currentProjectProfile.description !== description,
     ];
     const provisionerRelatedChanges = editCompares.some(editCompare => editCompare);

--- a/web/src/components/profileEdit/ProjectCardEdit.tsx
+++ b/web/src/components/profileEdit/ProjectCardEdit.tsx
@@ -112,7 +112,6 @@ const ProjectCardEdit: React.FC<IProjectCardEditProps> = (props) => {
               validate={validator.mustBeValidProfileName}
               defaultValue=""
               initialValue={projectDetails.name}
-              disabled
             />
           </Flex>
           <Flex flexDirection="column">


### PR DESCRIPTION
This PR introduces the ability to edit Project display names within the Registry / OpenShift. 

Fixes #237 