### PR TITLE
fix: added link to quota increase process

### DIFF
--- a/components/form/Quotas.tsx
+++ b/components/form/Quotas.tsx
@@ -158,9 +158,17 @@ export default function Quotas({
       </h2>
       <p className="font-bcsans text-base leading-6 mt-5">
         All quota increase requests require <b> Platform Services Team’s </b>
-        approval must have supporting information as per the Quota Increase Request Process. The Quota Requests without
-        supporting information
-        <b> will </b> not be processed.
+        approval, and must have supporting information as per the{' '}
+        <a
+          href="https://docs.developer.gov.bc.ca/request-quota-increase-for-openshift-project-set/"
+          className="text-blue-500 hover:text-blue-400"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Quota Increase Request Process
+        </a>
+        . Any Quota Requests without supporting information
+        <b> will not </b> be processed.
       </p>
       <div className="mt-10 grid grid-cols-1 gap-x-8 xl:gap-x-16 gap-y-8 sm:grid-cols-8 ">
         {(['production', 'test', 'tools', 'development'] as const).map((nameSpace) => (


### PR DESCRIPTION
- Added link to the Quota Increase Request Process documentation page
- Bolding now includes "not" for better clarity
- Addition of a Comma and Conjunction:

Original: 
> "All quota increase requests require Platform Services Team's approval must have supporting information as per the Quota Increase Request Process."

Changed: 

> "All quota increase requests require Platform Services Team’s approval, and must have supporting information as per the Quota Increase Request Process."

Change Explained: A comma and the conjunction "and" were added after "approval". This change improves the sentence structure, making it clearer and grammatically correct.

- Change in the Structure of the Second Sentence:

Original: 

> "The Quota Requests without supporting information will not be processed."

Changed: 

> "Any Quota Requests without supporting information will not be processed."

Change Explained: The phrase "The Quota Requests" was changed to "Any Quota Requests". This change shifts the tone slightly, making it more general and inclusive.

<img width="1635" alt="Screenshot 2024-01-10 at 12 15 33 PM" src="https://github.com/bcgov/platform-services-registry/assets/145396323/0889ed6b-7dce-491e-a8f7-56085989ec43">
