### PR TITLE
Move receivedHumanAction earlier so it is captured during rejection

### DIFF
--- a/api/src/controllers/request.ts
+++ b/api/src/controllers/request.ts
@@ -65,11 +65,12 @@ export const updateRequestHumanAction = async (
       userId: user.id,
     });
 
+    await RequestModel.receivedHumanAction(requestId);
+
     // Step 3.a. If approved: fulfillRequest functionality => create bot_message, send NATS message
     // Step 3.b. if rejected: updateRejectProject => archive ProjectSet, Email PO/TC with comment, complete request;
     if (type === HumanActionType.Approve) {
       await fulfillRequest(request);
-      await RequestModel.receivedHumanAction(requestId);
       return res.status(204).end();
     }
 


### PR DESCRIPTION
When a project request gets rejected in the Dashboard approvals, the `requiresHumanAction` flag never gets marked as negative. By moving this functionality outside of the `if (type === HumanActionType.Approve)` check ensures that the field is updated for all human actions.