### PR TITLE
Fix flyway Dockerfile

### DIFF
--- a/db/flyway.Dockerfile
+++ b/db/flyway.Dockerfile
@@ -1,9 +1,10 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11
+FROM registry.access.redhat.com/ubi8/openjdk-11:latest
 
 RUN mkdir flyway
 WORKDIR /flyway
 
 USER 0
+RUN microdnf -y install gzip
 
 ENV FLYWAY_VERSION 7.5.3
 
@@ -17,4 +18,4 @@ COPY sql/*.sql /flyway/sql/
 
 RUN chmod -R 777 .
 
-USER 1001
+USER jboss


### PR DESCRIPTION
flyway master build uses UBI image "registry.access.redhat.com/ubi8/openjdk-11", which was just updated, causing the build to break.  The Dockerfile (flyway.Dockerfile in this case) has been updated to accommodate the change.