### PR TITLE
Dashboard filter feature

### DIFF
--- a/web/src/components/common/UI/Table.tsx
+++ b/web/src/components/common/UI/Table.tsx
@@ -20,6 +20,7 @@ import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { useAsyncDebounce, useFilters, useGlobalFilter, useSortBy, useTable } from 'react-table';
 import { Box, Flex, Heading } from 'rebass';
+import useComponentVisible from '../../../hooks/useComponentVisible';
 import theme from '../../../theme';
 import Icon from './Icon';
 
@@ -221,7 +222,21 @@ const Table: React.FC<ITableProps> = (props) => {
   const handleRowClick = (row: any) => {
     history.push(`/profile/${row.original.id}/overview`);
   };
-
+  const StyledDropdown = styled.div`
+  display: block;
+  position: absolute;
+  min-width: 100px;
+  margin-right: 15px;
+  padding: 5px;
+  background-color: ${theme.colors.contrast};
+  border: 1px solid #000;
+  zindex: ${theme.zIndices[2]};
+`;
+  const { isComponentVisible, setIsComponentVisible } = useComponentVisible(false);
+  const handleDDDesktop = () => {
+    setIsComponentVisible(!isComponentVisible);
+  };
+  
   /* 
     Render the UI for your table
     - react-table doesn't have UI, it's headless. We just need to put the react-table props from the Hooks, and it will do its magic automatically
@@ -231,33 +246,40 @@ const Table: React.FC<ITableProps> = (props) => {
       <Flex flexWrap="wrap">
         <Heading>{title}</Heading>
         <Box mx='auto' />
+
+        <Box>
         <Icon
           hover
           color="primary"
           name='menuStack'
           width={1.4}
           height={1.4}
-          style={{margin: '14px 0 5px 0'}}
+          style={{margin: '14px 5px 5px 0', transform: 'rotate(90deg)', zIndex: 5}}
+          onClick={handleDDDesktop}
         />
+        {isComponentVisible && (
+          <StyledDropdown>
+            <div>
+              {allColumns.map(column => (
+                <div key={column.id}>
+                  <label>
+                    <Flex flexDirection="row">
+                      <Checkbox variant="inlineCheckbox" type="checkbox" {...column.getToggleHiddenProps()} />{' '}
+                      <Label>{column.Header}</Label>
+                    </Flex>
+                  </label>
+                </div>
+              ))}
+              <br />
+            </div>
+          </StyledDropdown>
+        )}</Box>
         <GlobalFilter
           preGlobalFilteredRows={preGlobalFilteredRows}
           globalFilter={state.globalFilter}
           setGlobalFilter={setGlobalFilter}
         />
       </Flex>
-      <div>
-        {allColumns.map(column => (
-          <div key={column.id}>
-            <label>
-              <Flex flexDirection="row">
-                <Checkbox variant="inlineCheckbox" type="checkbox" {...column.getToggleHiddenProps()} />{' '}
-                <Label>{column.Header}</Label>
-              </Flex>
-            </label>
-          </div>
-        ))}
-        <br />
-      </div>
       <table {...getTableProps()}>
         <thead>
           {headerGroups.map((headerGroup) => {

--- a/web/src/components/dashboard/ProjectDetails.tsx
+++ b/web/src/components/dashboard/ProjectDetails.tsx
@@ -1,0 +1,79 @@
+//
+// Copyright © 2020 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import React, { useMemo } from 'react';
+import { Box } from 'rebass';
+import Table from '../common/UI/Table';
+
+const ProjectRequests: React.FC<any> = (props) => {
+  const { profileDetails } = props;
+  /* 
+    - Columns is a simple array right now, but it will contain some logic later on. It is recommended by react-table to memoize the columns data
+    - Here in this example, we have grouped our columns into two headers. react-table is flexible enough to create grouped table headers
+  */
+    const columns = useMemo(
+      () => [
+        {
+          Header: 'Name',
+          accessor: 'name',
+        },
+        {
+          Header: 'Description',
+          accessor: 'description',
+        },
+        {
+          Header: 'Ministry',
+          accessor: 'busOrgId',
+        },
+        {
+          Header: 'Cluster',
+          accessor: 'primaryClusterDisplayName',
+        },
+        {
+          Header: 'Product Owner',
+          accessor: 'POEmail',
+        },
+        {
+          Header: 'Technical Contact',
+          accessor: 'TCEmail',
+        },
+        {
+          Header: 'Status',
+          accessor: 'provisioned',
+          Cell: ({ row: { values } }: any) => (values.provisioned ? 'Provisioned' : 'Pending'),
+        },
+        {
+          Header: 'Namespace',
+          accessor: 'namespacePrefix',
+        },
+        {
+          Header: 'Quota',
+          accessor: 'quotaSize',
+        },
+      ],
+      [],
+    );
+
+  return (
+    <div>
+      <Box style={{ overflow: 'auto' }}>
+        <Table columns={columns} data={profileDetails} linkedRows={true} title="Projects" />
+      </Box>
+    </div>
+  );
+};
+
+export default ProjectRequests;

--- a/web/src/components/dashboard/ProjectRequests.tsx
+++ b/web/src/components/dashboard/ProjectRequests.tsx
@@ -15,7 +15,7 @@
 //
 import React, { useEffect, useMemo, useState } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
-import { Box, Heading } from 'rebass';
+import { Box } from 'rebass';
 import useCommonState from '../../hooks/useCommonState';
 import { useModal } from '../../hooks/useModal';
 import useRegistryApi from '../../hooks/useRegistryApi';
@@ -136,8 +136,7 @@ const ProjectRequests: React.FC<any> = (props) => {
         }
       />
       <Box style={{ overflow: 'auto' }}>
-        <Heading>Project Requests</Heading>
-        <Table columns={requestColumns} data={requests} />
+        <Table columns={requestColumns} data={requests} title="Project Requests"/>
       </Box>
     </div>
   );

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -99,5 +99,8 @@ export default {
     checkbox: {
       margin: 'auto',
     },
+    inlineCheckbox: {
+      margin: '14px 0 5px 0',
+    },
   },
 };

--- a/web/src/views/Dashboard.tsx
+++ b/web/src/views/Dashboard.tsx
@@ -15,14 +15,14 @@
 //
 
 import { useKeycloak } from '@react-keycloak/web';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
-import { Box, Heading } from 'rebass';
+import { Box } from 'rebass';
 import { BackdropForPendingItem } from '../components/common/UI/Backdrop';
 import { Button } from '../components/common/UI/Button';
 import { ShadowBox } from '../components/common/UI/ShadowContainer';
-import Table from '../components/common/UI/Table';
 import ProfileCard from '../components/dashboard/ProfileCard';
+import ProjectDetails from '../components/dashboard/ProjectDetails';
 import ProjectRequests from '../components/dashboard/ProjectRequests';
 import { COMPONENT_METADATA, CSV_PROFILE_ATTRIBUTES } from '../constants';
 import useCommonState from '../hooks/useCommonState';
@@ -36,7 +36,7 @@ import {
   getProfileContacts,
   isProfileProvisioned,
   sortProfileByDatetime,
-  transformJsonToCsv,
+  transformJsonToCsv
 } from '../utils/transformDataHelper';
 
 const Dashboard: React.FC = () => {
@@ -155,45 +155,6 @@ const Dashboard: React.FC = () => {
     setTableView(!tableView);
   };
 
-  /* 
-    - Columns is a simple array right now, but it will contain some logic later on. It is recommended by react-table to memoize the columns data
-    - Here in this example, we have grouped our columns into two headers. react-table is flexible enough to create grouped table headers
-  */
-  const columns = useMemo(
-    () => [
-      {
-        Header: 'Name',
-        accessor: 'name',
-      },
-      {
-        Header: 'Description',
-        accessor: 'description',
-      },
-      {
-        Header: 'Ministry',
-        accessor: 'busOrgId',
-      },
-      {
-        Header: 'Cluster',
-        accessor: 'primaryClusterDisplayName',
-      },
-      {
-        Header: 'Product Owner',
-        accessor: 'POEmail',
-      },
-      {
-        Header: 'Technical Contact',
-        accessor: 'TCEmail',
-      },
-      {
-        Header: 'Status',
-        accessor: 'provisioned',
-        Cell: ({ row: { values } }: any) => (values.provisioned ? 'Provisioned' : 'Pending'),
-      },
-    ],
-    [],
-  );
-
   return (
     <>
       {profile.length > 0 && <Button onClick={downloadCSV}>Download CSV</Button>}
@@ -202,10 +163,7 @@ const Dashboard: React.FC = () => {
       {userRoles.includes('administrator') ? <ProjectRequests profileDetails={profile} /> : ''}
 
       {tableView ? (
-        <Box style={{ overflow: 'auto' }}>
-          <Heading>Projects</Heading>
-          <Table columns={columns} data={profile} linkedRows={true} />
-        </Box>
+        <ProjectDetails profileDetails={profile} />
       ) : (
         <div>
           {/* Project Cards */}


### PR DESCRIPTION
This PR introduces a dashboard table search capability as well as additional column views.

Users will be able to select from the following columns, with the last two hidden by default but still searchable:
- Name
- Description
- Ministry
- Cluster
- Product Owner
- Technical Contact
- Status
- Namespace*
- Quota*

Still to do / investigate:
- [ ] Fix Icon for Column checkboxs
- [X] configure checkboxes into dropdown
- [ ] fix styling on Search box

Fixes #155