### PR TITLE
feat: new kc clients for new UI

### DIFF
--- a/.env.localdev
+++ b/.env.localdev
@@ -8,7 +8,7 @@ DATABASE_URL=mongodb://mongodb:mongodb@localhost:27017/plt-svc?authSource=admin
 AUTH_BASE_URL=http://localhost:8080
 AUTH_SERVER_URL=http://localhost:8080
 AUTH_RELM=platform-services
-AUTH_RESOURCE=registry-web
+AUTH_RESOURCE=pltsvc
 AUTH_SECRET=testsecret
 
 M365_PROXY_URL=http://localhost:8000

--- a/app/api/auth/options.ts
+++ b/app/api/auth/options.ts
@@ -67,7 +67,7 @@ export const authOptions: AuthOptions = {
 
       const decodedToken = jwt.decode(token.accessToken || '') as any;
 
-      token.roles = decodedToken?.resource_access?.['registry-web']?.roles;
+      token.roles = decodedToken?.resource_access?.pltsvc?.roles ?? [];
 
       return token;
     },

--- a/helm/main/templates/mongodb-backup.yaml
+++ b/helm/main/templates/mongodb-backup.yaml
@@ -13,7 +13,7 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      {{- include "app.selectorLabels" . | nindent 6 }}
+      {{- include "main.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:

--- a/helm/main/values-101ed4-dev.yaml
+++ b/helm/main/values-101ed4-dev.yaml
@@ -6,6 +6,7 @@ global:
     "Env": "dev"
 
 app:
+  enabled: true
   env:
     "APP_ENV": "dev"
     "BASE_URL": "https://dev-pltsvc.apps.silver.devops.gov.bc.ca"

--- a/localdev/README.md
+++ b/localdev/README.md
@@ -48,7 +48,7 @@ Within the local Docker container context, `5 services` are established:
 - `Keycloak HTTP`: http://localhost:8080
 - `Keycloak HTTPS`: https://localhost:8443
 - `Keycloak Realm`: platform-services
-- `Keycloak Client ID`: registry-web
+- `Keycloak Client ID`: pltsvc
 - `Keyclaok Client Secret`: testsecret
 - `MongoDB URL`: mongodb@localhost:27017
 - `Microsoft 365 Proxy Url`: http://localhost:8000

--- a/localdev/docker-compose.yml
+++ b/localdev/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: password # pragma: allowlist secret
       REALM_NAME: platform-services
-      CLIENT_ID: registry-web
+      CLIENT_ID: pltsvc
       CLIENT_SECRET: testsecret # pragma: allowlist secret
     depends_on:
     - keycloak

--- a/terraform/keycloak/.terraform.lock.hcl
+++ b/terraform/keycloak/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/mrparkers/keycloak" {
+  version     = "4.3.1"
+  constraints = "4.3.1"
+  hashes = [
+    "h1:iYMw6G+fa3ZxO0u1yd+AKwhIqbeb6zICCRHCCR34xt8=",
+    "zh:2476767ef61e2e4a3e9c654e07bafc550ba36232c91301edcc703eb580d7cf1c",
+    "zh:3c60a8d9284ed5bc1c3a57f948bd726a29eecb1cf283f43f9f6df3b6595022d3",
+    "zh:4087277c8e79d72524d806048715c07d196faaf1ff8475131f558a6178f9d6f6",
+    "zh:426b4dde08ea33c32d9e2cc8c6a7a7b06a2d339f5770b6dc6f83cb5b8ca9b793",
+    "zh:476c52c28ebd97d2c14be1254e37b568625398090e0a828562f30c55429835eb",
+    "zh:563d21232e5cf2f5012f9a7c4ce6a6fd479b53383a47e44174c4855bdb536e29",
+    "zh:6542076d66db89e668bd916e20c6dc26059318e5f8ad9367d9699e6f3deffbd4",
+    "zh:66542debaec2514701a3744a13e01d188ebb5fbb044c9ee2bc484df2a975d72f",
+    "zh:77b37b37e76be7f21358ed683d1a5aa4f788af9f9c761e005d153b724d61b69a",
+    "zh:7e4ed34fb2523ca52b3b59cc992741dc41f56415655dce98d75c323a0b45debb",
+    "zh:7f703fc12304c767e5067aebf4302e232b4e5eee3fd184bacb95f368f4bc2b30",
+    "zh:930bc8ce87a1f883fdbf1466ba7d972929baaeaecba1b9099ddd030cc8ffe148",
+    "zh:cf2e7f5ca1cb0e70342815ede3530caff2fdefaf0d3e5993349e333ac1df1bf7",
+    "zh:cf87def6c46c997d9601ad10f4632882c9f1791f1c220cf29c2c6c144e51d0e2",
+    "zh:d168f1702efe239d7fdef8bf55ca526f53181f6b44ac9b91bcd7c26941116682",
+    "zh:e631c5ddd5116a730cc0da1b18879a4312edcb6f8edac2e6fa77d72c7ef334be",
+    "zh:f2f8ccaf97866e9d3f27449896c105c7fa325cedc65a62f618f38ff8e57a4d46",
+  ]
+}

--- a/terraform/keycloak/config.tf
+++ b/terraform/keycloak/config.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.5.7"
+
+  backend "kubernetes" {
+    namespace     = "101ed4-prod"
+    secret_suffix = "keycloak" # pragma: allowlist secret
+    config_path   = "~/.kube/config"
+  }
+
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "4.3.1"
+    }
+  }
+}

--- a/terraform/keycloak/dev/config.tf
+++ b/terraform/keycloak/dev/config.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "4.3.1"
+    }
+  }
+}
+
+provider "keycloak" {
+  realm         = "platform-services"
+  client_id     = var.client_id
+  client_secret = var.client_secret
+  url           = var.url
+  base_path     = var.base_path
+}

--- a/terraform/keycloak/dev/main.tf
+++ b/terraform/keycloak/dev/main.tf
@@ -1,0 +1,21 @@
+data "keycloak_realm" "pltsvc" {
+  realm = "platform-services"
+}
+
+resource "keycloak_openid_client" "pltsvc" {
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = "pltsvc"
+
+  name    = "platform registry app"
+  enabled = true
+
+  standard_flow_enabled        = true
+  implicit_flow_enabled        = false
+  direct_access_grants_enabled = false
+  service_accounts_enabled     = false
+
+  access_type = "CONFIDENTIAL"
+  valid_redirect_uris = [
+    "https://dev-pltsvc.apps.silver.devops.gov.bc.ca/*"
+  ]
+}

--- a/terraform/keycloak/dev/ministry-roles.tf
+++ b/terraform/keycloak/dev/ministry-roles.tf
@@ -1,0 +1,21 @@
+locals {
+  ministry_codes = ["citz", "hlth"]
+}
+
+resource "keycloak_role" "pltsvc_ministry_admin" {
+  for_each  = toset(local.ministry_codes)
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "ministry-${each.value}-admin"
+  description = "Ministry ${each.value} Administrator"
+}
+
+resource "keycloak_role" "pltsvc_ministry_reader" {
+  for_each  = toset(local.ministry_codes)
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "ministry-${each.value}-reader"
+  description = "Ministry ${each.value} Read-Only"
+}

--- a/terraform/keycloak/dev/roles.tf
+++ b/terraform/keycloak/dev/roles.tf
@@ -13,35 +13,3 @@ resource "keycloak_role" "pltsvc_reader" {
   name        = "reader"
   description = "Registry Read-Only"
 }
-
-resource "keycloak_role" "pltsvc_ministry_citz_admin" {
-  realm_id  = data.keycloak_realm.pltsvc.id
-  client_id = keycloak_openid_client.pltsvc.id
-
-  name        = "ministry-citz-admin"
-  description = "Ministry CITZ Administrator"
-}
-
-resource "keycloak_role" "pltsvc_ministry_citz_reader" {
-  realm_id  = data.keycloak_realm.pltsvc.id
-  client_id = keycloak_openid_client.pltsvc.id
-
-  name        = "ministry-citz-reader"
-  description = "Ministry CITZ Read-Only"
-}
-
-resource "keycloak_role" "pltsvc_ministry_hlth_admin" {
-  realm_id  = data.keycloak_realm.pltsvc.id
-  client_id = keycloak_openid_client.pltsvc.id
-
-  name        = "ministry-hlth-admin"
-  description = "Ministry HLTH Administrator"
-}
-
-resource "keycloak_role" "pltsvc_ministry_hlth_reader" {
-  realm_id  = data.keycloak_realm.pltsvc.id
-  client_id = keycloak_openid_client.pltsvc.id
-
-  name        = "ministry-hlth-reader"
-  description = "Ministry HLTH Read-Only"
-}

--- a/terraform/keycloak/dev/roles.tf
+++ b/terraform/keycloak/dev/roles.tf
@@ -1,0 +1,47 @@
+resource "keycloak_role" "pltsvc_admin" {
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "admin"
+  description = "Registry Administrator"
+}
+
+resource "keycloak_role" "pltsvc_reader" {
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "reader"
+  description = "Registry Read-Only"
+}
+
+resource "keycloak_role" "pltsvc_ministry_citz_admin" {
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "ministry-citz-admin"
+  description = "Ministry CITZ Administrator"
+}
+
+resource "keycloak_role" "pltsvc_ministry_citz_reader" {
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "ministry-citz-reader"
+  description = "Ministry CITZ Read-Only"
+}
+
+resource "keycloak_role" "pltsvc_ministry_hlth_admin" {
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "ministry-hlth-admin"
+  description = "Ministry HLTH Administrator"
+}
+
+resource "keycloak_role" "pltsvc_ministry_hlth_reader" {
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "ministry-hlth-reader"
+  description = "Ministry HLTH Read-Only"
+}

--- a/terraform/keycloak/dev/variables.tf
+++ b/terraform/keycloak/dev/variables.tf
@@ -1,0 +1,23 @@
+variable "client_id" {
+  description = "The client_id for the Keycloak client in 'platform-services' Realm"
+  default     = "realm-admin-cli"
+  type        = string
+}
+
+variable "client_secret" {
+  description = "The client_secret for the Keycloak client in 'platform-services' Realm"
+  type        = string
+  sensitive   = true
+}
+
+variable "url" {
+  description = "The URL of the Keycloak instance"
+  default     = "http://localhost:8080"
+  type        = string
+}
+
+variable "base_path" {
+  description = "The base path used for accessing the Keycloak REST API"
+  default     = "/auth"
+  type        = string
+}

--- a/terraform/keycloak/main.tf
+++ b/terraform/keycloak/main.tf
@@ -1,0 +1,23 @@
+module "keycloak_dev" {
+  source        = "./dev"
+  client_id     = var.dev_client_id
+  client_secret = var.dev_client_secret
+  url           = "https://dev.loginproxy.gov.bc.ca"
+  base_path     = "/auth"
+}
+
+module "keycloak_test" {
+  source        = "./test"
+  client_id     = var.test_client_id
+  client_secret = var.test_client_secret
+  url           = "https://test.loginproxy.gov.bc.ca"
+  base_path     = "/auth"
+}
+
+module "keycloak_prod" {
+  source        = "./prod"
+  client_id     = var.test_client_id
+  client_secret = var.prod_client_secret
+  url           = "https://loginproxy.gov.bc.ca"
+  base_path     = "/auth"
+}

--- a/terraform/keycloak/prod/config.tf
+++ b/terraform/keycloak/prod/config.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "4.3.1"
+    }
+  }
+}
+
+provider "keycloak" {
+  realm         = "platform-services"
+  client_id     = var.client_id
+  client_secret = var.client_secret
+  url           = var.url
+  base_path     = var.base_path
+}

--- a/terraform/keycloak/prod/main.tf
+++ b/terraform/keycloak/prod/main.tf
@@ -1,0 +1,21 @@
+data "keycloak_realm" "pltsvc" {
+  realm = "platform-services"
+}
+
+resource "keycloak_openid_client" "pltsvc" {
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = "pltsvc"
+
+  name    = "platform registry app"
+  enabled = true
+
+  standard_flow_enabled        = true
+  implicit_flow_enabled        = false
+  direct_access_grants_enabled = false
+  service_accounts_enabled     = false
+
+  access_type = "CONFIDENTIAL"
+  valid_redirect_uris = [
+    "https://pltsvc.apps.silver.devops.gov.bc.ca/*"
+  ]
+}

--- a/terraform/keycloak/prod/ministry-roles.tf
+++ b/terraform/keycloak/prod/ministry-roles.tf
@@ -1,0 +1,21 @@
+locals {
+  ministry_codes = ["citz", "hlth"]
+}
+
+resource "keycloak_role" "pltsvc_ministry_admin" {
+  for_each  = toset(local.ministry_codes)
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "ministry-${each.value}-admin"
+  description = "Ministry ${each.value} Administrator"
+}
+
+resource "keycloak_role" "pltsvc_ministry_reader" {
+  for_each  = toset(local.ministry_codes)
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "ministry-${each.value}-reader"
+  description = "Ministry ${each.value} Read-Only"
+}

--- a/terraform/keycloak/prod/roles.tf
+++ b/terraform/keycloak/prod/roles.tf
@@ -13,35 +13,3 @@ resource "keycloak_role" "pltsvc_reader" {
   name        = "reader"
   description = "Registry Read-Only"
 }
-
-resource "keycloak_role" "pltsvc_ministry_citz_admin" {
-  realm_id  = data.keycloak_realm.pltsvc.id
-  client_id = keycloak_openid_client.pltsvc.id
-
-  name        = "ministry-citz-admin"
-  description = "Ministry CITZ Administrator"
-}
-
-resource "keycloak_role" "pltsvc_ministry_citz_reader" {
-  realm_id  = data.keycloak_realm.pltsvc.id
-  client_id = keycloak_openid_client.pltsvc.id
-
-  name        = "ministry-citz-reader"
-  description = "Ministry CITZ Read-Only"
-}
-
-resource "keycloak_role" "pltsvc_ministry_hlth_admin" {
-  realm_id  = data.keycloak_realm.pltsvc.id
-  client_id = keycloak_openid_client.pltsvc.id
-
-  name        = "ministry-hlth-admin"
-  description = "Ministry HLTH Administrator"
-}
-
-resource "keycloak_role" "pltsvc_ministry_hlth_reader" {
-  realm_id  = data.keycloak_realm.pltsvc.id
-  client_id = keycloak_openid_client.pltsvc.id
-
-  name        = "ministry-hlth-reader"
-  description = "Ministry HLTH Read-Only"
-}

--- a/terraform/keycloak/prod/roles.tf
+++ b/terraform/keycloak/prod/roles.tf
@@ -1,0 +1,47 @@
+resource "keycloak_role" "pltsvc_admin" {
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "admin"
+  description = "Registry Administrator"
+}
+
+resource "keycloak_role" "pltsvc_reader" {
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "reader"
+  description = "Registry Read-Only"
+}
+
+resource "keycloak_role" "pltsvc_ministry_citz_admin" {
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "ministry-citz-admin"
+  description = "Ministry CITZ Administrator"
+}
+
+resource "keycloak_role" "pltsvc_ministry_citz_reader" {
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "ministry-citz-reader"
+  description = "Ministry CITZ Read-Only"
+}
+
+resource "keycloak_role" "pltsvc_ministry_hlth_admin" {
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "ministry-hlth-admin"
+  description = "Ministry HLTH Administrator"
+}
+
+resource "keycloak_role" "pltsvc_ministry_hlth_reader" {
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "ministry-hlth-reader"
+  description = "Ministry HLTH Read-Only"
+}

--- a/terraform/keycloak/prod/variables.tf
+++ b/terraform/keycloak/prod/variables.tf
@@ -1,0 +1,23 @@
+variable "client_id" {
+  description = "The client_id for the Keycloak client in 'platform-services' Realm"
+  default     = "realm-admin-cli"
+  type        = string
+}
+
+variable "client_secret" {
+  description = "The client_secret for the Keycloak client in 'platform-services' Realm"
+  type        = string
+  sensitive   = true
+}
+
+variable "url" {
+  description = "The URL of the Keycloak instance"
+  default     = "http://localhost:8080"
+  type        = string
+}
+
+variable "base_path" {
+  description = "The base path used for accessing the Keycloak REST API"
+  default     = "/auth"
+  type        = string
+}

--- a/terraform/keycloak/test/config.tf
+++ b/terraform/keycloak/test/config.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "4.3.1"
+    }
+  }
+}
+
+provider "keycloak" {
+  realm         = "platform-services"
+  client_id     = var.client_id
+  client_secret = var.client_secret
+  url           = var.url
+  base_path     = var.base_path
+}

--- a/terraform/keycloak/test/main.tf
+++ b/terraform/keycloak/test/main.tf
@@ -1,0 +1,21 @@
+data "keycloak_realm" "pltsvc" {
+  realm = "platform-services"
+}
+
+resource "keycloak_openid_client" "pltsvc" {
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = "pltsvc"
+
+  name    = "platform registry app"
+  enabled = true
+
+  standard_flow_enabled        = true
+  implicit_flow_enabled        = false
+  direct_access_grants_enabled = false
+  service_accounts_enabled     = false
+
+  access_type = "CONFIDENTIAL"
+  valid_redirect_uris = [
+    "https://test-pltsvc.apps.silver.devops.gov.bc.ca/*"
+  ]
+}

--- a/terraform/keycloak/test/ministry-roles.tf
+++ b/terraform/keycloak/test/ministry-roles.tf
@@ -1,0 +1,21 @@
+locals {
+  ministry_codes = ["citz", "hlth"]
+}
+
+resource "keycloak_role" "pltsvc_ministry_admin" {
+  for_each  = toset(local.ministry_codes)
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "ministry-${each.value}-admin"
+  description = "Ministry ${each.value} Administrator"
+}
+
+resource "keycloak_role" "pltsvc_ministry_reader" {
+  for_each  = toset(local.ministry_codes)
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "ministry-${each.value}-reader"
+  description = "Ministry ${each.value} Read-Only"
+}

--- a/terraform/keycloak/test/roles.tf
+++ b/terraform/keycloak/test/roles.tf
@@ -13,35 +13,3 @@ resource "keycloak_role" "pltsvc_reader" {
   name        = "reader"
   description = "Registry Read-Only"
 }
-
-resource "keycloak_role" "pltsvc_ministry_citz_admin" {
-  realm_id  = data.keycloak_realm.pltsvc.id
-  client_id = keycloak_openid_client.pltsvc.id
-
-  name        = "ministry-citz-admin"
-  description = "Ministry CITZ Administrator"
-}
-
-resource "keycloak_role" "pltsvc_ministry_citz_reader" {
-  realm_id  = data.keycloak_realm.pltsvc.id
-  client_id = keycloak_openid_client.pltsvc.id
-
-  name        = "ministry-citz-reader"
-  description = "Ministry CITZ Read-Only"
-}
-
-resource "keycloak_role" "pltsvc_ministry_hlth_admin" {
-  realm_id  = data.keycloak_realm.pltsvc.id
-  client_id = keycloak_openid_client.pltsvc.id
-
-  name        = "ministry-hlth-admin"
-  description = "Ministry HLTH Administrator"
-}
-
-resource "keycloak_role" "pltsvc_ministry_hlth_reader" {
-  realm_id  = data.keycloak_realm.pltsvc.id
-  client_id = keycloak_openid_client.pltsvc.id
-
-  name        = "ministry-hlth-reader"
-  description = "Ministry HLTH Read-Only"
-}

--- a/terraform/keycloak/test/roles.tf
+++ b/terraform/keycloak/test/roles.tf
@@ -1,0 +1,47 @@
+resource "keycloak_role" "pltsvc_admin" {
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "admin"
+  description = "Registry Administrator"
+}
+
+resource "keycloak_role" "pltsvc_reader" {
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "reader"
+  description = "Registry Read-Only"
+}
+
+resource "keycloak_role" "pltsvc_ministry_citz_admin" {
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "ministry-citz-admin"
+  description = "Ministry CITZ Administrator"
+}
+
+resource "keycloak_role" "pltsvc_ministry_citz_reader" {
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "ministry-citz-reader"
+  description = "Ministry CITZ Read-Only"
+}
+
+resource "keycloak_role" "pltsvc_ministry_hlth_admin" {
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "ministry-hlth-admin"
+  description = "Ministry HLTH Administrator"
+}
+
+resource "keycloak_role" "pltsvc_ministry_hlth_reader" {
+  realm_id  = data.keycloak_realm.pltsvc.id
+  client_id = keycloak_openid_client.pltsvc.id
+
+  name        = "ministry-hlth-reader"
+  description = "Ministry HLTH Read-Only"
+}

--- a/terraform/keycloak/test/variables.tf
+++ b/terraform/keycloak/test/variables.tf
@@ -1,0 +1,23 @@
+variable "client_id" {
+  description = "The client_id for the Keycloak client in 'platform-services' Realm"
+  default     = "realm-admin-cli"
+  type        = string
+}
+
+variable "client_secret" {
+  description = "The client_secret for the Keycloak client in 'platform-services' Realm"
+  type        = string
+  sensitive   = true
+}
+
+variable "url" {
+  description = "The URL of the Keycloak instance"
+  default     = "http://localhost:8080"
+  type        = string
+}
+
+variable "base_path" {
+  description = "The base path used for accessing the Keycloak REST API"
+  default     = "/auth"
+  type        = string
+}

--- a/terraform/keycloak/variables.tf
+++ b/terraform/keycloak/variables.tf
@@ -1,0 +1,38 @@
+# KEYCLOAK_DEV
+variable "dev_client_id" {
+  description = "The client_id for the Dev Keycloak client in 'platform-services' Realm"
+  default     = "realm-admin-cli"
+  type        = string
+}
+
+variable "dev_client_secret" {
+  description = "The client_secret for the Dev Keycloak client in 'platform-services' Realm"
+  type        = string
+  sensitive   = true
+}
+
+# KEYCLOAK_TEST
+variable "test_client_id" {
+  description = "The client_id for the Test Keycloak client in 'platform-services' Realm"
+  default     = "realm-admin-cli"
+  type        = string
+}
+
+variable "test_client_secret" {
+  description = "The client_secret for the Test Keycloak client in 'platform-services' Realm"
+  type        = string
+  sensitive   = true
+}
+
+# KEYCLOAK_PROD
+variable "prod_client_id" {
+  description = "The client_id for the Test Keycloak client in 'platform-services' Realm"
+  default     = "realm-admin-cli"
+  type        = string
+}
+
+variable "prod_client_secret" {
+  description = "The client_secret for the Test Keycloak client in 'platform-services' Realm"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
let's create new KC clients to avoid any conflicts with the current registry's usage:
please update `AUTH_RESOURCE` to `pltsvc` and `AUTH_SECRET` from new Keycloak clients respectfully:
- dev: https://dev.loginproxy.gov.bc.ca/auth/admin/platform-services/console/#/realms/platform-services/clients/13514f3c-0d09-4ecf-860f-d34cbcebd7b2/credentials
- test: https://test.loginproxy.gov.bc.ca/auth/admin/platform-services/console/#/realms/platform-services/clients/513cb1b1-25da-4095-8ed9-1afa59ca716e/credentials
- dev: https://loginproxy.gov.bc.ca/auth/admin/platform-services/console/#/realms/platform-services/clients/624b2484-cb5b-4d1e-9a7f-87558a01cefd/credentials
