### PR TITLE
chore: use published localdev images in test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,7 @@ jobs:
         mkdir -p ./localdev/mnt/mongodb
         mkdir -p ./localdev/mnt/postgres
 
-        docker-compose -f localdev/docker-compose.yml up -d
-
+        docker-compose -f localdev/docker-compose.yml -f localdev/docker-compose-ci.yml up -d
         node_modules/.bin/wait-on http://localhost:8080/health/ready --timeout 120000
         cp .env.localdev .env.test
         npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,20 +29,19 @@ jobs:
         mkdir -p $DOCKER_CONFIG/cli-plugins
         curl -SL https://github.com/docker/compose/releases/download/v2.23.0/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
         chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
+        docker compose version
 
     - name: Run test
       run: |
         mkdir -p ./localdev/mnt/mongodb
         mkdir -p ./localdev/mnt/postgres
 
-        docker compose version
-        ~/.docker/cli-plugins/docker-compose version
         ~/.docker/cli-plugins/docker-compose -f localdev/docker-compose.yml -f localdev/docker-compose-ci.yml up -d
         node_modules/.bin/wait-on http://localhost:8080/health/ready --timeout 120000
         cp .env.localdev .env.test
         npm run test
 
-        docker-compose -f localdev/docker-compose.yml -f localdev/docker-compose-ci.yml down
+        ~/.docker/cli-plugins/docker-compose -f localdev/docker-compose.yml -f localdev/docker-compose-ci.yml down
         sudo rm -rf ./localdev/mnt
 
   pre-commit:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,15 @@ jobs:
     - name: Run build
       run: npm run build
 
+    - name: Install Docker Compose v2
+      # See https://docs.docker.com/compose/install/linux/
+      run: |
+        DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
+        mkdir -p $DOCKER_CONFIG/cli-plugins
+        curl -SL https://github.com/docker/compose/releases/download/v2.23.0/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
+        chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
+        docker compose version
+
     - name: Run test
       run: |
         mkdir -p ./localdev/mnt/mongodb
@@ -32,7 +41,7 @@ jobs:
         cp .env.localdev .env.test
         npm run test
 
-        docker-compose -f localdev/docker-compose.yml down
+        docker-compose -f localdev/docker-compose.yml -f localdev/docker-compose-ci.yml down
         sudo rm -rf ./localdev/mnt
 
   pre-commit:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,14 +29,15 @@ jobs:
         mkdir -p $DOCKER_CONFIG/cli-plugins
         curl -SL https://github.com/docker/compose/releases/download/v2.23.0/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
         chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
-        docker compose version
 
     - name: Run test
       run: |
         mkdir -p ./localdev/mnt/mongodb
         mkdir -p ./localdev/mnt/postgres
 
-        docker-compose -f localdev/docker-compose.yml -f localdev/docker-compose-ci.yml up -d
+        docker compose version
+        ~/.docker/cli-plugins/docker-compose version
+        ~/.docker/cli-plugins/docker-compose -f localdev/docker-compose.yml -f localdev/docker-compose-ci.yml up -d
         node_modules/.bin/wait-on http://localhost:8080/health/ready --timeout 120000
         cp .env.localdev .env.test
         npm run test

--- a/localdev/docker-compose-ci.yml
+++ b/localdev/docker-compose-ci.yml
@@ -1,0 +1,12 @@
+services:
+  keycloak:
+    image: ghcr.io/bcgov/pltsvc-localdev-keycloak:latest
+    build: {}
+
+  keycloak-provision:
+    image: ghcr.io/bcgov/pltsvc-localdev-keycloak-provision:latest
+    build: {}
+
+  m365proxy:
+    image: ghcr.io/bcgov/pltsvc-localdev-m365proxy:latest
+    build: {}


### PR DESCRIPTION
- it will reduce the time to test integration tests in CI by using deployed container images.