### PR TITLE
Refactored NATS context message into snake case and v2 format

### DIFF
--- a/api/__tests__/__snapshots__/fulfillment.spec.ts.snap
+++ b/api/__tests__/__snapshots__/fulfillment.spec.ts.snap
@@ -92,7 +92,7 @@ Array [
       "values": Array [
         3,
         "registry_project_provisioning_silver",
-        "{\\"action\\":\\"create\\",\\"profile_id\\":4,\\"cluster_id\\":1,\\"cluster_name\\":\\"silver\\",\\"display_name\\":\\"Project X\\",\\"description\\":\\"This is a cool project.\\",\\"namespaces\\":[{\\"namespaceId\\":13,\\"name\\":\\"4ea35c-tools\\",\\"clusters\\":[{\\"clusterId\\":1,\\"name\\":\\"silver\\",\\"provisioned\\":false}],\\"quota\\":\\"small\\",\\"cpu\\":{\\"requests\\":4,\\"limits\\":8},\\"memory\\":{\\"requests\\":\\"16Gi\\",\\"limits\\":\\"32Gi\\"},\\"storage\\":{\\"block\\":\\"50Gi\\",\\"file\\":\\"50Gi\\",\\"backup\\":\\"25Gi\\",\\"capacity\\":\\"50Gi\\",\\"pvcCount\\":20}},{\\"namespaceId\\":14,\\"name\\":\\"4ea35c-test\\",\\"clusters\\":[{\\"clusterId\\":1,\\"name\\":\\"silver\\",\\"provisioned\\":false}],\\"quota\\":\\"small\\",\\"cpu\\":{\\"requests\\":4,\\"limits\\":8},\\"memory\\":{\\"requests\\":\\"16Gi\\",\\"limits\\":\\"32Gi\\"},\\"storage\\":{\\"block\\":\\"50Gi\\",\\"file\\":\\"50Gi\\",\\"backup\\":\\"25Gi\\",\\"capacity\\":\\"50Gi\\",\\"pvcCount\\":20}},{\\"namespaceId\\":15,\\"name\\":\\"4ea35c-dev\\",\\"clusters\\":[{\\"clusterId\\":1,\\"name\\":\\"silver\\",\\"provisioned\\":false}],\\"quota\\":\\"small\\",\\"cpu\\":{\\"requests\\":4,\\"limits\\":8},\\"memory\\":{\\"requests\\":\\"16Gi\\",\\"limits\\":\\"32Gi\\"},\\"storage\\":{\\"block\\":\\"50Gi\\",\\"file\\":\\"50Gi\\",\\"backup\\":\\"25Gi\\",\\"capacity\\":\\"50Gi\\",\\"pvcCount\\":20}},{\\"namespaceId\\":16,\\"name\\":\\"4ea35c-prod\\",\\"clusters\\":[{\\"clusterId\\":1,\\"name\\":\\"silver\\",\\"provisioned\\":false}],\\"quota\\":\\"small\\",\\"cpu\\":{\\"requests\\":4,\\"limits\\":8},\\"memory\\":{\\"requests\\":\\"16Gi\\",\\"limits\\":\\"32Gi\\"},\\"storage\\":{\\"block\\":\\"50Gi\\",\\"file\\":\\"50Gi\\",\\"backup\\":\\"25Gi\\",\\"capacity\\":\\"50Gi\\",\\"pvcCount\\":20}}],\\"contacts\\":[{\\"user_id\\":\\"jane1100\\",\\"provider\\":\\"github\\",\\"email\\":\\"jane@example.com\\",\\"rocketchat_username\\":null,\\"role\\":\\"owner\\"},{\\"user_id\\":\\"john1100\\",\\"provider\\":\\"github\\",\\"email\\":\\"john@example.com\\",\\"rocketchat_username\\":null,\\"role\\":\\"lead\\"}]}",
+        "{\\"action\\":\\"create\\",\\"profile_id\\":4,\\"cluster_id\\":1,\\"cluster_name\\":\\"silver\\",\\"display_name\\":\\"Project X\\",\\"description\\":\\"This is a cool project.\\",\\"namespaces\\":[{\\"namespaceId\\":13,\\"name\\":\\"4ea35c-tools\\",\\"clusters\\":[{\\"clusterId\\":1,\\"name\\":\\"silver\\",\\"provisioned\\":false}],\\"quota\\":\\"small\\",\\"quotas\\":{\\"cpu\\":{\\"requests\\":4,\\"limits\\":8},\\"memory\\":{\\"requests\\":\\"16Gi\\",\\"limits\\":\\"32Gi\\"},\\"storage\\":{\\"block\\":\\"50Gi\\",\\"file\\":\\"50Gi\\",\\"backup\\":\\"25Gi\\",\\"capacity\\":\\"50Gi\\",\\"pvcCount\\":20}}},{\\"namespaceId\\":14,\\"name\\":\\"4ea35c-test\\",\\"clusters\\":[{\\"clusterId\\":1,\\"name\\":\\"silver\\",\\"provisioned\\":false}],\\"quota\\":\\"small\\",\\"quotas\\":{\\"cpu\\":{\\"requests\\":4,\\"limits\\":8},\\"memory\\":{\\"requests\\":\\"16Gi\\",\\"limits\\":\\"32Gi\\"},\\"storage\\":{\\"block\\":\\"50Gi\\",\\"file\\":\\"50Gi\\",\\"backup\\":\\"25Gi\\",\\"capacity\\":\\"50Gi\\",\\"pvcCount\\":20}}},{\\"namespaceId\\":15,\\"name\\":\\"4ea35c-dev\\",\\"clusters\\":[{\\"clusterId\\":1,\\"name\\":\\"silver\\",\\"provisioned\\":false}],\\"quota\\":\\"small\\",\\"quotas\\":{\\"cpu\\":{\\"requests\\":4,\\"limits\\":8},\\"memory\\":{\\"requests\\":\\"16Gi\\",\\"limits\\":\\"32Gi\\"},\\"storage\\":{\\"block\\":\\"50Gi\\",\\"file\\":\\"50Gi\\",\\"backup\\":\\"25Gi\\",\\"capacity\\":\\"50Gi\\",\\"pvcCount\\":20}}},{\\"namespaceId\\":16,\\"name\\":\\"4ea35c-prod\\",\\"clusters\\":[{\\"clusterId\\":1,\\"name\\":\\"silver\\",\\"provisioned\\":false}],\\"quota\\":\\"small\\",\\"quotas\\":{\\"cpu\\":{\\"requests\\":4,\\"limits\\":8},\\"memory\\":{\\"requests\\":\\"16Gi\\",\\"limits\\":\\"32Gi\\"},\\"storage\\":{\\"block\\":\\"50Gi\\",\\"file\\":\\"50Gi\\",\\"backup\\":\\"25Gi\\",\\"capacity\\":\\"50Gi\\",\\"pvcCount\\":20}}}],\\"contacts\\":[{\\"user_id\\":\\"jane1100\\",\\"provider\\":\\"github\\",\\"email\\":\\"jane@example.com\\",\\"rocketchat_username\\":null,\\"role\\":\\"owner\\"},{\\"user_id\\":\\"john1100\\",\\"provider\\":\\"github\\",\\"email\\":\\"john@example.com\\",\\"rocketchat_username\\":null,\\"role\\":\\"lead\\"}]}",
         "silver",
         false,
       ],
@@ -133,23 +133,25 @@ Object {
           "provisioned": false,
         },
       ],
-      "cpu": Object {
-        "limits": 8,
-        "requests": 4,
-      },
-      "memory": Object {
-        "limits": "32Gi",
-        "requests": "16Gi",
-      },
       "name": "4ea35c-tools",
       "namespaceId": 13,
       "quota": "small",
-      "storage": Object {
-        "backup": "25Gi",
-        "block": "50Gi",
-        "capacity": "50Gi",
-        "file": "50Gi",
-        "pvcCount": 20,
+      "quotas": Object {
+        "cpu": Object {
+          "limits": 8,
+          "requests": 4,
+        },
+        "memory": Object {
+          "limits": "32Gi",
+          "requests": "16Gi",
+        },
+        "storage": Object {
+          "backup": "25Gi",
+          "block": "50Gi",
+          "capacity": "50Gi",
+          "file": "50Gi",
+          "pvcCount": 20,
+        },
       },
     },
     Object {
@@ -160,23 +162,25 @@ Object {
           "provisioned": false,
         },
       ],
-      "cpu": Object {
-        "limits": 8,
-        "requests": 4,
-      },
-      "memory": Object {
-        "limits": "32Gi",
-        "requests": "16Gi",
-      },
       "name": "4ea35c-test",
       "namespaceId": 14,
       "quota": "small",
-      "storage": Object {
-        "backup": "25Gi",
-        "block": "50Gi",
-        "capacity": "50Gi",
-        "file": "50Gi",
-        "pvcCount": 20,
+      "quotas": Object {
+        "cpu": Object {
+          "limits": 8,
+          "requests": 4,
+        },
+        "memory": Object {
+          "limits": "32Gi",
+          "requests": "16Gi",
+        },
+        "storage": Object {
+          "backup": "25Gi",
+          "block": "50Gi",
+          "capacity": "50Gi",
+          "file": "50Gi",
+          "pvcCount": 20,
+        },
       },
     },
     Object {
@@ -187,23 +191,25 @@ Object {
           "provisioned": false,
         },
       ],
-      "cpu": Object {
-        "limits": 8,
-        "requests": 4,
-      },
-      "memory": Object {
-        "limits": "32Gi",
-        "requests": "16Gi",
-      },
       "name": "4ea35c-dev",
       "namespaceId": 15,
       "quota": "small",
-      "storage": Object {
-        "backup": "25Gi",
-        "block": "50Gi",
-        "capacity": "50Gi",
-        "file": "50Gi",
-        "pvcCount": 20,
+      "quotas": Object {
+        "cpu": Object {
+          "limits": 8,
+          "requests": 4,
+        },
+        "memory": Object {
+          "limits": "32Gi",
+          "requests": "16Gi",
+        },
+        "storage": Object {
+          "backup": "25Gi",
+          "block": "50Gi",
+          "capacity": "50Gi",
+          "file": "50Gi",
+          "pvcCount": 20,
+        },
       },
     },
     Object {
@@ -214,23 +220,25 @@ Object {
           "provisioned": false,
         },
       ],
-      "cpu": Object {
-        "limits": 8,
-        "requests": 4,
-      },
-      "memory": Object {
-        "limits": "32Gi",
-        "requests": "16Gi",
-      },
       "name": "4ea35c-prod",
       "namespaceId": 16,
       "quota": "small",
-      "storage": Object {
-        "backup": "25Gi",
-        "block": "50Gi",
-        "capacity": "50Gi",
-        "file": "50Gi",
-        "pvcCount": 20,
+      "quotas": Object {
+        "cpu": Object {
+          "limits": 8,
+          "requests": 4,
+        },
+        "memory": Object {
+          "limits": "32Gi",
+          "requests": "16Gi",
+        },
+        "storage": Object {
+          "backup": "25Gi",
+          "block": "50Gi",
+          "capacity": "50Gi",
+          "file": "50Gi",
+          "pvcCount": 20,
+        },
       },
     },
   ],
@@ -270,23 +278,25 @@ Object {
           "provisioned": false,
         },
       ],
-      "cpu": Object {
-        "limits": 8,
-        "requests": 4,
-      },
-      "memory": Object {
-        "limits": "32Gi",
-        "requests": "16Gi",
-      },
       "name": "4ea35c-tools",
       "namespaceId": 13,
       "quota": "small",
-      "storage": Object {
-        "backup": "25Gi",
-        "block": "50Gi",
-        "capacity": "50Gi",
-        "file": "50Gi",
-        "pvcCount": 20,
+      "quotas": Object {
+        "cpu": Object {
+          "limits": 8,
+          "requests": 4,
+        },
+        "memory": Object {
+          "limits": "32Gi",
+          "requests": "16Gi",
+        },
+        "storage": Object {
+          "backup": "25Gi",
+          "block": "50Gi",
+          "capacity": "50Gi",
+          "file": "50Gi",
+          "pvcCount": 20,
+        },
       },
     },
     Object {
@@ -297,23 +307,25 @@ Object {
           "provisioned": false,
         },
       ],
-      "cpu": Object {
-        "limits": 8,
-        "requests": 4,
-      },
-      "memory": Object {
-        "limits": "32Gi",
-        "requests": "16Gi",
-      },
       "name": "4ea35c-test",
       "namespaceId": 14,
       "quota": "small",
-      "storage": Object {
-        "backup": "25Gi",
-        "block": "50Gi",
-        "capacity": "50Gi",
-        "file": "50Gi",
-        "pvcCount": 20,
+      "quotas": Object {
+        "cpu": Object {
+          "limits": 8,
+          "requests": 4,
+        },
+        "memory": Object {
+          "limits": "32Gi",
+          "requests": "16Gi",
+        },
+        "storage": Object {
+          "backup": "25Gi",
+          "block": "50Gi",
+          "capacity": "50Gi",
+          "file": "50Gi",
+          "pvcCount": 20,
+        },
       },
     },
     Object {
@@ -324,23 +336,25 @@ Object {
           "provisioned": false,
         },
       ],
-      "cpu": Object {
-        "limits": 8,
-        "requests": 4,
-      },
-      "memory": Object {
-        "limits": "32Gi",
-        "requests": "16Gi",
-      },
       "name": "4ea35c-dev",
       "namespaceId": 15,
       "quota": "small",
-      "storage": Object {
-        "backup": "25Gi",
-        "block": "50Gi",
-        "capacity": "50Gi",
-        "file": "50Gi",
-        "pvcCount": 20,
+      "quotas": Object {
+        "cpu": Object {
+          "limits": 8,
+          "requests": 4,
+        },
+        "memory": Object {
+          "limits": "32Gi",
+          "requests": "16Gi",
+        },
+        "storage": Object {
+          "backup": "25Gi",
+          "block": "50Gi",
+          "capacity": "50Gi",
+          "file": "50Gi",
+          "pvcCount": 20,
+        },
       },
     },
     Object {
@@ -351,23 +365,25 @@ Object {
           "provisioned": false,
         },
       ],
-      "cpu": Object {
-        "limits": 8,
-        "requests": 4,
-      },
-      "memory": Object {
-        "limits": "32Gi",
-        "requests": "16Gi",
-      },
       "name": "4ea35c-prod",
       "namespaceId": 16,
       "quota": "small",
-      "storage": Object {
-        "backup": "25Gi",
-        "block": "50Gi",
-        "capacity": "50Gi",
-        "file": "50Gi",
-        "pvcCount": 20,
+      "quotas": Object {
+        "cpu": Object {
+          "limits": 8,
+          "requests": 4,
+        },
+        "memory": Object {
+          "limits": "32Gi",
+          "requests": "16Gi",
+        },
+        "storage": Object {
+          "backup": "25Gi",
+          "block": "50Gi",
+          "capacity": "50Gi",
+          "file": "50Gi",
+          "pvcCount": 20,
+        },
       },
     },
   ],
@@ -407,23 +423,25 @@ Object {
           "provisioned": false,
         },
       ],
-      "cpu": Object {
-        "limits": 8,
-        "requests": 4,
-      },
-      "memory": Object {
-        "limits": "32Gi",
-        "requests": "16Gi",
-      },
       "name": "4ea35c-tools",
       "namespaceId": 13,
       "quota": "small",
-      "storage": Object {
-        "backup": "25Gi",
-        "block": "50Gi",
-        "capacity": "50Gi",
-        "file": "50Gi",
-        "pvcCount": 20,
+      "quotas": Object {
+        "cpu": Object {
+          "limits": 8,
+          "requests": 4,
+        },
+        "memory": Object {
+          "limits": "32Gi",
+          "requests": "16Gi",
+        },
+        "storage": Object {
+          "backup": "25Gi",
+          "block": "50Gi",
+          "capacity": "50Gi",
+          "file": "50Gi",
+          "pvcCount": 20,
+        },
       },
     },
     Object {
@@ -434,23 +452,25 @@ Object {
           "provisioned": false,
         },
       ],
-      "cpu": Object {
-        "limits": 8,
-        "requests": 4,
-      },
-      "memory": Object {
-        "limits": "32Gi",
-        "requests": "16Gi",
-      },
       "name": "4ea35c-test",
       "namespaceId": 14,
       "quota": "small",
-      "storage": Object {
-        "backup": "25Gi",
-        "block": "50Gi",
-        "capacity": "50Gi",
-        "file": "50Gi",
-        "pvcCount": 20,
+      "quotas": Object {
+        "cpu": Object {
+          "limits": 8,
+          "requests": 4,
+        },
+        "memory": Object {
+          "limits": "32Gi",
+          "requests": "16Gi",
+        },
+        "storage": Object {
+          "backup": "25Gi",
+          "block": "50Gi",
+          "capacity": "50Gi",
+          "file": "50Gi",
+          "pvcCount": 20,
+        },
       },
     },
     Object {
@@ -461,23 +481,25 @@ Object {
           "provisioned": false,
         },
       ],
-      "cpu": Object {
-        "limits": 8,
-        "requests": 4,
-      },
-      "memory": Object {
-        "limits": "32Gi",
-        "requests": "16Gi",
-      },
       "name": "4ea35c-dev",
       "namespaceId": 15,
       "quota": "small",
-      "storage": Object {
-        "backup": "25Gi",
-        "block": "50Gi",
-        "capacity": "50Gi",
-        "file": "50Gi",
-        "pvcCount": 20,
+      "quotas": Object {
+        "cpu": Object {
+          "limits": 8,
+          "requests": 4,
+        },
+        "memory": Object {
+          "limits": "32Gi",
+          "requests": "16Gi",
+        },
+        "storage": Object {
+          "backup": "25Gi",
+          "block": "50Gi",
+          "capacity": "50Gi",
+          "file": "50Gi",
+          "pvcCount": 20,
+        },
       },
     },
     Object {
@@ -488,23 +510,25 @@ Object {
           "provisioned": false,
         },
       ],
-      "cpu": Object {
-        "limits": 8,
-        "requests": 4,
-      },
-      "memory": Object {
-        "limits": "32Gi",
-        "requests": "16Gi",
-      },
       "name": "4ea35c-prod",
       "namespaceId": 16,
       "quota": "small",
-      "storage": Object {
-        "backup": "25Gi",
-        "block": "50Gi",
-        "capacity": "50Gi",
-        "file": "50Gi",
-        "pvcCount": 20,
+      "quotas": Object {
+        "cpu": Object {
+          "limits": 8,
+          "requests": 4,
+        },
+        "memory": Object {
+          "limits": "32Gi",
+          "requests": "16Gi",
+        },
+        "storage": Object {
+          "backup": "25Gi",
+          "block": "50Gi",
+          "capacity": "50Gi",
+          "file": "50Gi",
+          "pvcCount": 20,
+        },
       },
     },
   ],
@@ -544,23 +568,25 @@ Object {
           "provisioned": false,
         },
       ],
-      "cpu": Object {
-        "limits": 8,
-        "requests": 4,
-      },
-      "memory": Object {
-        "limits": "32Gi",
-        "requests": "16Gi",
-      },
       "name": "4ea35c-tools",
       "namespaceId": 13,
       "quota": "small",
-      "storage": Object {
-        "backup": "25Gi",
-        "block": "50Gi",
-        "capacity": "50Gi",
-        "file": "50Gi",
-        "pvcCount": 20,
+      "quotas": Object {
+        "cpu": Object {
+          "limits": 8,
+          "requests": 4,
+        },
+        "memory": Object {
+          "limits": "32Gi",
+          "requests": "16Gi",
+        },
+        "storage": Object {
+          "backup": "25Gi",
+          "block": "50Gi",
+          "capacity": "50Gi",
+          "file": "50Gi",
+          "pvcCount": 20,
+        },
       },
     },
     Object {
@@ -571,23 +597,25 @@ Object {
           "provisioned": false,
         },
       ],
-      "cpu": Object {
-        "limits": 8,
-        "requests": 4,
-      },
-      "memory": Object {
-        "limits": "32Gi",
-        "requests": "16Gi",
-      },
       "name": "4ea35c-test",
       "namespaceId": 14,
       "quota": "small",
-      "storage": Object {
-        "backup": "25Gi",
-        "block": "50Gi",
-        "capacity": "50Gi",
-        "file": "50Gi",
-        "pvcCount": 20,
+      "quotas": Object {
+        "cpu": Object {
+          "limits": 8,
+          "requests": 4,
+        },
+        "memory": Object {
+          "limits": "32Gi",
+          "requests": "16Gi",
+        },
+        "storage": Object {
+          "backup": "25Gi",
+          "block": "50Gi",
+          "capacity": "50Gi",
+          "file": "50Gi",
+          "pvcCount": 20,
+        },
       },
     },
     Object {
@@ -598,23 +626,25 @@ Object {
           "provisioned": false,
         },
       ],
-      "cpu": Object {
-        "limits": 8,
-        "requests": 4,
-      },
-      "memory": Object {
-        "limits": "32Gi",
-        "requests": "16Gi",
-      },
       "name": "4ea35c-dev",
       "namespaceId": 15,
       "quota": "small",
-      "storage": Object {
-        "backup": "25Gi",
-        "block": "50Gi",
-        "capacity": "50Gi",
-        "file": "50Gi",
-        "pvcCount": 20,
+      "quotas": Object {
+        "cpu": Object {
+          "limits": 8,
+          "requests": 4,
+        },
+        "memory": Object {
+          "limits": "32Gi",
+          "requests": "16Gi",
+        },
+        "storage": Object {
+          "backup": "25Gi",
+          "block": "50Gi",
+          "capacity": "50Gi",
+          "file": "50Gi",
+          "pvcCount": 20,
+        },
       },
     },
     Object {
@@ -625,23 +655,25 @@ Object {
           "provisioned": false,
         },
       ],
-      "cpu": Object {
-        "limits": 8,
-        "requests": 4,
-      },
-      "memory": Object {
-        "limits": "32Gi",
-        "requests": "16Gi",
-      },
       "name": "4ea35c-prod",
       "namespaceId": 16,
       "quota": "small",
-      "storage": Object {
-        "backup": "25Gi",
-        "block": "50Gi",
-        "capacity": "50Gi",
-        "file": "50Gi",
-        "pvcCount": 20,
+      "quotas": Object {
+        "cpu": Object {
+          "limits": 8,
+          "requests": 4,
+        },
+        "memory": Object {
+          "limits": "32Gi",
+          "requests": "16Gi",
+        },
+        "storage": Object {
+          "backup": "25Gi",
+          "block": "50Gi",
+          "capacity": "50Gi",
+          "file": "50Gi",
+          "pvcCount": 20,
+        },
       },
     },
   ],

--- a/api/__tests__/__snapshots__/fulfillment.spec.ts.snap
+++ b/api/__tests__/__snapshots__/fulfillment.spec.ts.snap
@@ -135,6 +135,7 @@ Object {
       ],
       "name": "4ea35c-tools",
       "namespaceId": 13,
+      "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
         "cpu": Object {
@@ -164,6 +165,7 @@ Object {
       ],
       "name": "4ea35c-test",
       "namespaceId": 14,
+      "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
         "cpu": Object {
@@ -193,6 +195,7 @@ Object {
       ],
       "name": "4ea35c-dev",
       "namespaceId": 15,
+      "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
         "cpu": Object {
@@ -222,6 +225,7 @@ Object {
       ],
       "name": "4ea35c-prod",
       "namespaceId": 16,
+      "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
         "cpu": Object {
@@ -280,6 +284,7 @@ Object {
       ],
       "name": "4ea35c-tools",
       "namespaceId": 13,
+      "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
         "cpu": Object {
@@ -309,6 +314,7 @@ Object {
       ],
       "name": "4ea35c-test",
       "namespaceId": 14,
+      "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
         "cpu": Object {
@@ -338,6 +344,7 @@ Object {
       ],
       "name": "4ea35c-dev",
       "namespaceId": 15,
+      "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
         "cpu": Object {
@@ -367,6 +374,7 @@ Object {
       ],
       "name": "4ea35c-prod",
       "namespaceId": 16,
+      "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
         "cpu": Object {
@@ -425,6 +433,7 @@ Object {
       ],
       "name": "4ea35c-tools",
       "namespaceId": 13,
+      "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
         "cpu": Object {
@@ -454,6 +463,7 @@ Object {
       ],
       "name": "4ea35c-test",
       "namespaceId": 14,
+      "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
         "cpu": Object {
@@ -483,6 +493,7 @@ Object {
       ],
       "name": "4ea35c-dev",
       "namespaceId": 15,
+      "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
         "cpu": Object {
@@ -512,6 +523,7 @@ Object {
       ],
       "name": "4ea35c-prod",
       "namespaceId": 16,
+      "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
         "cpu": Object {
@@ -570,6 +582,7 @@ Object {
       ],
       "name": "4ea35c-tools",
       "namespaceId": 13,
+      "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
         "cpu": Object {
@@ -599,6 +612,7 @@ Object {
       ],
       "name": "4ea35c-test",
       "namespaceId": 14,
+      "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
         "cpu": Object {
@@ -628,6 +642,7 @@ Object {
       ],
       "name": "4ea35c-dev",
       "namespaceId": 15,
+      "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
         "cpu": Object {
@@ -657,6 +672,7 @@ Object {
       ],
       "name": "4ea35c-prod",
       "namespaceId": 16,
+      "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
         "cpu": Object {

--- a/api/__tests__/__snapshots__/fulfillment.spec.ts.snap
+++ b/api/__tests__/__snapshots__/fulfillment.spec.ts.snap
@@ -43,7 +43,7 @@ Array [
                         FROM ref_quota WHERE id = 'small') d),
                     'memory', (SELECT row_to_json(d) FROM (SELECT memory_requests AS \\"requests\\", memory_limits AS \\"limits\\"
                         FROM ref_quota WHERE id = 'small') d),
-                    'storage', (SELECT row_to_json(d) FROM (SELECT storage_block AS \\"block\\", storage_file AS \\"file\\", storage_backup AS \\"backup\\", storage_capacity AS \\"capacity\\"
+                    'storage', (SELECT row_to_json(d) FROM (SELECT storage_block AS \\"block\\", storage_file AS \\"file\\", storage_backup AS \\"backup\\", storage_capacity AS \\"capacity\\", storage_pvc_count AS \\"pvcCount\\"
                         FROM ref_quota WHERE id = 'small') d)
                 );
             ",
@@ -52,22 +52,20 @@ Array [
   Array [
     Object {
       "text": "
-        SELECT namespace.id AS \\"namespaceId\\", namespace.name,
-        coalesce(
-          (
-            SELECT array_to_json(array_agg(row_to_json(x)))
-            FROM (
-              SELECT ref_cluster.id AS \\"clusterId\\", ref_cluster.name, cluster_namespace.provisioned
-              FROM ref_cluster JOIN cluster_namespace ON ref_cluster.id = cluster_namespace.cluster_id
-              WHERE namespace.id = cluster_namespace.namespace_id
-            ) x
-          ),
-          '[]'
-        ) AS clusters
-        FROM namespace WHERE namespace.profile_id = $1;
-      ",
+        SELECT * FROM namespace
+          WHERE profile_id = $1 AND archived = false;",
       "values": Array [
         4,
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "text": "
+        SELECT * FROM ref_cluster WHERE name = $1;
+      ",
+      "values": Array [
+        "silver",
       ],
     },
   ],
@@ -94,7 +92,7 @@ Array [
       "values": Array [
         3,
         "registry_project_provisioning_silver",
-        "{\\"action\\":\\"create\\",\\"type\\":\\"standard\\",\\"profileId\\":4,\\"displayName\\":\\"Project X\\",\\"newDisplayName\\":\\"NULL\\",\\"description\\":\\"This is a cool project.\\",\\"quota\\":\\"small\\",\\"quotas\\":{\\"cpu\\":{\\"requests\\":4,\\"limits\\":8},\\"memory\\":{\\"requests\\":\\"16Gi\\",\\"limits\\":\\"32Gi\\"},\\"storage\\":{\\"block\\":\\"50Gi\\",\\"file\\":\\"50Gi\\",\\"backup\\":\\"25Gi\\",\\"capacity\\":\\"50Gi\\"}},\\"namespaces\\":[{\\"namespaceId\\":13,\\"name\\":\\"4ea35c-tools\\",\\"clusters\\":[{\\"clusterId\\":1,\\"name\\":\\"silver\\",\\"provisioned\\":false}]},{\\"namespaceId\\":14,\\"name\\":\\"4ea35c-test\\",\\"clusters\\":[{\\"clusterId\\":1,\\"name\\":\\"silver\\",\\"provisioned\\":false}]},{\\"namespaceId\\":15,\\"name\\":\\"4ea35c-dev\\",\\"clusters\\":[{\\"clusterId\\":1,\\"name\\":\\"silver\\",\\"provisioned\\":false}]},{\\"namespaceId\\":16,\\"name\\":\\"4ea35c-prod\\",\\"clusters\\":[{\\"clusterId\\":1,\\"name\\":\\"silver\\",\\"provisioned\\":false}]}],\\"technicalContact\\":{\\"userId\\":\\"john1100\\",\\"provider\\":\\"github\\",\\"email\\":\\"john@example.com\\"},\\"productOwner\\":{\\"userId\\":\\"jane1100\\",\\"provider\\":\\"github\\",\\"email\\":\\"jane@example.com\\"}}",
+        "{\\"action\\":\\"create\\",\\"profile_id\\":4,\\"cluster_id\\":1,\\"cluster_name\\":\\"silver\\",\\"display_name\\":\\"Project X\\",\\"description\\":\\"This is a cool project.\\",\\"namespaces\\":[{\\"namespaceId\\":13,\\"name\\":\\"4ea35c-tools\\",\\"clusters\\":[{\\"clusterId\\":1,\\"name\\":\\"silver\\",\\"provisioned\\":false}],\\"quota\\":\\"small\\",\\"cpu\\":{\\"requests\\":4,\\"limits\\":8},\\"memory\\":{\\"requests\\":\\"16Gi\\",\\"limits\\":\\"32Gi\\"},\\"storage\\":{\\"block\\":\\"50Gi\\",\\"file\\":\\"50Gi\\",\\"backup\\":\\"25Gi\\",\\"capacity\\":\\"50Gi\\",\\"pvcCount\\":20}},{\\"namespaceId\\":14,\\"name\\":\\"4ea35c-test\\",\\"clusters\\":[{\\"clusterId\\":1,\\"name\\":\\"silver\\",\\"provisioned\\":false}],\\"quota\\":\\"small\\",\\"cpu\\":{\\"requests\\":4,\\"limits\\":8},\\"memory\\":{\\"requests\\":\\"16Gi\\",\\"limits\\":\\"32Gi\\"},\\"storage\\":{\\"block\\":\\"50Gi\\",\\"file\\":\\"50Gi\\",\\"backup\\":\\"25Gi\\",\\"capacity\\":\\"50Gi\\",\\"pvcCount\\":20}},{\\"namespaceId\\":15,\\"name\\":\\"4ea35c-dev\\",\\"clusters\\":[{\\"clusterId\\":1,\\"name\\":\\"silver\\",\\"provisioned\\":false}],\\"quota\\":\\"small\\",\\"cpu\\":{\\"requests\\":4,\\"limits\\":8},\\"memory\\":{\\"requests\\":\\"16Gi\\",\\"limits\\":\\"32Gi\\"},\\"storage\\":{\\"block\\":\\"50Gi\\",\\"file\\":\\"50Gi\\",\\"backup\\":\\"25Gi\\",\\"capacity\\":\\"50Gi\\",\\"pvcCount\\":20}},{\\"namespaceId\\":16,\\"name\\":\\"4ea35c-prod\\",\\"clusters\\":[{\\"clusterId\\":1,\\"name\\":\\"silver\\",\\"provisioned\\":false}],\\"quota\\":\\"small\\",\\"cpu\\":{\\"requests\\":4,\\"limits\\":8},\\"memory\\":{\\"requests\\":\\"16Gi\\",\\"limits\\":\\"32Gi\\"},\\"storage\\":{\\"block\\":\\"50Gi\\",\\"file\\":\\"50Gi\\",\\"backup\\":\\"25Gi\\",\\"capacity\\":\\"50Gi\\",\\"pvcCount\\":20}}],\\"contacts\\":[{\\"user_id\\":\\"jane1100\\",\\"provider\\":\\"github\\",\\"email\\":\\"jane@example.com\\",\\"rocketchat_username\\":null,\\"role\\":\\"owner\\"},{\\"user_id\\":\\"john1100\\",\\"provider\\":\\"github\\",\\"email\\":\\"john@example.com\\",\\"rocketchat_username\\":null,\\"role\\":\\"lead\\"}]}",
         "silver",
         false,
       ],
@@ -106,8 +104,26 @@ Array [
 exports[`Fulfillment utility Provisioning context is created 1`] = `
 Object {
   "action": "create",
+  "cluster_id": 1,
+  "cluster_name": "silver",
+  "contacts": Array [
+    Object {
+      "email": "jane@example.com",
+      "provider": "github",
+      "rocketchat_username": null,
+      "role": "owner",
+      "user_id": "jane1100",
+    },
+    Object {
+      "email": "john@example.com",
+      "provider": "github",
+      "rocketchat_username": null,
+      "role": "lead",
+      "user_id": "john1100",
+    },
+  ],
   "description": "This is a cool project.",
-  "displayName": "Project X",
+  "display_name": "Project X",
   "namespaces": Array [
     Object {
       "clusters": Array [
@@ -117,8 +133,24 @@ Object {
           "provisioned": false,
         },
       ],
+      "cpu": Object {
+        "limits": 8,
+        "requests": 4,
+      },
+      "memory": Object {
+        "limits": "32Gi",
+        "requests": "16Gi",
+      },
       "name": "4ea35c-tools",
       "namespaceId": 13,
+      "quota": "small",
+      "storage": Object {
+        "backup": "25Gi",
+        "block": "50Gi",
+        "capacity": "50Gi",
+        "file": "50Gi",
+        "pvcCount": 20,
+      },
     },
     Object {
       "clusters": Array [
@@ -128,8 +160,24 @@ Object {
           "provisioned": false,
         },
       ],
+      "cpu": Object {
+        "limits": 8,
+        "requests": 4,
+      },
+      "memory": Object {
+        "limits": "32Gi",
+        "requests": "16Gi",
+      },
       "name": "4ea35c-test",
       "namespaceId": 14,
+      "quota": "small",
+      "storage": Object {
+        "backup": "25Gi",
+        "block": "50Gi",
+        "capacity": "50Gi",
+        "file": "50Gi",
+        "pvcCount": 20,
+      },
     },
     Object {
       "clusters": Array [
@@ -139,8 +187,24 @@ Object {
           "provisioned": false,
         },
       ],
+      "cpu": Object {
+        "limits": 8,
+        "requests": 4,
+      },
+      "memory": Object {
+        "limits": "32Gi",
+        "requests": "16Gi",
+      },
       "name": "4ea35c-dev",
       "namespaceId": 15,
+      "quota": "small",
+      "storage": Object {
+        "backup": "25Gi",
+        "block": "50Gi",
+        "capacity": "50Gi",
+        "file": "50Gi",
+        "pvcCount": 20,
+      },
     },
     Object {
       "clusters": Array [
@@ -150,49 +214,53 @@ Object {
           "provisioned": false,
         },
       ],
+      "cpu": Object {
+        "limits": 8,
+        "requests": 4,
+      },
+      "memory": Object {
+        "limits": "32Gi",
+        "requests": "16Gi",
+      },
       "name": "4ea35c-prod",
       "namespaceId": 16,
+      "quota": "small",
+      "storage": Object {
+        "backup": "25Gi",
+        "block": "50Gi",
+        "capacity": "50Gi",
+        "file": "50Gi",
+        "pvcCount": 20,
+      },
     },
   ],
-  "newDisplayName": "NULL",
-  "productOwner": Object {
-    "email": "jane@example.com",
-    "provider": "github",
-    "userId": "jane1100",
-  },
-  "profileId": 4,
-  "quota": "small",
-  "quotas": Object {
-    "cpu": Object {
-      "limits": 8,
-      "requests": 4,
-    },
-    "memory": Object {
-      "limits": "32Gi",
-      "requests": "16Gi",
-    },
-    "storage": Object {
-      "backup": "25Gi",
-      "block": "50Gi",
-      "capacity": "50Gi",
-      "file": "50Gi",
-      "pvcCount": 20,
-    },
-  },
-  "technicalContact": Object {
-    "email": "john@example.com",
-    "provider": "github",
-    "userId": "john1100",
-  },
-  "type": "standard",
+  "profile_id": 4,
 }
 `;
 
 exports[`Fulfillment utility creates the contact edit context 1`] = `
 Object {
   "action": "edit",
+  "cluster_id": 1,
+  "cluster_name": "silver",
+  "contacts": Array [
+    Object {
+      "email": "jane@example.com",
+      "provider": "github",
+      "rocketchat_username": null,
+      "role": "owner",
+      "user_id": "janedoe",
+    },
+    Object {
+      "email": "jim@example.com",
+      "provider": "github",
+      "rocketchat_username": null,
+      "role": "lead",
+      "user_id": "jim1100",
+    },
+  ],
   "description": "This is a cool project.",
-  "displayName": "Project X",
+  "display_name": "Project X",
   "namespaces": Array [
     Object {
       "clusters": Array [
@@ -202,8 +270,24 @@ Object {
           "provisioned": false,
         },
       ],
+      "cpu": Object {
+        "limits": 8,
+        "requests": 4,
+      },
+      "memory": Object {
+        "limits": "32Gi",
+        "requests": "16Gi",
+      },
       "name": "4ea35c-tools",
       "namespaceId": 13,
+      "quota": "small",
+      "storage": Object {
+        "backup": "25Gi",
+        "block": "50Gi",
+        "capacity": "50Gi",
+        "file": "50Gi",
+        "pvcCount": 20,
+      },
     },
     Object {
       "clusters": Array [
@@ -213,8 +297,24 @@ Object {
           "provisioned": false,
         },
       ],
+      "cpu": Object {
+        "limits": 8,
+        "requests": 4,
+      },
+      "memory": Object {
+        "limits": "32Gi",
+        "requests": "16Gi",
+      },
       "name": "4ea35c-test",
       "namespaceId": 14,
+      "quota": "small",
+      "storage": Object {
+        "backup": "25Gi",
+        "block": "50Gi",
+        "capacity": "50Gi",
+        "file": "50Gi",
+        "pvcCount": 20,
+      },
     },
     Object {
       "clusters": Array [
@@ -224,8 +324,24 @@ Object {
           "provisioned": false,
         },
       ],
+      "cpu": Object {
+        "limits": 8,
+        "requests": 4,
+      },
+      "memory": Object {
+        "limits": "32Gi",
+        "requests": "16Gi",
+      },
       "name": "4ea35c-dev",
       "namespaceId": 15,
+      "quota": "small",
+      "storage": Object {
+        "backup": "25Gi",
+        "block": "50Gi",
+        "capacity": "50Gi",
+        "file": "50Gi",
+        "pvcCount": 20,
+      },
     },
     Object {
       "clusters": Array [
@@ -235,48 +351,53 @@ Object {
           "provisioned": false,
         },
       ],
+      "cpu": Object {
+        "limits": 8,
+        "requests": 4,
+      },
+      "memory": Object {
+        "limits": "32Gi",
+        "requests": "16Gi",
+      },
       "name": "4ea35c-prod",
       "namespaceId": 16,
+      "quota": "small",
+      "storage": Object {
+        "backup": "25Gi",
+        "block": "50Gi",
+        "capacity": "50Gi",
+        "file": "50Gi",
+        "pvcCount": 20,
+      },
     },
   ],
-  "newDisplayName": "NULL",
-  "productOwner": Object {
-    "email": "jane@example.com",
-    "provider": "github",
-    "userId": "janedoe",
-  },
-  "profileId": 4,
-  "quota": "small",
-  "quotas": Object {
-    "cpu": Object {
-      "limits": 8,
-      "requests": 4,
-    },
-    "memory": Object {
-      "limits": "32Gi",
-      "requests": "16Gi",
-    },
-    "storage": Object {
-      "backup": "25Gi",
-      "block": "50Gi",
-      "capacity": "50Gi",
-      "file": "50Gi",
-    },
-  },
-  "technicalContact": Object {
-    "email": "jim@example.com",
-    "provider": "github",
-    "userId": "jim1100",
-  },
-  "type": "standard",
+  "profile_id": 4,
 }
 `;
 
 exports[`Fulfillment utility creates the profile edit context 1`] = `
 Object {
   "action": "edit",
+  "cluster_id": 1,
+  "cluster_name": "silver",
+  "contacts": Array [
+    Object {
+      "email": "jane@example.com",
+      "provider": "github",
+      "rocketchat_username": null,
+      "role": "owner",
+      "user_id": "jane1100",
+    },
+    Object {
+      "email": "john@example.com",
+      "provider": "github",
+      "rocketchat_username": null,
+      "role": "lead",
+      "user_id": "john1100",
+    },
+  ],
   "description": "This is a cool edited project.",
-  "displayName": "Project X",
+  "display_name": "Project X",
   "namespaces": Array [
     Object {
       "clusters": Array [
@@ -286,8 +407,24 @@ Object {
           "provisioned": false,
         },
       ],
+      "cpu": Object {
+        "limits": 8,
+        "requests": 4,
+      },
+      "memory": Object {
+        "limits": "32Gi",
+        "requests": "16Gi",
+      },
       "name": "4ea35c-tools",
       "namespaceId": 13,
+      "quota": "small",
+      "storage": Object {
+        "backup": "25Gi",
+        "block": "50Gi",
+        "capacity": "50Gi",
+        "file": "50Gi",
+        "pvcCount": 20,
+      },
     },
     Object {
       "clusters": Array [
@@ -297,8 +434,24 @@ Object {
           "provisioned": false,
         },
       ],
+      "cpu": Object {
+        "limits": 8,
+        "requests": 4,
+      },
+      "memory": Object {
+        "limits": "32Gi",
+        "requests": "16Gi",
+      },
       "name": "4ea35c-test",
       "namespaceId": 14,
+      "quota": "small",
+      "storage": Object {
+        "backup": "25Gi",
+        "block": "50Gi",
+        "capacity": "50Gi",
+        "file": "50Gi",
+        "pvcCount": 20,
+      },
     },
     Object {
       "clusters": Array [
@@ -308,8 +461,24 @@ Object {
           "provisioned": false,
         },
       ],
+      "cpu": Object {
+        "limits": 8,
+        "requests": 4,
+      },
+      "memory": Object {
+        "limits": "32Gi",
+        "requests": "16Gi",
+      },
       "name": "4ea35c-dev",
       "namespaceId": 15,
+      "quota": "small",
+      "storage": Object {
+        "backup": "25Gi",
+        "block": "50Gi",
+        "capacity": "50Gi",
+        "file": "50Gi",
+        "pvcCount": 20,
+      },
     },
     Object {
       "clusters": Array [
@@ -319,48 +488,53 @@ Object {
           "provisioned": false,
         },
       ],
+      "cpu": Object {
+        "limits": 8,
+        "requests": 4,
+      },
+      "memory": Object {
+        "limits": "32Gi",
+        "requests": "16Gi",
+      },
       "name": "4ea35c-prod",
       "namespaceId": 16,
+      "quota": "small",
+      "storage": Object {
+        "backup": "25Gi",
+        "block": "50Gi",
+        "capacity": "50Gi",
+        "file": "50Gi",
+        "pvcCount": 20,
+      },
     },
   ],
-  "newDisplayName": "NULL",
-  "productOwner": Object {
-    "email": "jane@example.com",
-    "provider": "github",
-    "userId": "jane1100",
-  },
-  "profileId": 4,
-  "quota": "small",
-  "quotas": Object {
-    "cpu": Object {
-      "limits": 8,
-      "requests": 4,
-    },
-    "memory": Object {
-      "limits": "32Gi",
-      "requests": "16Gi",
-    },
-    "storage": Object {
-      "backup": "25Gi",
-      "block": "50Gi",
-      "capacity": "50Gi",
-      "file": "50Gi",
-    },
-  },
-  "technicalContact": Object {
-    "email": "john@example.com",
-    "provider": "github",
-    "userId": "john1100",
-  },
-  "type": "standard",
+  "profile_id": 4,
 }
 `;
 
 exports[`Fulfillment utility creates the quota edit context 1`] = `
 Object {
   "action": "edit",
+  "cluster_id": 1,
+  "cluster_name": "silver",
+  "contacts": Array [
+    Object {
+      "email": "jane@example.com",
+      "provider": "github",
+      "rocketchat_username": null,
+      "role": "owner",
+      "user_id": "jane1100",
+    },
+    Object {
+      "email": "john@example.com",
+      "provider": "github",
+      "rocketchat_username": null,
+      "role": "lead",
+      "user_id": "john1100",
+    },
+  ],
   "description": "This is a cool project.",
-  "displayName": "Project X",
+  "display_name": "Project X",
   "namespaces": Array [
     Object {
       "clusters": Array [
@@ -370,8 +544,24 @@ Object {
           "provisioned": false,
         },
       ],
+      "cpu": Object {
+        "limits": 8,
+        "requests": 4,
+      },
+      "memory": Object {
+        "limits": "32Gi",
+        "requests": "16Gi",
+      },
       "name": "4ea35c-tools",
       "namespaceId": 13,
+      "quota": "small",
+      "storage": Object {
+        "backup": "25Gi",
+        "block": "50Gi",
+        "capacity": "50Gi",
+        "file": "50Gi",
+        "pvcCount": 20,
+      },
     },
     Object {
       "clusters": Array [
@@ -381,8 +571,24 @@ Object {
           "provisioned": false,
         },
       ],
+      "cpu": Object {
+        "limits": 8,
+        "requests": 4,
+      },
+      "memory": Object {
+        "limits": "32Gi",
+        "requests": "16Gi",
+      },
       "name": "4ea35c-test",
       "namespaceId": 14,
+      "quota": "small",
+      "storage": Object {
+        "backup": "25Gi",
+        "block": "50Gi",
+        "capacity": "50Gi",
+        "file": "50Gi",
+        "pvcCount": 20,
+      },
     },
     Object {
       "clusters": Array [
@@ -392,8 +598,24 @@ Object {
           "provisioned": false,
         },
       ],
+      "cpu": Object {
+        "limits": 8,
+        "requests": 4,
+      },
+      "memory": Object {
+        "limits": "32Gi",
+        "requests": "16Gi",
+      },
       "name": "4ea35c-dev",
       "namespaceId": 15,
+      "quota": "small",
+      "storage": Object {
+        "backup": "25Gi",
+        "block": "50Gi",
+        "capacity": "50Gi",
+        "file": "50Gi",
+        "pvcCount": 20,
+      },
     },
     Object {
       "clusters": Array [
@@ -403,39 +625,26 @@ Object {
           "provisioned": false,
         },
       ],
+      "cpu": Object {
+        "limits": 8,
+        "requests": 4,
+      },
+      "memory": Object {
+        "limits": "32Gi",
+        "requests": "16Gi",
+      },
       "name": "4ea35c-prod",
       "namespaceId": 16,
+      "quota": "small",
+      "storage": Object {
+        "backup": "25Gi",
+        "block": "50Gi",
+        "capacity": "50Gi",
+        "file": "50Gi",
+        "pvcCount": 20,
+      },
     },
   ],
-  "newDisplayName": "NULL",
-  "productOwner": Object {
-    "email": "jane@example.com",
-    "provider": "github",
-    "userId": "jane1100",
-  },
-  "profileId": 4,
-  "quota": "small",
-  "quotas": Object {
-    "cpu": Object {
-      "limits": 8,
-      "requests": 4,
-    },
-    "memory": Object {
-      "limits": "32Gi",
-      "requests": "16Gi",
-    },
-    "storage": Object {
-      "backup": "25Gi",
-      "block": "50Gi",
-      "capacity": "50Gi",
-      "file": "50Gi",
-    },
-  },
-  "technicalContact": Object {
-    "email": "john@example.com",
-    "provider": "github",
-    "userId": "john1100",
-  },
-  "type": "standard",
+  "profile_id": 4,
 }
 `;

--- a/api/__tests__/__snapshots__/fulfillment.spec.ts.snap
+++ b/api/__tests__/__snapshots__/fulfillment.spec.ts.snap
@@ -92,7 +92,7 @@ Array [
       "values": Array [
         3,
         "registry_project_provisioning_silver",
-        "{\\"action\\":\\"create\\",\\"profile_id\\":4,\\"cluster_id\\":1,\\"cluster_name\\":\\"silver\\",\\"display_name\\":\\"Project X\\",\\"description\\":\\"This is a cool project.\\",\\"namespaces\\":[{\\"namespaceId\\":13,\\"name\\":\\"4ea35c-tools\\",\\"clusters\\":[{\\"clusterId\\":1,\\"name\\":\\"silver\\",\\"provisioned\\":false}],\\"quota\\":\\"small\\",\\"quotas\\":{\\"cpu\\":{\\"requests\\":4,\\"limits\\":8},\\"memory\\":{\\"requests\\":\\"16Gi\\",\\"limits\\":\\"32Gi\\"},\\"storage\\":{\\"block\\":\\"50Gi\\",\\"file\\":\\"50Gi\\",\\"backup\\":\\"25Gi\\",\\"capacity\\":\\"50Gi\\",\\"pvcCount\\":20}}},{\\"namespaceId\\":14,\\"name\\":\\"4ea35c-test\\",\\"clusters\\":[{\\"clusterId\\":1,\\"name\\":\\"silver\\",\\"provisioned\\":false}],\\"quota\\":\\"small\\",\\"quotas\\":{\\"cpu\\":{\\"requests\\":4,\\"limits\\":8},\\"memory\\":{\\"requests\\":\\"16Gi\\",\\"limits\\":\\"32Gi\\"},\\"storage\\":{\\"block\\":\\"50Gi\\",\\"file\\":\\"50Gi\\",\\"backup\\":\\"25Gi\\",\\"capacity\\":\\"50Gi\\",\\"pvcCount\\":20}}},{\\"namespaceId\\":15,\\"name\\":\\"4ea35c-dev\\",\\"clusters\\":[{\\"clusterId\\":1,\\"name\\":\\"silver\\",\\"provisioned\\":false}],\\"quota\\":\\"small\\",\\"quotas\\":{\\"cpu\\":{\\"requests\\":4,\\"limits\\":8},\\"memory\\":{\\"requests\\":\\"16Gi\\",\\"limits\\":\\"32Gi\\"},\\"storage\\":{\\"block\\":\\"50Gi\\",\\"file\\":\\"50Gi\\",\\"backup\\":\\"25Gi\\",\\"capacity\\":\\"50Gi\\",\\"pvcCount\\":20}}},{\\"namespaceId\\":16,\\"name\\":\\"4ea35c-prod\\",\\"clusters\\":[{\\"clusterId\\":1,\\"name\\":\\"silver\\",\\"provisioned\\":false}],\\"quota\\":\\"small\\",\\"quotas\\":{\\"cpu\\":{\\"requests\\":4,\\"limits\\":8},\\"memory\\":{\\"requests\\":\\"16Gi\\",\\"limits\\":\\"32Gi\\"},\\"storage\\":{\\"block\\":\\"50Gi\\",\\"file\\":\\"50Gi\\",\\"backup\\":\\"25Gi\\",\\"capacity\\":\\"50Gi\\",\\"pvcCount\\":20}}}],\\"contacts\\":[{\\"user_id\\":\\"jane1100\\",\\"provider\\":\\"github\\",\\"email\\":\\"jane@example.com\\",\\"rocketchat_username\\":null,\\"role\\":\\"owner\\"},{\\"user_id\\":\\"john1100\\",\\"provider\\":\\"github\\",\\"email\\":\\"john@example.com\\",\\"rocketchat_username\\":null,\\"role\\":\\"lead\\"}]}",
+        "{\\"action\\":\\"create\\",\\"profile_id\\":4,\\"cluster_id\\":1,\\"cluster_name\\":\\"silver\\",\\"display_name\\":\\"Project X\\",\\"description\\":\\"This is a cool project.\\",\\"namespaces\\":[{\\"name\\":\\"4ea35c-tools\\",\\"quota\\":\\"small\\",\\"quotas\\":{\\"cpu\\":{\\"requests\\":4,\\"limits\\":8},\\"memory\\":{\\"requests\\":\\"16Gi\\",\\"limits\\":\\"32Gi\\"},\\"storage\\":{\\"block\\":\\"50Gi\\",\\"file\\":\\"50Gi\\",\\"backup\\":\\"25Gi\\",\\"capacity\\":\\"50Gi\\",\\"pvc_count\\":20}}},{\\"name\\":\\"4ea35c-test\\",\\"quota\\":\\"small\\",\\"quotas\\":{\\"cpu\\":{\\"requests\\":4,\\"limits\\":8},\\"memory\\":{\\"requests\\":\\"16Gi\\",\\"limits\\":\\"32Gi\\"},\\"storage\\":{\\"block\\":\\"50Gi\\",\\"file\\":\\"50Gi\\",\\"backup\\":\\"25Gi\\",\\"capacity\\":\\"50Gi\\",\\"pvc_count\\":20}}},{\\"name\\":\\"4ea35c-dev\\",\\"quota\\":\\"small\\",\\"quotas\\":{\\"cpu\\":{\\"requests\\":4,\\"limits\\":8},\\"memory\\":{\\"requests\\":\\"16Gi\\",\\"limits\\":\\"32Gi\\"},\\"storage\\":{\\"block\\":\\"50Gi\\",\\"file\\":\\"50Gi\\",\\"backup\\":\\"25Gi\\",\\"capacity\\":\\"50Gi\\",\\"pvc_count\\":20}}},{\\"name\\":\\"4ea35c-prod\\",\\"quota\\":\\"small\\",\\"quotas\\":{\\"cpu\\":{\\"requests\\":4,\\"limits\\":8},\\"memory\\":{\\"requests\\":\\"16Gi\\",\\"limits\\":\\"32Gi\\"},\\"storage\\":{\\"block\\":\\"50Gi\\",\\"file\\":\\"50Gi\\",\\"backup\\":\\"25Gi\\",\\"capacity\\":\\"50Gi\\",\\"pvc_count\\":20}}}],\\"contacts\\":[{\\"user_id\\":\\"jane1100\\",\\"provider\\":\\"github\\",\\"email\\":\\"jane@example.com\\",\\"rocketchat_username\\":null,\\"role\\":\\"owner\\"},{\\"user_id\\":\\"john1100\\",\\"provider\\":\\"github\\",\\"email\\":\\"john@example.com\\",\\"rocketchat_username\\":null,\\"role\\":\\"lead\\"}]}",
         "silver",
         false,
       ],
@@ -126,15 +126,7 @@ Object {
   "display_name": "Project X",
   "namespaces": Array [
     Object {
-      "clusters": Array [
-        Object {
-          "clusterId": 1,
-          "name": "silver",
-          "provisioned": false,
-        },
-      ],
       "name": "4ea35c-tools",
-      "namespaceId": 13,
       "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
@@ -151,20 +143,12 @@ Object {
           "block": "50Gi",
           "capacity": "50Gi",
           "file": "50Gi",
-          "pvcCount": 20,
+          "pvc_count": undefined,
         },
       },
     },
     Object {
-      "clusters": Array [
-        Object {
-          "clusterId": 1,
-          "name": "silver",
-          "provisioned": false,
-        },
-      ],
       "name": "4ea35c-test",
-      "namespaceId": 14,
       "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
@@ -181,20 +165,12 @@ Object {
           "block": "50Gi",
           "capacity": "50Gi",
           "file": "50Gi",
-          "pvcCount": 20,
+          "pvc_count": undefined,
         },
       },
     },
     Object {
-      "clusters": Array [
-        Object {
-          "clusterId": 1,
-          "name": "silver",
-          "provisioned": false,
-        },
-      ],
       "name": "4ea35c-dev",
-      "namespaceId": 15,
       "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
@@ -211,20 +187,12 @@ Object {
           "block": "50Gi",
           "capacity": "50Gi",
           "file": "50Gi",
-          "pvcCount": 20,
+          "pvc_count": undefined,
         },
       },
     },
     Object {
-      "clusters": Array [
-        Object {
-          "clusterId": 1,
-          "name": "silver",
-          "provisioned": false,
-        },
-      ],
       "name": "4ea35c-prod",
-      "namespaceId": 16,
       "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
@@ -241,7 +209,7 @@ Object {
           "block": "50Gi",
           "capacity": "50Gi",
           "file": "50Gi",
-          "pvcCount": 20,
+          "pvc_count": undefined,
         },
       },
     },
@@ -275,15 +243,7 @@ Object {
   "display_name": "Project X",
   "namespaces": Array [
     Object {
-      "clusters": Array [
-        Object {
-          "clusterId": 1,
-          "name": "silver",
-          "provisioned": false,
-        },
-      ],
       "name": "4ea35c-tools",
-      "namespaceId": 13,
       "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
@@ -300,20 +260,12 @@ Object {
           "block": "50Gi",
           "capacity": "50Gi",
           "file": "50Gi",
-          "pvcCount": 20,
+          "pvc_count": undefined,
         },
       },
     },
     Object {
-      "clusters": Array [
-        Object {
-          "clusterId": 1,
-          "name": "silver",
-          "provisioned": false,
-        },
-      ],
       "name": "4ea35c-test",
-      "namespaceId": 14,
       "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
@@ -330,20 +282,12 @@ Object {
           "block": "50Gi",
           "capacity": "50Gi",
           "file": "50Gi",
-          "pvcCount": 20,
+          "pvc_count": undefined,
         },
       },
     },
     Object {
-      "clusters": Array [
-        Object {
-          "clusterId": 1,
-          "name": "silver",
-          "provisioned": false,
-        },
-      ],
       "name": "4ea35c-dev",
-      "namespaceId": 15,
       "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
@@ -360,20 +304,12 @@ Object {
           "block": "50Gi",
           "capacity": "50Gi",
           "file": "50Gi",
-          "pvcCount": 20,
+          "pvc_count": undefined,
         },
       },
     },
     Object {
-      "clusters": Array [
-        Object {
-          "clusterId": 1,
-          "name": "silver",
-          "provisioned": false,
-        },
-      ],
       "name": "4ea35c-prod",
-      "namespaceId": 16,
       "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
@@ -390,7 +326,7 @@ Object {
           "block": "50Gi",
           "capacity": "50Gi",
           "file": "50Gi",
-          "pvcCount": 20,
+          "pvc_count": undefined,
         },
       },
     },
@@ -424,15 +360,7 @@ Object {
   "display_name": "Project X",
   "namespaces": Array [
     Object {
-      "clusters": Array [
-        Object {
-          "clusterId": 1,
-          "name": "silver",
-          "provisioned": false,
-        },
-      ],
       "name": "4ea35c-tools",
-      "namespaceId": 13,
       "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
@@ -449,20 +377,12 @@ Object {
           "block": "50Gi",
           "capacity": "50Gi",
           "file": "50Gi",
-          "pvcCount": 20,
+          "pvc_count": undefined,
         },
       },
     },
     Object {
-      "clusters": Array [
-        Object {
-          "clusterId": 1,
-          "name": "silver",
-          "provisioned": false,
-        },
-      ],
       "name": "4ea35c-test",
-      "namespaceId": 14,
       "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
@@ -479,20 +399,12 @@ Object {
           "block": "50Gi",
           "capacity": "50Gi",
           "file": "50Gi",
-          "pvcCount": 20,
+          "pvc_count": undefined,
         },
       },
     },
     Object {
-      "clusters": Array [
-        Object {
-          "clusterId": 1,
-          "name": "silver",
-          "provisioned": false,
-        },
-      ],
       "name": "4ea35c-dev",
-      "namespaceId": 15,
       "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
@@ -509,20 +421,12 @@ Object {
           "block": "50Gi",
           "capacity": "50Gi",
           "file": "50Gi",
-          "pvcCount": 20,
+          "pvc_count": undefined,
         },
       },
     },
     Object {
-      "clusters": Array [
-        Object {
-          "clusterId": 1,
-          "name": "silver",
-          "provisioned": false,
-        },
-      ],
       "name": "4ea35c-prod",
-      "namespaceId": 16,
       "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
@@ -539,7 +443,7 @@ Object {
           "block": "50Gi",
           "capacity": "50Gi",
           "file": "50Gi",
-          "pvcCount": 20,
+          "pvc_count": undefined,
         },
       },
     },
@@ -573,15 +477,7 @@ Object {
   "display_name": "Project X",
   "namespaces": Array [
     Object {
-      "clusters": Array [
-        Object {
-          "clusterId": 1,
-          "name": "silver",
-          "provisioned": false,
-        },
-      ],
       "name": "4ea35c-tools",
-      "namespaceId": 13,
       "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
@@ -598,20 +494,12 @@ Object {
           "block": "50Gi",
           "capacity": "50Gi",
           "file": "50Gi",
-          "pvcCount": 20,
+          "pvc_count": undefined,
         },
       },
     },
     Object {
-      "clusters": Array [
-        Object {
-          "clusterId": 1,
-          "name": "silver",
-          "provisioned": false,
-        },
-      ],
       "name": "4ea35c-test",
-      "namespaceId": 14,
       "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
@@ -628,20 +516,12 @@ Object {
           "block": "50Gi",
           "capacity": "50Gi",
           "file": "50Gi",
-          "pvcCount": 20,
+          "pvc_count": undefined,
         },
       },
     },
     Object {
-      "clusters": Array [
-        Object {
-          "clusterId": 1,
-          "name": "silver",
-          "provisioned": false,
-        },
-      ],
       "name": "4ea35c-dev",
-      "namespaceId": 15,
       "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
@@ -658,20 +538,12 @@ Object {
           "block": "50Gi",
           "capacity": "50Gi",
           "file": "50Gi",
-          "pvcCount": 20,
+          "pvc_count": undefined,
         },
       },
     },
     Object {
-      "clusters": Array [
-        Object {
-          "clusterId": 1,
-          "name": "silver",
-          "provisioned": false,
-        },
-      ],
       "name": "4ea35c-prod",
-      "namespaceId": 16,
       "namespace_id": undefined,
       "quota": "small",
       "quotas": Object {
@@ -688,7 +560,7 @@ Object {
           "block": "50Gi",
           "capacity": "50Gi",
           "file": "50Gi",
-          "pvcCount": 20,
+          "pvc_count": undefined,
         },
       },
     },

--- a/api/__tests__/fulfillment.spec.ts
+++ b/api/__tests__/fulfillment.spec.ts
@@ -48,6 +48,9 @@ const contactEditObject = fs.readFileSync(p7, 'utf8');
 const p9 = path.join(__dirname, 'fixtures/get-bot-message-set.json');
 const botMessageSet = JSON.parse(fs.readFileSync(p9, 'utf8'));
 
+const p10 = path.join(__dirname, 'fixtures/select-default-cluster.json');
+const profileCluster = JSON.parse(fs.readFileSync(p10, 'utf8'));
+
 jest.mock('../src/libs/profile', () => {
   return {
     getQuotaSize: jest.fn().mockResolvedValue(QuotaSize.Small),
@@ -77,6 +80,7 @@ describe('Fulfillment utility', () => {
     client.query.mockReturnValueOnce({ rows: quotas });
     // buildContext
     client.query.mockReturnValueOnce({ rows: profileClusterNamespaces });
+    client.query.mockReturnValueOnce({ rows: [{id: 1, name: 'silver'}] });
     // createBotMessageSet
     client.query.mockReturnValueOnce({ rows: [{name: 'silver'}] });
     client.query.mockReturnValueOnce({ rows: botMessageSet });
@@ -96,6 +100,7 @@ describe('Fulfillment utility', () => {
     client.query.mockReturnValueOnce({ rows: contacts });
     client.query.mockReturnValueOnce({ rows: quotas });
     client.query.mockReturnValueOnce({ rows: profileClusterNamespaces });
+    client.query.mockReturnValueOnce({ rows: profileCluster });
     const result = await contextForProvisioning(12345, false);
 
     expect(result).toBeDefined();
@@ -108,6 +113,7 @@ describe('Fulfillment utility', () => {
     client.query.mockReturnValueOnce({ rows: [] });
     client.query.mockReturnValueOnce({ rows: quotas });
     client.query.mockReturnValueOnce({ rows: profileClusterNamespaces });
+    client.query.mockReturnValueOnce({ rows: profileCluster });
 
     await expect(contextForProvisioning(12345, false)).rejects.toThrow();
   });
@@ -127,6 +133,8 @@ describe('Fulfillment utility', () => {
     client.query.mockReturnValueOnce({ rows: quotas });
     client.query.mockReturnValueOnce({ rows: contacts });
     client.query.mockReturnValueOnce({ rows: profileClusterNamespaces });
+    client.query.mockReturnValueOnce({ rows: profileCluster });
+
     const result = await contextForEditing(12345, requestEditType, requestEditObject);
 
     expect(result).toBeDefined();
@@ -140,6 +148,8 @@ describe('Fulfillment utility', () => {
     client.query.mockReturnValueOnce({ rows: profile });
     client.query.mockReturnValueOnce({ rows: quotas });
     client.query.mockReturnValueOnce({ rows: profileClusterNamespaces });
+    client.query.mockReturnValueOnce({ rows: profileCluster });
+
     const result = await contextForEditing(12345, requestEditType, requestEditObject);
 
     expect(result).toBeDefined();
@@ -156,6 +166,8 @@ describe('Fulfillment utility', () => {
 
     client.query.mockReturnValueOnce({ rows: contacts });
     client.query.mockReturnValueOnce({ rows: profileClusterNamespaces });
+    client.query.mockReturnValueOnce({ rows: profileCluster });
+
     const result = await contextForEditing(12345, requestEditType, requestEditObject);
 
     expect(result).toBeDefined();
@@ -172,6 +184,7 @@ describe('Fulfillment utility', () => {
     client.query.mockReturnValueOnce({ rows: profile });
     client.query.mockReturnValueOnce({ rows: [] });
     client.query.mockReturnValueOnce({ rows: profileClusterNamespaces });
+    client.query.mockReturnValueOnce({ rows: profileCluster });
 
     await expect(contextForEditing(12345, requestEditType, requestEditObject)).rejects.toThrow();
   });

--- a/api/src/db/model/namespace.ts
+++ b/api/src/db/model/namespace.ts
@@ -306,7 +306,7 @@ export default class NamespaceModel extends Model {
     }
   }
 
-  private async findNamespacesForProfile(profileId: number): Promise<ProjectNamespace[]> {
+  async findNamespacesForProfile(profileId: number): Promise<ProjectNamespace[]> {
     const query = {
       text: `
         SELECT * FROM ${this.table}

--- a/api/src/libs/bot-message.ts
+++ b/api/src/libs/bot-message.ts
@@ -30,7 +30,7 @@ export const createBotMessageSet = async ( requestId: number, natsSubject: strin
       throw new Error('Cant get profile id');
   }
 
-  const clusters = await NamespaceModel.findClustersForProfile(natsContext.profileId);
+  const clusters = await NamespaceModel.findClustersForProfile(natsContext.profile_id);
 
   for (const cluster of clusters) {
     await RequestModel.createBotMessage({

--- a/api/src/libs/fulfillment.ts
+++ b/api/src/libs/fulfillment.ts
@@ -128,17 +128,17 @@ const generateContext = async (request: Request): Promise<NatsContext> => {
   }
 }
 
-const formatNamespaces = (namespace, quota, quotas): NatsProjectNamespace => {
-  return {...namespace, quota, ...quotas}
+const formatNamespacesForNats = (namespace, quota, quotas): NatsProjectNamespace => {
+  return {...namespace, quota, quotas}
 }
 
-const formatTechnicalContacts = (contact): NatsContact => {
+const formatContactsForNats = (contact): NatsContact => {
   return {
     user_id: contact.githubId,
     provider: 'github', // TODO:(JL) Fix as part of #94.
     email: contact.email,
     rocketchat_username: null, // TODO:(SB) Update when rocketchat func is implemented
-    role: (contact.roleId === ROLE_IDS.TECHNICAL_CONTACT ? NatsContactRole['Lead'] : NatsContactRole['Owner'])
+    role: (contact.roleId === ROLE_IDS.TECHNICAL_CONTACT ? NatsContactRole.Lead : NatsContactRole.Owner),
   }
 }
 
@@ -150,14 +150,14 @@ const buildContext = async (
       throw new Error('Cant get profile id');
     }
     const namespacesDetails = await NamespaceModel.findNamespacesForProfile(profile.id);
-    
-    const namespaces: NatsProjectNamespace[] = namespacesDetails.map(n => formatNamespaces(n, quotaSize, quotas))
+
+    const namespaces: NatsProjectNamespace[] = namespacesDetails.map(n => formatNamespacesForNats(n, quotaSize, quotas))
 
     const cluster = await ClusterModel.findByName(profile.primaryClusterName);
 
-    const contacts: NatsContact[] = profileContacts.map(contact => formatTechnicalContacts(contact));
+    const contacts: NatsContact[] = profileContacts.map(contact => formatContactsForNats(contact));
 
-    if (!profile || !namespaces || !cluster.id || contacts.length == 0) {
+    if (!profile || !namespaces || !cluster.id || contacts.length === 0) {
       throw new Error('Missing arguments to build nats context');
     }
 

--- a/api/src/libs/fulfillment.ts
+++ b/api/src/libs/fulfillment.ts
@@ -129,7 +129,9 @@ const generateContext = async (request: Request): Promise<NatsContext> => {
 }
 
 const formatNamespacesForNats = (namespace, quota, quotas): NatsProjectNamespace => {
-  return {...namespace, quota, quotas}
+  namespace.namespace_id = namespace.id;
+  delete namespace.id;
+  return {...namespace, quota, quotas};
 }
 
 const formatContactsForNats = (contact): NatsContact => {

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 
-import { ProjectNamespace } from './db/model/namespace';
 import { Quotas, QuotaSize } from './db/model/quota';
 
 export const enum NatsContextAction {
@@ -23,31 +22,39 @@ export const enum NatsContextAction {
     Sync = 'sync',
 }
 
-export const enum NatsContextType {
-    Standard = 'standard',
+export const enum NatsContactRole {
+    Owner = 'owner',
+    Lead = 'lead',
+    Contact = 'contact',
 }
 
-// the agreed json structure between api and provisioner
-export interface NatsContext {
-    action: NatsContextAction,
-    type: NatsContextType,
-    profileId: number,
-    displayName: string,
-    newDisplayName: string,
-    description: string,
+export interface NatsContact {
+    user_id: string,
+    provider: string,
+    email: string,
+    rocketchat_username: null,
+    role: NatsContactRole,
+}
+
+export interface NatsProjectNamespace {
+    id: number,
+    name: string,
     quota: QuotaSize,
     quotas: Quotas,
-    namespaces: ProjectNamespace[],
-    technicalContact: {
-        userId: string,
-        provider: string,
-        email: string,
-    },
-    productOwner: {
-        userId: string,
-        provider: string,
-        email: string,
-    },
+
+}
+
+// To avoid issues with provisioner, snake case is the preferred
+// pattern for the NatsContext. 
+export interface NatsContext {
+    action: NatsContextAction,
+    profile_id: number,
+    cluster_id: number,
+    cluster_name: string,
+    display_name: string,
+    description: string,
+    namespaces: NatsProjectNamespace[],
+    contacts: NatsContact[];
 }
 
 // TODO: a bit hacky to name data members off the actual tool name

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -37,7 +37,7 @@ export interface NatsContact {
 }
 
 export interface NatsProjectNamespace {
-    id: number,
+    namespace_id: number,
     name: string,
     quota: QuotaSize,
     quotas: Quotas,

--- a/web/.eslintrc
+++ b/web/.eslintrc
@@ -1,6 +1,11 @@
 {
   "plugins": ["prettier", "@typescript-eslint"],
-  "extends": ["airbnb-typescript", "react-app", "prettier"],
+  "extends": [
+    "airbnb-typescript", 
+    "react-app",  
+    "prettier/@typescript-eslint",
+    "plugin:prettier/recommended"
+  ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "project": "./tsconfig.json"

--- a/web/src/views/Dashboard.tsx
+++ b/web/src/views/Dashboard.tsx
@@ -36,7 +36,7 @@ import {
   getProfileContacts,
   isProfileProvisioned,
   sortProfileByDatetime,
-  transformJsonToCsv
+  transformJsonToCsv,
 } from '../utils/transformDataHelper';
 
 const Dashboard: React.FC = () => {


### PR DESCRIPTION
As noted in [ticket #1274](https://app.zenhub.com/workspaces/platform-experience-5bb7c5ab4b5806bc2beb9d15/issues/bcdevops/developer-experience/1274) the JSON message between the Registry and the Provisioner required some refactoring.

This PR refactors the namespace and contact logic to align with the new format. 

Note: The NATS interface has been documented in snake case instead of the conventional camel case used throughout the Registry. I figured this would avoid potential incidents in the future of expected output vs modifying the JSON payload from camelCase to snake_case immediately before transmission. I am open to thoughts regarding this design decision though.