### PR TITLE
Multiple Technical Leads (Dashboard)

### DIFF
--- a/web/src/components/profileEdit/ContactCardEdit.tsx
+++ b/web/src/components/profileEdit/ContactCardEdit.tsx
@@ -26,7 +26,7 @@ import {
   MINIMUM_TECHNICAL_LEADS,
   PROFILE_EDIT_VIEW_NAMES,
   ROLES,
-  ROUTE_PATHS,
+  ROUTE_PATHS
 } from '../../constants';
 import useCommonState from '../../hooks/useCommonState';
 import useRegistryApi from '../../hooks/useRegistryApi';

--- a/web/src/utils/transformDataHelper.tsx
+++ b/web/src/utils/transformDataHelper.tsx
@@ -122,9 +122,13 @@ export function isProfileProvisioned(profile: any, namespaces: any[]): boolean {
 }
 
 export function sortContacts(contacts: ContactDetails[]): ContactDetails[] {
+<<<<<<< HEAD
   return contacts.sort(
     (a: ContactDetails, b: ContactDetails) => Number(a.roleId) - Number(b.roleId),
   );
+=======
+  return contacts.sort((a: ContactDetails, b: ContactDetails) => a.roleId - b.roleId);
+>>>>>>> f55674b (Add multiple Technical Leads to project creation process)
 }
 
 // TODO (sb): Remove this transform when updating dashboard JSON fetch

--- a/web/src/views/ProfileCreate.tsx
+++ b/web/src/views/ProfileCreate.tsx
@@ -26,7 +26,10 @@ import { ROUTE_PATHS } from '../constants';
 import useCommonState from '../hooks/useCommonState';
 import useRegistryApi from '../hooks/useRegistryApi';
 import { promptErrToastWithText, promptSuccessToastWithText } from '../utils/promptToastHelper';
+<<<<<<< HEAD
 import { transformClusters } from '../utils/transformDataHelper';
+=======
+>>>>>>> f55674b (Add multiple Technical Leads to project creation process)
 import Wizard, { WizardPage } from '../utils/Wizard';
 
 const ProfileCreate: React.FC = () => {
@@ -43,7 +46,10 @@ const ProfileCreate: React.FC = () => {
     setOpenBackdrop(true);
     try {
       const technicalContacts = [...technicalLeads, productOwner];
+<<<<<<< HEAD
       const clusters = transformClusters(profile);
+=======
+>>>>>>> f55674b (Add multiple Technical Leads to project creation process)
 
       // 1. Create the project profile.
       const response: any = await api.createProfile(profile);
@@ -56,8 +62,13 @@ const ProfileCreate: React.FC = () => {
         await api.linkContactToProfileById(profileId, tc.data.id);
       }
 
+<<<<<<< HEAD
       // 4. Trigger provisioning
       await api.createNamespaceByProfileId(profileId, clusters);
+=======
+      // 3. Trigger provisioning
+      await api.createNamespaceByProfileId(profileId);
+>>>>>>> f55674b (Add multiple Technical Leads to project creation process)
 
       // 4. Create Project Request
       await api.createProjectRequestByProfileId(profileId);


### PR DESCRIPTION
This PR implements the capability to view multiple technical leads in a project from the Registry dashboard. This PR includes a fairly substantial refactor of the API logic to enable faster loading and enhanced viewing of multiple contacts and clusters.

** NOTE: This PR is the depends upon Multiple Technical Leads (Create and Edit) **

Fixes #450