### PR TITLE
Workflow concurrency

### DIFF
--- a/.github/workflows/dev-api.yml
+++ b/.github/workflows/dev-api.yml
@@ -70,6 +70,7 @@ jobs:
   s2i-build:
     runs-on: ubuntu-latest
     needs: [test, build]
+    concurrency: platsrv-registry-api
     defaults:
       run:
         working-directory: .

--- a/.github/workflows/dev-db.yml
+++ b/.github/workflows/dev-db.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   docker-build:
     runs-on: ubuntu-latest
+    concurrency: platsrv-registry-flyway
     steps:
 
       # Build the image using the specified build config

--- a/.github/workflows/dev-web.yml
+++ b/.github/workflows/dev-web.yml
@@ -106,6 +106,7 @@ jobs:
   s2i-build:
     runs-on: ubuntu-latest
     needs: [test, build]
+    concurrency: platsrv-registry-web
     defaults:
       run:
         working-directory: .

--- a/.github/workflows/promote_to_test-v2.yml
+++ b/.github/workflows/promote_to_test-v2.yml
@@ -48,6 +48,7 @@ jobs:
     needs: check_for_component_changes
     runs-on: ubuntu-latest
     if: ${{ needs.check_for_component_changes.outputs.db == 'true' || github.event_name == 'workflow_dispatch' }}
+    concurrency: platsrv-registry-flyway
     steps:
       # Build the DB image from master only if there are DB updates
       # Get its build ID
@@ -171,6 +172,7 @@ jobs:
   api_s2i-build:
     needs: api_build
     runs-on: ubuntu-latest
+    concurrency: platsrv-registry-api
     defaults:
       run:
         working-directory: .
@@ -316,6 +318,7 @@ jobs:
   web_s2i_build:
     needs: web_build
     runs-on: ubuntu-latest
+    concurrency: platsrv-registry-web
     defaults:
       run:
         working-directory: .


### PR DESCRIPTION
I've added a concurrency check to workflows that build images in order to prevent errors from simultaneous build jobs.  The value of the concurrency field is the image name, such as `platsrv-registry-api`, and is set on a per-job (build) basis.  A second workflow run will show "pending" until the first run is complete.  This allows all runs to be processed, instead of cancelling the second one, which may have been initiated by a second commit.