### PR TITLE
feat: add global api response handler

### DIFF
--- a/app/api/private-cloud/create/route.ts
+++ b/app/api/private-cloud/create/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth/next';
+import withErrorHandler from '@/helpers/apiErrorHandler';
 import { authOptions } from '@/app/api/auth/options';
 import { Prisma } from '@prisma/client';
 import { PrivateCloudCreateRequestBodySchema, PrivateCloudCreateRequestBody } from '@/schema';
@@ -8,7 +9,7 @@ import createRequest from '@/requestActions/private-cloud/createRequest';
 import { sendNewRequestEmails } from '@/ches/emailHandler';
 import { PrivateCloudRequestWithProjectAndRequestedProject } from '@/requestActions/private-cloud/createRequest';
 
-export async function POST(req: NextRequest) {
+export const POST = withErrorHandler(async (req: NextRequest) => {
   // Authentication
   const session = await getServerSession(authOptions);
 
@@ -50,4 +51,4 @@ export async function POST(req: NextRequest) {
   return new NextResponse('Success creating request', {
     status: 200,
   });
-}
+});

--- a/helpers/apiErrorHandler.ts
+++ b/helpers/apiErrorHandler.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+function withErrorHandler(fn: (req: NextRequest) => Promise<NextResponse<unknown>>) {
+  return async function (request: NextRequest) {
+    try {
+      return await fn(request);
+    } catch (error) {
+      console.error(error);
+      return NextResponse.json({ message: 'Internal Server Error', error }, { status: 500 });
+    }
+  };
+}
+
+export default withErrorHandler;


### PR DESCRIPTION
- since the api endpoints are captured errors and using `try.. catch` can be duplicated in multiple places, let's have a global handler to capture the responses and errors.