### PR TITLE
feat: add helm chart for airflow deployment

### DIFF
--- a/helm/secdash/.helmignore
+++ b/helm/secdash/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/secdash/Chart.lock
+++ b/helm/secdash/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: airflow
+  repository: https://airflow.apache.org/
+  version: 1.11.0
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 12.1.15
+digest: sha256:e9ca995172e7da420b4a5dc2081d1fa27dbb9360158dda92a0eae54be9f422c8
+generated: "2023-12-07T19:12:25.496324607-08:00"

--- a/helm/secdash/Chart.yaml
+++ b/helm/secdash/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: airflow
+description: A Helm chart for Security Dashboard Airflow
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+dependencies:
+  - name: airflow
+    version: "1.11.0"
+    repository: "https://airflow.apache.org/"
+    condition: airflow.enabled
+  - name: postgresql
+    version: "12.1.15"
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled

--- a/helm/secdash/Makefile
+++ b/helm/secdash/Makefile
@@ -1,0 +1,79 @@
+SHELL := /usr/bin/env bash
+NAME := secdash
+
+NAMESPACE=
+
+ifndef NAMESPACE
+$(error NAMESPACE is not set)
+endif
+
+# Get the allowed UID that is allowed in the namespace
+UID := $(shell oc get project "${NAMESPACE}" -o json | jq -r '.metadata.annotations."openshift.io/sa.scc.uid-range"' | cut -d'/' -f1)
+
+# Calculate the SHA256 sum of the 'dags' directory to trigger deployment when changes occur
+SHA := $(shell find ./dags -type f -exec sha256sum {} + | sha256sum | cut -d' ' -f1)
+
+DAGS_DIRECTORY := ./dags
+
+# Get the list of filenames in the directory
+FILENAMES := $(notdir $(wildcard $(DAGS_DIRECTORY)/*))
+INDEX := 0
+
+# It is necessary to set individual volume mounts for each DAG file since
+# mounting the entire ConfigMap data creates symbolic links.
+#
+# Example directory structure after mounting ConfigMap data:
+# drwxr-sr-x. 2 root    1015800000 37 Dec  9 00:00 ..2023_12_09_00_00_55.2390650048
+# lrwxrwxrwx. 1 root    1015800000 32 Dec  9 00:00 ..data -> ..2023_12_09_00_00_55.2390650048
+# lrwxrwxrwx. 1 root    1015800000 14 Dec  9 00:00 testa.py -> ..data/testa.py
+# lrwxrwxrwx. 1 root    1015800000 15 Dec  9 00:00 testb.py -> ..data/testb.py
+define arguments
+	"${NAME}" . -n "${NAMESPACE}" -f values.yaml -f "values-${NAMESPACE}.yaml" \
+	--set airflow.uid="${UID}" \
+	--set airflow.gid="${UID}" \
+	--set dags.sha="${SHA}" \
+	$(foreach filename,$(FILENAMES),\
+		--set "dags.volumeMounts[$(INDEX)].name=secdash-airflow-dags-copy" \
+		--set "dags.volumeMounts[$(INDEX)].mountPath=/newdags/$(filename)" \
+		--set "dags.volumeMounts[$(INDEX)].readOnly=true" \
+		--set "dags.volumeMounts[$(INDEX)].subPath=$(filename)" \
+		$(eval INDEX=$(shell expr $(INDEX) + 1)) \
+	)
+endef
+
+.PHONY: clean-job
+clean-job:
+	kubectl delete job secdash-airflow-dags-copy || true
+
+.PHONY: helm-dep
+helm-dep:
+	helm dependency update
+
+.PHONY: install
+install: helm-dep
+install:
+	@helm install $(call arguments)
+
+.PHONY: upgrade
+upgrade: helm-dep
+upgrade:
+	@helm upgrade --install $(call arguments)
+
+.PHONY: lint
+lint: helm-dep
+lint:
+	@helm upgrade --dry-run --install $(call arguments)
+
+.PHONY: uninstall
+uninstall: helm-dep
+uninstall:
+	@helm uninstall ${NAME} -n ${NAMESPACE}
+
+.PHONY: template
+template: helm-dep
+template:
+	@helm template $(call arguments) --debug > template.yaml
+
+.PHONY: force-install
+force-install: uninstall
+force-install: install

--- a/helm/secdash/README.md
+++ b/helm/secdash/README.md
@@ -1,0 +1,24 @@
+# Airflow (Task Scheduler) Deployment Procedure
+
+## Overview
+
+The primary Helm chart for deployment relies on two subordinate Helm charts: `Airflow` and `PostgreSql`. Given that `Airflow` is dependent on `PostgreSql`, the initial deployment sequence involves deploying `PostgreSql` before initiating the deployment of `Airflow` instances.
+
+## Deployment Steps
+
+1. In the Helm values file specific to the environment (e.g., `values-101ed4-tools.yaml`), set the value of `airflow.enabled` to `false`.
+2. Deploy the `PostgreSQL` database:
+
+```sh
+make upgrade NAMESPACE=101ed4-tools
+```
+
+3. Once the database deployment is complete, proceed to deploy `Airflow`:
+
+```sh
+make upgrade NAMESPACE=101ed4-tools
+```
+
+## Considerations
+
+- Prior to the deployment of `Airflow`, a [job]('./templates/templates/job.yaml) runs to `synchronize the dags`. Due to the upload mechanism using a [config map]('./templates/templates/configmap.yaml), there is a file `size limitation of 1MB` for the total dag files. If the size of dag files grows in the future, alternative methods for file synchronization will need to be explored.

--- a/helm/secdash/dags/test.py
+++ b/helm/secdash/dags/test.py
@@ -1,0 +1,62 @@
+"""Example DAG demonstrating the usage of the BashOperator."""
+
+from datetime import timedelta
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.operators.dummy import DummyOperator
+from airflow.utils.dates import days_ago
+
+args = {
+    'owner': 'airflow',
+}
+
+with DAG(
+    dag_id='example_bash_operator',
+    default_args=args,
+    schedule_interval='0 0 * * *',
+    start_date=days_ago(2),
+    dagrun_timeout=timedelta(minutes=60),
+    tags=['example', 'example2'],
+    params={"example_key": "example_value"},
+) as dag:
+
+    run_this_last = DummyOperator(
+        task_id='run_this_last',
+    )
+
+    # [START howto_operator_bash]
+    run_this = BashOperator(
+        task_id='run_after_loop',
+        bash_command='echo 1',
+    )
+    # [END howto_operator_bash]
+
+    run_this >> run_this_last
+
+    for i in range(3):
+        task = BashOperator(
+            task_id='runme_' + str(i),
+            bash_command='echo "{{ task_instance_key_str }}" && sleep 1',
+        )
+        task >> run_this
+
+    # [START howto_operator_bash_template]
+    also_run_this = BashOperator(
+        task_id='also_run_this',
+        bash_command='echo "run_id={{ run_id }} | dag_run={{ dag_run }}"',
+    )
+    # [END howto_operator_bash_template]
+    also_run_this >> run_this_last
+
+# [START howto_operator_bash_skip]
+this_will_skip = BashOperator(
+    task_id='this_will_skip',
+    bash_command='echo "hello world"; exit 99;',
+    dag=dag,
+)
+# [END howto_operator_bash_skip]
+this_will_skip >> run_this_last
+
+if __name__ == "__main__":
+    dag.cli()

--- a/helm/secdash/example-job.yaml
+++ b/helm/secdash/example-job.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: airflow-init-db
+spec:
+  template:
+    spec:
+      containers:
+      - name: airflow-init-db
+        image: apache/airflow
+        args: ["db", "init"]
+        env:
+          - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
+            value: postgresql://nonroot:nonroot@secdash-postgresql:5432/airflow # pragma: allowlist secret
+      restartPolicy: Never

--- a/helm/secdash/example-job.yaml
+++ b/helm/secdash/example-job.yaml
@@ -11,5 +11,5 @@ spec:
         args: ["db", "init"]
         env:
           - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
-            value: postgresql://nonroot:nonroot@secdash-postgresql:5432/airflow # pragma: allowlist secret
+            value: postgresql://<username>:<password>@secdash-postgresql:5432/airflow # pragma: allowlist secret
       restartPolicy: Never

--- a/helm/secdash/templates/_helpers.tpl
+++ b/helm/secdash/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "main.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "main.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "main.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "main.labels" -}}
+helm.sh/chart: {{ include "main.chart" . }}
+{{ include "main.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "main.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "main.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "main.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "main.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/secdash/templates/configmap.yaml
+++ b/helm/secdash/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "main.fullname" . }}-airflow-dags
+  labels: {{ include "main.labels" . | nindent 4 }}
+data:
+{{ (.Files.Glob "dags/*").AsConfig | indent 2 }}

--- a/helm/secdash/templates/job.yaml
+++ b/helm/secdash/templates/job.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.airflow.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "main.fullname" . }}-airflow-dags-copy
+  labels: {{ include "main.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade,pre-rollback"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "-5"
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 1200
+  template:
+    metadata:
+      name: {{ include "main.fullname" . }}-airflow-dags-copy
+    spec:
+      containers:
+        - name: {{ include "main.fullname" . }}-airflow-dags-copy
+          image: busybox:1.36.1
+          command: [/bin/sh, -c]
+          args:
+            - |
+              # Copy new files
+              cp -R /newdags/* /dags/;
+              echo "Files copied successfully!";
+
+              # Remove "py" files in /dags that are not present in /newdags
+              comm -23 <(find /dags -type f -name '*.py' -exec basename {} \; | sort) <(find /newdags -type f -name '*.py' -exec basename {} \; | sort) | xargs -I {} rm /dags/{}
+              echo "Unused files deleted!";
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          env:
+            - name: DAGS_SHA
+              value: {{ .Values.dags.sha }}
+          volumeMounts:
+            - name: secdash-airflow-dags
+              mountPath: /dags
+            {{- if .Values.dags.volumeMounts }}
+              {{- toYaml .Values.dags.volumeMounts | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: secdash-airflow-dags-copy
+          configMap:
+            name: secdash-airflow-dags
+        - name: secdash-airflow-dags
+          persistentVolumeClaim:
+            claimName: secdash-airflow-dags
+      restartPolicy: Never
+{{- end }}

--- a/helm/secdash/templates/networkpolicy.yaml
+++ b/helm/secdash/templates/networkpolicy.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "main.fullname" . }}-allow-from-openshift-ingress
+spec:
+  # This policy allows any pod with a route & service combination
+  # to accept traffic from the OpenShift router pods. This is
+  # required for things outside of OpenShift (like the Internet)
+  # to reach your pods.
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "main.fullname" . }}-allow-same-namespace
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - podSelector: {}
+  policyTypes:
+    - Ingress

--- a/helm/secdash/templates/pvc.yaml
+++ b/helm/secdash/templates/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "main.fullname" . }}-airflow-dags
+  labels: {{ include "main.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 200Mi
+  storageClassName: netapp-file-standard

--- a/helm/secdash/templates/route.yaml
+++ b/helm/secdash/templates/route.yaml
@@ -1,0 +1,18 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "main.fullname" . }}-airflow-web
+  annotations:
+    haproxy.router.openshift.io/balance: roundrobin
+    haproxy.router.openshift.io/disable_cookies: 'true'
+    haproxy.router.openshift.io/timeout: 600s
+spec:
+  {{- if .Values.airflow.route.host }}
+  host: {{ .Values.airflow.route.host }}
+  {{- end }}
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: airflow-webserver

--- a/helm/secdash/templates/secrets/postgresql.yaml
+++ b/helm/secdash/templates/secrets/postgresql.yaml
@@ -1,0 +1,24 @@
+{{- $secretName := printf "%s-%s" (include "main.fullname" .) "postgresql" }}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName ) }}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels: {{ include "main.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+type: Opaque
+data:
+  {{- if $secret }}
+  admin-password: {{ index $secret.data "admin-password" }}
+  user-password: {{ index $secret.data "user-password" }}
+  replication-password: {{ index $secret.data "replication-password" }}
+  connection: {{ index $secret.data "connection" }}
+  {{- else }}
+  {{- $randPassword := randAlphaNum 32 }}
+  admin-password: {{ randAlphaNum 32 | b64enc | quote }}
+  user-password: {{ $randPassword | b64enc | quote }}
+  replication-password: {{ randAlphaNum 32 | b64enc | quote }}
+  connection: {{ printf "postgresql://nonroot:%s@secdash-postgresql:5432/airflow" $randPassword | b64enc | quote }} # pragma: allowlist secret
+  {{- end }}

--- a/helm/secdash/templates/secrets/webserver.yaml
+++ b/helm/secdash/templates/secrets/webserver.yaml
@@ -1,0 +1,17 @@
+{{- $secretName := printf "%s-%s" (include "main.fullname" .) "airflow-webserver" }}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName ) }}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels: {{ include "main.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+type: Opaque
+data:
+  {{- if $secret }}
+  webserver-secret-key: {{ index $secret.data "webserver-secret-key" }}
+  {{- else }}
+  webserver-secret-key: {{ randAlphaNum 32 | b64enc | quote }}
+  {{- end }}

--- a/helm/secdash/values-101ed4-tools.yaml
+++ b/helm/secdash/values-101ed4-tools.yaml
@@ -1,0 +1,11 @@
+global:
+  env:
+    "Env": "tools"
+
+airflow:
+  enabled: true
+  route:
+    host: secdash-airflow.apps.silver.devops.gov.bc.ca
+
+postgresql:
+  enabled: true

--- a/helm/secdash/values.yaml
+++ b/helm/secdash/values.yaml
@@ -1,0 +1,186 @@
+# See https://helm.sh/docs/chart_template_guide/subcharts_and_globals/#global-chart-values
+global:
+  licensePlate: 101ed4
+  vault:
+    # licensePlate-nonprod or licensePlate-prod
+    role:
+    # sub-path of the vault secret
+    subPath:
+    podAnnotations:
+      # See https://developer.hashicorp.com/vault/docs/platform/k8s/injector/annotations#agent-annotations
+      vault.hashicorp.com/auth-path: auth/k8s-silver
+      vault.hashicorp.com/namespace: platform-services
+      vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-inject-token: "false"
+      vault.hashicorp.com/agent-pre-populate: "true"
+      vault.hashicorp.com/agent-pre-populate-only: "true"
+      vault.hashicorp.com/agent-requests-cpu: 50m
+      vault.hashicorp.com/agent-limits-cpu: 100m
+      vault.hashicorp.com/agent-requests-mem: 32Mi
+      vault.hashicorp.com/agent-limits-mem: 64Mi
+  env:
+    "Env": ""
+
+  serviceAccountName: 101ed4-vault
+
+nameOverride: secdash
+fullnameOverride: secdash
+
+dags:
+  sha:
+  # The following configurations will be populated dynamically by the Makefile
+  # based on the DAG filenames in the dag directory.
+  volumeMounts: []
+
+# See https://github.com/apache/airflow/blob/main/chart/values.yaml
+airflow:
+  enabled: false
+  route:
+    host:
+
+  fullnameOverride: airflow
+  nameOverride: airflow
+  useStandardNaming: true
+
+  # See https://github.com/apache/airflow/blob/4a4913c6f729756b528a0f0095c0273e853bc197/chart/values.yaml#L46
+  uid:
+  gid:
+
+  # See https://github.com/apache/airflow/blob/4a4913c6f729756b528a0f0095c0273e853bc197/chart/values.yaml#L77
+  airflowVersion: "2.7.3"
+
+  # See https://github.com/apache/airflow/blob/4a4913c6f729756b528a0f0095c0273e853bc197/chart/values.yaml#L80
+  images:
+    useDefaultImageForMigration: true
+    migrationsWaitTimeout: 60
+
+  # See https://github.com/apache/airflow/blob/4a4913c6f729756b528a0f0095c0273e853bc197/chart/values.yaml#L257
+  rbac:
+    create: true
+    createSCCRoleBinding: false
+
+  # See https://github.com/apache/airflow/blob/4a4913c6f729756b528a0f0095c0273e853bc197/chart/values.yaml#L264
+  executor: KubernetesExecutor
+
+  # See https://github.com/apache/airflow/blob/4a4913c6f729756b528a0f0095c0273e853bc197/chart/values.yaml#L379
+  data:
+    metadataSecretName: secdash-postgresql # pragma: allowlist secret
+    # metadataConnection:
+    #   user: nonroot
+    #   pass: nonroot
+    #   protocol: postgresql
+    #   host: secdash-postgresql
+    #   port: 5432
+    #   db: airflow
+
+  # See https://github.com/apache/airflow/blob/4a4913c6f729756b528a0f0095c0273e853bc197/chart/values.yaml#L430
+  webserverSecretKeySecretName: secdash-airflow-webserver # pragma: allowlist secret
+
+  # See https://github.com/apache/airflow/blob/4a4913c6f729756b528a0f0095c0273e853bc197/chart/values.yaml#L490
+  workers:
+    extraVolumes:
+      - name: secdash-airflow-dags
+        persistentVolumeClaim:
+          claimName: secdash-airflow-dags
+    extraVolumeMounts:
+      - name: secdash-airflow-dags
+        mountPath: /opt/airflow/dags
+
+  # See https://github.com/apache/airflow/blob/4a4913c6f729756b528a0f0095c0273e853bc197/chart/values.yaml#L770
+  scheduler:
+    replicas: 1
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 500Mi
+
+    extraVolumes:
+      - name: secdash-airflow-dags
+        persistentVolumeClaim:
+          claimName: secdash-airflow-dags
+    extraVolumeMounts:
+      - name: secdash-airflow-dags
+        mountPath: /opt/airflow/dags
+
+  # See https://github.com/apache/airflow/blob/4a4913c6f729756b528a0f0095c0273e853bc197/chart/values.yaml#L1130
+  webserver:
+    replicas: 1
+    resources:
+      limits:
+        cpu: 500m
+        memory: 2Gi
+      requests:
+        cpu: 50m
+        memory: 700Mi
+
+  # See https://github.com/apache/airflow/blob/4a4913c6f729756b528a0f0095c0273e853bc197/chart/values.yaml#L1342
+  triggerer:
+    enabled: false
+
+  # See https://github.com/apache/airflow/blob/4a4913c6f729756b528a0f0095c0273e853bc197/chart/values.yaml#L1807
+  statsd:
+    enabled: false
+
+  # See https://github.com/apache/airflow/blob/4a4913c6f729756b528a0f0095c0273e853bc197/chart/values.yaml#L2278
+  postgresql:
+    enabled: false
+
+  # See https://github.com/apache/airflow/blob/4a4913c6f729756b528a0f0095c0273e853bc197/chart/values.yaml#L2298
+  config:
+    core:
+      dag_concurrency: 5
+      max_active_runs_per_dag: 1
+      min_serialized_dag_update_interval: 10
+      min_serialized_dag_fetch_interval: 5
+      dags_are_paused_at_creation: False
+    webserver:
+      web_server_worker_timeout: 300
+      workers: 2
+
+    smtp:
+      smtp_host: apps.smtp.gov.bc.ca
+      smtp_starttls: false
+      smtp_mail_from: pltsvc@gov.bc.ca
+
+    scheduler:
+      min_file_process_interval: 30
+
+    kubernetes_executor:
+      run_as_user: "{{ .Values.uid }}"
+      delete_worker_pods: "True"
+
+  # See https://github.com/apache/airflow/blob/4a4913c6f729756b528a0f0095c0273e853bc197/chart/values.yaml#L2397
+  dags:
+    persistence:
+      enabled: false
+
+    gitSync:
+      enabled: false
+
+# See https://github.com/bitnami/charts/tree/main/bitnami/postgresql
+postgresql:
+  enabled: true
+  primary:
+    podSecurityContext:
+      enabled: false
+    containerSecurityContext:
+      enabled: false
+    persistence:
+      size: 1Gi
+  readReplicas:
+    persistence:
+      size: 1Gi
+  global:
+    postgresql:
+      auth:
+        database: airflow
+        username: nonroot
+        replicationUsername: replication
+        existingSecret: secdash-postgresql # pragma: allowlist secret
+        secretKeys:
+          adminPasswordKey: admin-password # pragma: allowlist secret
+          userPasswordKey: user-password # pragma: allowlist secret
+          replicationPasswordKey: replication-password # pragma: allowlist secret


### PR DESCRIPTION
# Airflow (Task Scheduler) Deployment Procedure

## Overview

The primary Helm chart for deployment relies on two subordinate Helm charts: `Airflow` and `PostgreSql`. Given that `Airflow` is dependent on `PostgreSql`, the initial deployment sequence involves deploying `PostgreSql` before initiating the deployment of `Airflow` instances.

## Deployment Steps

1. In the Helm values file specific to the environment (e.g., `values-101ed4-tools.yaml`), set the value of `airflow.enabled` to `false`.
2. Deploy the `PostgreSQL` database:

```sh
make upgrade NAMESPACE=101ed4-tools
```

3. Once the database deployment is complete, proceed to deploy `Airflow`:

```sh
make upgrade NAMESPACE=101ed4-tools
```

## Considerations

- Prior to the deployment of `Airflow`, a [job]('./templates/templates/job.yaml) runs to `synchronize the dags`. Due to the upload mechanism using a [config map]('./templates/templates/configmap.yaml), there is a file `size limitation of 1MB` for the total dag files. If the size of dag files grows in the future, alternative methods for file synchronization will need to be explored.
