### PR TITLE
Remove unique profile name constraint

### DIFF
--- a/db/sql/V2.4__remove_unique_profile_name_constraint.sql
+++ b/db/sql/V2.4__remove_unique_profile_name_constraint.sql
@@ -1,0 +1,6 @@
+BEGIN TRANSACTION;
+
+ALTER TABLE profile
+DROP CONSTRAINT profile_name_unique;
+
+END TRANSACTION;


### PR DESCRIPTION
Due to the revised gitops storage organization, teams can now edit project names as they wish. This no longer requires project names to be unique as a result. This PR removes the unique profile name constraint from the database.