### PR TITLE
chore: fix build errors

### DIFF
--- a/app/api/private-cloud/requests/route.ts
+++ b/app/api/private-cloud/requests/route.ts
@@ -28,9 +28,9 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       +defaultPageSize,
       +currentPage,
       search,
-      ministry,
-      cluster,
-      userEmail
+      ministry ?? '',
+      cluster ?? '',
+      userEmail ?? ''
     );
 
     if (!data) {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -148,6 +148,7 @@ model PublicCloudRequestedProject {
   created                  DateTime            @default(now())
   accountCoding            String
   budget                   Budget
+  billingGroup             String
   projectOwnerId           String              @db.ObjectId
   projectOwner             User                @relation("publicCloudRequestedProjectOwner", fields: [projectOwnerId], references: [id], onDelete: Cascade)
   primaryTechnicalLeadId   String              @db.ObjectId

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -148,7 +148,6 @@ model PublicCloudRequestedProject {
   created                  DateTime            @default(now())
   accountCoding            String
   budget                   Budget
-  billingGroup             String
   projectOwnerId           String              @db.ObjectId
   projectOwner             User                @relation("publicCloudRequestedProjectOwner", fields: [projectOwnerId], references: [id], onDelete: Cascade)
   primaryTechnicalLeadId   String              @db.ObjectId

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -92,7 +92,6 @@ async function main() {
             prod: +faker.commerce.price(),
             tools: +faker.commerce.price(),
           },
-          commonComponents,
         },
       });
     }


### PR DESCRIPTION
I believe it could happen with a `prisma`'s nature of auto-generating types by running `prisma generate`.
So that when `schema.prisma` is updated and forgets to run the command again, it would be difficult to pick up the type errors in the local environments.