### PR TITLE
Update sync pending project details fetch

### DIFF
--- a/api/src/controllers/sync.ts
+++ b/api/src/controllers/sync.ts
@@ -20,7 +20,7 @@ import { errorWithCode, logger } from '@bcgov/common-nodejs-utils';
 import { Request, Response } from 'express';
 import DataManager from '../db';
 import { ProjectProfile } from '../db/model/profile';
-import { RequestType } from '../db/model/request';
+import { RequestEditType, RequestType } from '../db/model/request';
 import { contextForEditing, contextForProvisioning } from '../libs/fulfillment';
 import { getProvisionStatus } from '../libs/profile';
 import shared from '../libs/shared';
@@ -148,6 +148,10 @@ export const getProfileBotJsonUnderPending = async (
             const errmsg = `Unable to get request edit Type`;
             throw new Error(errmsg);
           }
+          if (request.editType === RequestEditType.ProjectProfile) {
+            request.editObject = JSON.stringify(request.editObject)
+          }
+
           context = await contextForEditing(profileId, request.editType, request.editObject);
           break;
         default:


### PR DESCRIPTION
The sync flow happened to bypass a JSON.stringify step necessary for the buildContext function to run. This PR includes a check for Edit Type and parses the object if it is a project profile.