### PR TITLE
Disable edit logic for Quota edit

### DIFF
--- a/web/src/views/ProfileEdit.tsx
+++ b/web/src/views/ProfileEdit.tsx
@@ -226,11 +226,12 @@ const ProfileEdit: React.FC = (props: any) => {
                     <Text as="h3" color={theme.colors.contrast} mx={2}>
                       {c.title}
                     </Text>
-                    {!profileState.hasPendingEdit && profileState.isProvisioned && (
-                      <RouterLink className="misc-class-m-dropdown-link" to={c.href}>
-                        <Icon hover color="contrast" name="edit" width={1.5} height={1.5} />
-                      </RouterLink>
-                    )}
+                    {(!profileState.hasPendingEdit && profileState.isProvisioned) ||
+                      (c.title === 'Quota Information' && (
+                        <RouterLink className="misc-class-m-dropdown-link" to={c.href}>
+                          <Icon hover color="contrast" name="edit" width={1.5} height={1.5} />
+                        </RouterLink>
+                      ))}
                   </Flex>
                   <ShadowBox p={3} key={profileId} style={{ position: 'relative' }}>
                     {c.component}

--- a/web/src/views/ProfileEdit.tsx
+++ b/web/src/views/ProfileEdit.tsx
@@ -226,12 +226,12 @@ const ProfileEdit: React.FC = (props: any) => {
                     <Text as="h3" color={theme.colors.contrast} mx={2}>
                       {c.title}
                     </Text>
-                    {(!profileState.hasPendingEdit && profileState.isProvisioned) ||
-                      (c.title === 'Quota Information' && (
-                        <RouterLink className="misc-class-m-dropdown-link" to={c.href}>
-                          <Icon hover color="contrast" name="edit" width={1.5} height={1.5} />
-                        </RouterLink>
-                      ))}
+                    {((!profileState.hasPendingEdit && profileState.isProvisioned) ||
+                      c.title === 'Quota Information') && (
+                      <RouterLink className="misc-class-m-dropdown-link" to={c.href}>
+                        <Icon hover color="contrast" name="edit" width={1.5} height={1.5} />
+                      </RouterLink>
+                    )}
                   </Flex>
                   <ShadowBox p={3} key={profileId} style={{ position: 'relative' }}>
                     {c.component}

--- a/web/src/views/ProfileEdit.tsx
+++ b/web/src/views/ProfileEdit.tsx
@@ -226,12 +226,9 @@ const ProfileEdit: React.FC = (props: any) => {
                     <Text as="h3" color={theme.colors.contrast} mx={2}>
                       {c.title}
                     </Text>
-                    {((!profileState.hasPendingEdit && profileState.isProvisioned) ||
-                      c.title === 'Quota Information') && (
-                      <RouterLink className="misc-class-m-dropdown-link" to={c.href}>
-                        <Icon hover color="contrast" name="edit" width={1.5} height={1.5} />
-                      </RouterLink>
-                    )}
+                    <RouterLink className="misc-class-m-dropdown-link" to={c.href}>
+                      <Icon hover color="contrast" name="edit" width={1.5} height={1.5} />
+                    </RouterLink>
                   </Flex>
                   <ShadowBox p={3} key={profileId} style={{ position: 'relative' }}>
                     {c.component}


### PR DESCRIPTION
Ticket: https://app.zenhub.com/workspaces/platform-experience-5bb7c5ab4b5806bc2beb9d15/issues/bcgov/platform-services-registry/403
remove the logic to hide the ‘edit’ button if pending edits, that way users can still get to the edit page even if there is a pending edit.