### PR TITLE
Update contact edit sync context parse

### DIFF
--- a/api/src/controllers/sync.ts
+++ b/api/src/controllers/sync.ts
@@ -153,7 +153,7 @@ export const getProfileBotJsonUnderPending = async (
             const errmsg = `Unable to get request edit Type`;
             throw new Error(errmsg);
           }
-          if (request.editType === RequestEditType.ProjectProfile) {
+          if (request.editType === RequestEditType.ProjectProfile || request.editType === RequestEditType.Contacts) {
             request.editObject = JSON.stringify(request.editObject)
           }
 


### PR DESCRIPTION
The sync flow happened to bypass a JSON.stringify step necessary for the buildContext function to run. This PR includes a check for Edit Type and parses the object if it is a contact edit.

This was first discovered in PR #447 