### PR TITLE
Documentation link

### DIFF
--- a/web/src/components/dashboard/PSRDocumentationLink.tsx
+++ b/web/src/components/dashboard/PSRDocumentationLink.tsx
@@ -6,8 +6,8 @@ const PSRDocumentationLink: React.FC = () => {
   return (
     <Box>
       <Text>
-        Git documentation for Platform Services Registry and a link to report issues can be found
-        <Link to="https://github.com/bcgov/platform-services-registry">here</Link>
+        {/* eslint-disable-next-line */}
+        Git documentation for Platform Services Registry and a link to report issues can be found <Link to="https://github.com/bcgov/platform-services-registry">here</Link>
       </Text>
     </Box>
   );

--- a/web/src/components/dashboard/PSRDocumentationLink.tsx
+++ b/web/src/components/dashboard/PSRDocumentationLink.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Box, Text } from 'rebass';
+
+const PSRDocumentationLink: React.FC = () => {
+  return (
+    <Box>
+      <Text>
+        Git documentation for Platform Services Registry and a link to report issues can be found
+        <Link to="https://github.com/bcgov/platform-services-registry">here</Link>
+      </Text>
+    </Box>
+  );
+};
+
+export default PSRDocumentationLink;

--- a/web/src/views/Dashboard.tsx
+++ b/web/src/views/Dashboard.tsx
@@ -18,6 +18,7 @@ import { useKeycloak } from '@react-keycloak/web';
 import React, { useEffect, useState } from 'react';
 import ProjectDetails from '../components/dashboard/ProjectDetails';
 import ProjectRequests from '../components/dashboard/ProjectRequests';
+import PSRDocumentationLink from '../components/dashboard/PSRDocumentationLink';
 import useCommonState from '../hooks/useCommonState';
 import useInterval from '../hooks/useInterval';
 import useRegistryApi from '../hooks/useRegistryApi';
@@ -77,6 +78,7 @@ const Dashboard: React.FC = () => {
 
   return (
     <>
+      <PSRDocumentationLink />
       {(userRoles.includes('administrator') || userRoles.includes('read_only_administrator')) && (
         <ProjectRequests
           profileDetails={profileDetails}


### PR DESCRIPTION
<img width="1525" alt="image" src="https://user-images.githubusercontent.com/4934684/158259278-794f388a-b046-4611-9557-7681aa0c6810.png">

From the task description:
"I could not find any links or references to any (Help or About) documentation that describes this applications purpose, functions, scope. Without this kind of information I find it harder to use the application and provide meaningful feedback." 

I just added a link to the top of the dashboard, "Git documentation for Platform Services Registry and a link to report issues can be found [here](http://localhost:8101/https://github.com/bcgov/platform-services-registry)"

I created a new React component "PSRDocumentationLink" for this, and added it on the dashboard. 