### PR TITLE
chore: enable unsafe-inline CSP for static HTML files

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -25,8 +25,11 @@ export function middleware(request: NextRequest) {
   const cspSegments = [
     "base-uri 'self'",
     "default-src 'self'",
-    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
-    `style-src 'self' 'nonce-${nonce}'`,
+    // Let's take another look at CSP since it necessitates the regeneration of static HTML files.
+    // `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
+    // `style-src 'self' 'nonce-${nonce}'`,
+    `script-src 'self' 'unsafe-inline'`,
+    `style-src 'self' 'unsafe-inline'`,
     `img-src 'self' blob: data: ${gravatar_com}`,
     `connect-src 'self' ${gravatar_com} ${loginproxy_gov}`,
     `frame-src ${loginproxy_gov}`,


### PR DESCRIPTION
- This tool might helps but let's take another look later: https://www.npmjs.com/package/@next-safe/middleware