### PR TITLE
Fix/whitespace trimming

### DIFF
--- a/api/src/libs/utils.ts
+++ b/api/src/libs/utils.ts
@@ -59,10 +59,13 @@ export const validateRequiredFields = (
 
 // the function BELOW is to address such issue
 // in order to make sure the final manifest yaml file is valid to ocp
+
+// also removes trailing white space in profile description
 export const replaceForDescription = (contextJson: any) => {
   const updatedContextJson = contextJson;
+
   const doubleQuoteReplaced = contextJson.description
-    ? contextJson.description.replace(/"/g, " ").replace(/\\/g, "")
+    ? contextJson.description.replace(/"/g, " ").replace(/\\/g, "").trim()
     : null;
 
   updatedContextJson.description = doubleQuoteReplaced;

--- a/api/src/libs/utils.ts
+++ b/api/src/libs/utils.ts
@@ -63,7 +63,6 @@ export const validateRequiredFields = (
 // also removes trailing white space in profile description
 export const replaceForDescription = (contextJson: any) => {
   const updatedContextJson = contextJson;
-
   const doubleQuoteReplaced = contextJson.description
     ? contextJson.description.replace(/"/g, " ").replace(/\\/g, "").trim()
     : null;


### PR DESCRIPTION
This trims the whitespace of the project description.
I placed the code in a function used previously for a double quote issue.

The whitespace will still occur in the current logger in "sendNatsMessage", as the "replaceForDescription" is called after the logger is called.