### PR TITLE
fix: wording on privatecloud modal and links in modals

### DIFF
--- a/components/modal/CreatePrivateCloud.tsx
+++ b/components/modal/CreatePrivateCloud.tsx
@@ -65,32 +65,6 @@ export default function Modal({
                       regarding your product status and details.
                     </p>
                   </div>
-                  <div className="bg-blue-50 mt-4 p-4 rounded-md flex">
-                    <div className="border-2 border-blue-700 relative w-1 h-1 bg-inherit rounded-full flex justify-center items-center text-center p-2 m-2 mr-4">
-                      <span className="font-bold text-blue-700 font-sans text-xs">i</span>
-                    </div>
-                    <div>
-                      <p className="font-bcsans text-sm text-blue-700 font-semibold mt-2">Note:</p>
-                      <p className="font-bcsans text-sm text-blue-700 mt-1">
-                        The approval of new project set creation request is subject to having a signed Memorandum of
-                        Understanding (MoU) with the Public Cloud Team. If you do not have a MoU in place, please email
-                        us at
-                        <span> </span>
-                        <a href="mailto:cloud.pathfinder@gov.bc.ca" className="underline">
-                          cloud.pathfinder@gov.bc.ca
-                        </a>
-                        .
-                      </p>
-                      <p className="font-bcsans text-sm text-blue-700 mt-4">
-                        In order to request a project deletion, please email us at
-                        <span> </span>
-                        <a href="mailto:cloud.pathfinder@gov.bc.ca" className="underline">
-                          cloud.pathfinder@gov.bc.ca
-                        </a>
-                        .
-                      </p>
-                    </div>
-                  </div>
                   <div className="flex border-t-1 mt-8 pt-4">
                     <input
                       id="none"
@@ -102,8 +76,15 @@ export default function Modal({
                     />
                     <p className="font-bcsans text-sm text-gray-900 mt-4">
                       By checking this box, I confirm that I have read and understood the roles and responsibilities as
-                      described in the <span> </span>
-                      <span className="underline text-blue-700">Onboarding Guide.</span>
+                      described in the
+                      <a
+                        href="https://digital.gov.bc.ca/cloud/services/private/onboard/"
+                        target="_blank"
+                        className="ml-1 underline text-blue-700"
+                        rel="noreferrer"
+                      >
+                        Onboarding Guide.
+                      </a>
                     </p>
                   </div>
                 </div>
@@ -111,7 +92,6 @@ export default function Modal({
                   <button
                     type="button"
                     className="px-12 rounded-md bg-white tracking-[.2em] py-2.5 text-sm font-bcsans text-bcblue shadow-sm ring-1 ring-inset ring-bcblue hover:bg-gray-50 mr-4"
-                    // "mt-3 inline-flex items-center justify-center -md bg-white text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0"
                     onClick={() => setOpen(false)}
                     ref={cancelButtonRef}
                   >

--- a/components/modal/CreatePublicCloud.tsx
+++ b/components/modal/CreatePublicCloud.tsx
@@ -107,7 +107,14 @@ export default function Modal({
                       Understanding (MoU) and have attended an onboarding session with the Public Cloud Accelerator
                       Service Team. I also confirm that I have read and understood the roles and responsibilities as
                       described in the
-                      <span className="underline text-blue-700">Public Cloud Services Shared Responsibility Model</span>
+                      <a
+                        href="https://digital.gov.bc.ca/cloud/services/public/onboard/#understand"
+                        target="_blank"
+                        className="ml-1 underline text-blue-700"
+                        rel="noreferrer"
+                      >
+                        Public Cloud Services Shared Responsibility Model
+                      </a>
                       .
                     </p>
                   </div>

--- a/emails/templates/private-cloud/RequestRejection.tsx
+++ b/emails/templates/private-cloud/RequestRejection.tsx
@@ -26,7 +26,7 @@ export const RequestRejectionTemplate = ({ request, comment }: EmailProp) => {
                 <Text>Hi {request.requestedProject.name} team, </Text>
                 <Text className="">
                   Your request regarding the product {request.requestedProject.name} on the Private Cloud Openshift
-                  platform has rejected due to the following reason(s):
+                  platform has been rejected due to the following reason(s):
                 </Text>
                 <Text className="">{comment}</Text>
                 <Text>


### PR DESCRIPTION
Fixed modal for PrivateCloudModal and added the link for `Onboarding Guide`
![image](https://github.com/bcgov/platform-services-registry/assets/95054192/1e3e723d-bfdc-4fd2-99f0-281e0cc6a637)


Added link for `Public Cloud Services Shared Responsibility` in PublicCloudModal
![image](https://github.com/bcgov/platform-services-registry/assets/95054192/ef0b877a-6ba8-4d97-bd1f-ebcf9ae894f5)

Fixed wording for rejection email
