### PR TITLE
fix: add decimal values in budget field

### DIFF
--- a/components/form/Budget.tsx
+++ b/components/form/Budget.tsx
@@ -1,6 +1,7 @@
 import { useFormContext } from 'react-hook-form';
 import classNames from '@/components/utils/classnames';
 import BudgetInput from '@/components/form/BudgetInput';
+import React, { useEffect } from 'react';
 
 export default function Budget({ disabled }: { disabled?: boolean }) {
   const {
@@ -9,6 +10,14 @@ export default function Budget({ disabled }: { disabled?: boolean }) {
   } = useFormContext();
 
   const budget = watch('budget', {});
+
+  useEffect(() => {}, [errors]);
+
+  const totalBudget = [budget.dev, budget.test, budget.prod, budget.tools]
+    .map((value) => Number(value) || 0)
+    .reduce((sum, value) => sum + value, 0);
+
+  const formattedTotalBudget = parseFloat(totalBudget.toFixed(2));
 
   return (
     <div className="border-b border-gray-900/10 pb-14">
@@ -67,12 +76,10 @@ export default function Budget({ disabled }: { disabled?: boolean }) {
             id="total"
             placeholder="Value populated from Dev+Test+Prod+Tools"
             disabled={true}
-            value={[budget.dev, budget.test, budget.prod, budget.tools]
-              .map((value) => Number(value) || 0)
-              .reduce((sum, value) => sum + value, 0)}
+            value={formattedTotalBudget}
           />
           <span className="pointer-events-none absolute left-3 top-0 mb-0 max-w-[90%] origin-[0_0] truncate pt-[0.37rem] leading-[1.6] text-neutral-500 transition-all duration-200 ease-out peer-focus:-translate-y-[0.9rem] peer-focus:scale-[0.8] peer-focus:text-primary peer-data-[te-input-state-active]:-translate-y-[0.9rem] peer-data-[te-input-state-active]:scale-[0.8] motion-reduce:transition-none dark:text-neutral-200 dark:peer-focus:text-primary"></span>
-          {errors.budget && (
+          {Object.keys(errors.budget || {}).length > 0 && (
             <p className={classNames(errors.budget ? 'text-red-400' : '', 'mt-3 text-sm leading-6 text-gray-600')}>
               Budget is required, Every value should be no less than USD 50
             </p>

--- a/components/form/Budget.tsx
+++ b/components/form/Budget.tsx
@@ -1,7 +1,6 @@
 import { useFormContext } from 'react-hook-form';
 import classNames from '@/components/utils/classnames';
 import BudgetInput from '@/components/form/BudgetInput';
-import React, { useEffect } from 'react';
 
 export default function Budget({ disabled }: { disabled?: boolean }) {
   const {
@@ -10,8 +9,6 @@ export default function Budget({ disabled }: { disabled?: boolean }) {
   } = useFormContext();
 
   const budget = watch('budget', {});
-
-  useEffect(() => {}, [errors]);
 
   const totalBudget = [budget.dev, budget.test, budget.prod, budget.tools]
     .map((value) => Number(value) || 0)

--- a/components/form/BudgetInput.tsx
+++ b/components/form/BudgetInput.tsx
@@ -1,9 +1,6 @@
 import { useFormContext } from 'react-hook-form';
-import classNames from '@/components/utils/classnames';
-import React, { useState } from 'react';
 
 export default function BudgetInput({ disabled, title, name }: { disabled?: boolean; title: string; name: string }) {
-  const [inputValue, setInputValue] = useState('50.00');
   const {
     register,
     formState: { errors },
@@ -37,22 +34,6 @@ export default function BudgetInput({ disabled, title, name }: { disabled?: bool
           </span>
         </div>
       </div>
-      {/* <input
-        disabled={disabled}
-        defaultValue={50.00}
-        type="number"
-        step="any"
-        className={classNames(
-          "block w-full rounded-md border-0 py-1.5 pl-7 pr-12 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6",
-          disabled
-            ? 'disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-noneinvalid:border-pink-500 invalid:text-pink-600 focus:invalid:border-pink-500 focus:invalid:ring-pink-500'
-            : '',
-        )}
-        placeholder={'Enter amount here'}
-        {...register(name, {
-          valueAsNumber: true,
-        })}
-      /> */}
     </div>
   );
 }

--- a/components/form/BudgetInput.tsx
+++ b/components/form/BudgetInput.tsx
@@ -1,7 +1,9 @@
 import { useFormContext } from 'react-hook-form';
 import classNames from '@/components/utils/classnames';
+import React, { useState } from 'react';
 
 export default function BudgetInput({ disabled, title, name }: { disabled?: boolean; title: string; name: string }) {
+  const [inputValue, setInputValue] = useState('50.00');
   const {
     register,
     formState: { errors },
@@ -19,6 +21,8 @@ export default function BudgetInput({ disabled, title, name }: { disabled?: bool
         <input
           disabled={disabled}
           type="number"
+          id={name}
+          step="0.01"
           className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none block w-full rounded-md border-0 py-1.5 pl-7 pr-12 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
           placeholder="50.00"
           defaultValue={50.0}

--- a/schema.ts
+++ b/schema.ts
@@ -85,7 +85,7 @@ export const BudgetInputSchema = z.object({
   dev: z.number().min(50.0, 'Value should be no less than USD 50').default(50.0),
   test: z.number().min(50.0, 'Value should be no less than USD 50').default(50.0),
   prod: z.number().min(50.0, 'Value should be no less than USD 50').default(50.0),
-  tools: z.number().min(50.0, 'Value should be no less than USD 50').default(5.0),
+  tools: z.number().min(50.0, 'Value should be no less than USD 50').default(50.0),
 });
 
 export const UserInputSchema = z.object({


### PR DESCRIPTION
- Can now add numbers that contain decimals with up to 2 following digits i.e `50.11`,`50.1`,`50.`
- Floating point precision is now fixed
- Now handling errors properly when adding a decimal value that are more than 2 digits.

<img width="1635" alt="Screenshot 2024-01-09 at 6 14 14 PM" src="https://github.com/bcgov/platform-services-registry/assets/145396323/240a158b-c9c4-4a88-bc6a-4a6e32f325d3">
