### PR TITLE
feat: public cloud edit request now edit summary email

### DIFF
--- a/ches/public-cloud/emailHandler.ts
+++ b/ches/public-cloud/emailHandler.ts
@@ -12,7 +12,7 @@ import AdminCreateTemplate from '@/emails/_templates/public-cloud/AdminCreateReq
 import CreateRequestTemplate from '@/emails/_templates/public-cloud/CreateRequest';
 import DeleteApprovalTemplate from '@/emails/_templates/public-cloud/DeleteApproval';
 import DeleteRequestTemplate from '@/emails/_templates/public-cloud/DeleteRequest';
-import EditRequestTemplate from '@/emails/_templates/public-cloud/EditRequest';
+import EditSummaryTemplate from '@/emails/_templates/public-cloud/EditSummary';
 import ProvisionedTemplate from '@/emails/_templates/public-cloud/Provisioned';
 import RequestApprovalTemplate from '@/emails/_templates/public-cloud/RequestApproval';
 import RequestRejectionTemplate from '@/emails/_templates/public-cloud/RequestRejection';
@@ -48,7 +48,7 @@ export const sendCreateRequestEmails = async (request: PublicCloudRequestWithReq
 
 export const sendEditRequestEmails = async (request: PublicCloudRequestWithProjectAndRequestedProject) => {
   try {
-    const userEmail = render(EditRequestTemplate({ request }), { pretty: true });
+    const userEmail = render(EditSummaryTemplate({ request }), { pretty: true });
 
     await sendEmail({
       body: userEmail,

--- a/emails/PublicCloudEditRequest.tsx
+++ b/emails/PublicCloudEditRequest.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { samplePublicEditRequest } from './_components/Params';
-import EditRequestTemplate from './_templates/public-cloud/EditRequest';
+import EditSummaryTemplate from './_templates/public-cloud/EditSummary';
 
 const EditRequest = () => {
-  return <EditRequestTemplate request={samplePublicEditRequest} comment="SAMPLE COMMENT" />;
+  return <EditSummaryTemplate request={samplePublicEditRequest} comment="SAMPLE COMMENT" />;
 };
 
 export default EditRequest;

--- a/emails/_components/Edit/BudgetChanges.tsx
+++ b/emails/_components/Edit/BudgetChanges.tsx
@@ -32,7 +32,7 @@ export default function BudgetChanges({
                 <div key={key} className="mb-4">
                   <Text className="font-semibold">{key.toUpperCase()} Budget</Text>
                   <Text className="mt-0 mb-0">Current: USD ${currentValue.toFixed(2)}</Text>
-                  <Text className="mt-0 mb-0">Requested: USD ${requestedValue.toFixed(2)}</Text>
+                  <Text className="mt-0 mb-0">Updated: USD ${requestedValue.toFixed(2)}</Text>
                 </div>
               );
             }
@@ -46,7 +46,7 @@ export default function BudgetChanges({
           <Heading className="text-lg text-black mb-2">Account Coding Changes</Heading>
           <div>
             <Text className="mb-0">Current Account Coding: {accountCodingCurrent}</Text>
-            <Text className="mt-0 mb-0">Requested Account Coding: {accountCodingRequested}</Text>
+            <Text className="mt-0 mb-0">Updated Account Coding: {accountCodingRequested}</Text>
           </div>
         </>
       )}

--- a/emails/_components/Edit/ContactChanges.tsx
+++ b/emails/_components/Edit/ContactChanges.tsx
@@ -8,6 +8,7 @@ export default function ContactChanges({
   poRequested,
   tl1Requested,
   tl2Requested,
+  requestedLabel = 'Requested',
 }: {
   poCurrent: User;
   tl1Current: User;
@@ -15,6 +16,7 @@ export default function ContactChanges({
   poRequested: User;
   tl1Requested: User;
   tl2Requested: User | null;
+  requestedLabel?: string;
 }) {
   return (
     <div>
@@ -28,7 +30,7 @@ export default function ContactChanges({
           <Link className="mb-2" href={`mailto:${poCurrent.email}`}>
             {poCurrent.email}
           </Link>
-          <Text className="font-semibold mb-0">Requested Product Owner</Text>
+          <Text className="font-semibold mb-0">{requestedLabel} Product Owner</Text>
           <Text className="mb-1 mt-2">
             {poRequested.firstName} {poRequested.lastName}
           </Text>
@@ -44,7 +46,7 @@ export default function ContactChanges({
           <Link className="mb-2" href={`mailto:${tl1Current.email}`}>
             {tl1Current.email}
           </Link>
-          <Text className="font-semibold mb-0">Requested Primary Technical Lead</Text>
+          <Text className="font-semibold mb-0">{requestedLabel} Primary Technical Lead</Text>
           <Text className="mb-1 mt-2">
             {tl1Requested.firstName} {tl1Requested.lastName}
           </Text>
@@ -67,7 +69,7 @@ export default function ContactChanges({
           ) : (
             <Text className="mb-1">No Current Lead</Text>
           )}
-          <Text className="font-semibold mb-0">Requested Secondary Technical Lead</Text>
+          <Text className="font-semibold mb-0">{requestedLabel} Secondary Technical Lead</Text>
           {tl2Requested ? (
             <>
               <Text className="mb-1 mt-2">

--- a/emails/_components/Edit/DescriptionChanges.tsx
+++ b/emails/_components/Edit/DescriptionChanges.tsx
@@ -7,6 +7,7 @@ export default function DescriptionChanges({
   nameRequested,
   descRequested,
   ministryRequested,
+  requestedLabel = 'Requested',
 }: {
   nameCurrent: string;
   descCurrent: string;
@@ -14,6 +15,7 @@ export default function DescriptionChanges({
   nameRequested: string;
   descRequested: string;
   ministryRequested: string;
+  requestedLabel?: string;
 }) {
   return (
     <div>
@@ -22,7 +24,7 @@ export default function DescriptionChanges({
         <div className="mb-4">
           <Text className="font-semibold mb-0">Current Product Name</Text>
           <Text className="mt-0 mb-0">{nameCurrent}</Text>
-          <Text className="font-semibold mt-2 mb-0">Requested Product Name</Text>
+          <Text className="font-semibold mt-2 mb-0">{requestedLabel} Product Name</Text>
           <Text className="mt-0">{nameRequested}</Text>
         </div>
       )}
@@ -30,7 +32,7 @@ export default function DescriptionChanges({
         <div className="mb-4">
           <Text className="font-semibold mb-0">Current Description</Text>
           <Text className="mt-0 mb-0">{descCurrent}</Text>
-          <Text className="font-semibold mt-2 mb-0">Requested Description</Text>
+          <Text className="font-semibold mt-2 mb-0">{requestedLabel} Description</Text>
           <Text className="mt-0">{descRequested}</Text>
         </div>
       )}
@@ -38,7 +40,7 @@ export default function DescriptionChanges({
         <div className="mb-4">
           <Text className="font-semibold mb-0">Current Ministry</Text>
           <Text className="mt-0 mb-0">{ministryCurrent}</Text>
-          <Text className="font-semibold mt-2 mb-0">Requested Ministry</Text>
+          <Text className="font-semibold mt-2 mb-0">{requestedLabel} Ministry</Text>
           <Text className="mt-0">{ministryRequested}</Text>
         </div>
       )}

--- a/emails/_templates/public-cloud/EditSummary.tsx
+++ b/emails/_templates/public-cloud/EditSummary.tsx
@@ -7,7 +7,6 @@ import Closing from '../../_components/Closing';
 import { TailwindConfig } from '../../_components/TailwindConfig';
 import { comparePublicCloudProjects } from '../../_components/Edit/utils/compareProjects';
 import ContactChanges from '../../_components/Edit/ContactChanges';
-import QuotaChanges from '../../_components/Edit/QuotaChanges';
 import DescriptionChanges from '../../_components/Edit/DescriptionChanges';
 import BudgetChanges from '../../_components/Edit/BudgetChanges';
 
@@ -16,7 +15,7 @@ interface EmailProp {
   comment?: string;
 }
 
-const EditRequestTemplate = ({ request, comment }: EmailProp) => {
+const EditSummaryTemplate = ({ request, comment }: EmailProp) => {
   if (!request || !request.project || !request.requestedProject) return <></>;
   const current = request.project;
   const requested = request.requestedProject;
@@ -30,17 +29,17 @@ const EditRequestTemplate = ({ request, comment }: EmailProp) => {
           <Body className="bg-white my-auto mx-auto font-sans text-xs text-darkergrey">
             <div className="m-12">
               <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">
-                <Heading className="text-lg text-black">New Edit Product Request!</Heading>
+                <Heading className="text-lg text-black">Your Edit Summary!</Heading>
                 <Text>Hi {current.name} Team, </Text>
                 <Text className="">
-                  You have submitted an edit request for your product with the license plate {request.licencePlate}. Our
-                  administrators have been notified and will review your request.
+                  You have edited your product with the license plate {request.licencePlate}. Here is a summary of your
+                  changes.
                 </Text>
                 <Button
                   href={'https://registry.developer.gov.bc.ca/public-cloud/products/active-requests'}
                   className="bg-bcorange rounded-md px-4 py-2 text-white"
                 >
-                  Review Request
+                  View Changes
                 </Button>
               </div>
               <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">
@@ -56,6 +55,7 @@ const EditRequestTemplate = ({ request, comment }: EmailProp) => {
                     nameRequested={requested.name}
                     descRequested={requested.description}
                     ministryRequested={requested.ministry}
+                    requestedLabel="Updated"
                   />
                 </div>
               )}
@@ -68,6 +68,7 @@ const EditRequestTemplate = ({ request, comment }: EmailProp) => {
                     poRequested={requested.projectOwner}
                     tl1Requested={requested.primaryTechnicalLead}
                     tl2Requested={requested?.secondaryTechnicalLead}
+                    requestedLabel="Updated"
                   />
                 </div>
               )}
@@ -92,4 +93,4 @@ const EditRequestTemplate = ({ request, comment }: EmailProp) => {
   );
 };
 
-export default EditRequestTemplate;
+export default EditSummaryTemplate;

--- a/emails/_templates/public-cloud/EditSummary.tsx
+++ b/emails/_templates/public-cloud/EditSummary.tsx
@@ -32,8 +32,8 @@ const EditSummaryTemplate = ({ request, comment }: EmailProp) => {
                 <Heading className="text-lg text-black">Your Edit Summary!</Heading>
                 <Text>Hi {current.name} Team, </Text>
                 <Text className="">
-                  You have edited your product with the license plate {request.licencePlate}. Here is a summary of your
-                  changes.
+                  You have edited your product in the Public Cloud Landing Zone with the license plate{' '}
+                  {request.licencePlate}. Here is a summary of your changes.
                 </Text>
                 <Button
                   href={'https://registry.developer.gov.bc.ca/public-cloud/products/active-requests'}


### PR DESCRIPTION
Updating the wording of an `edit request` email to now be consistent with an `edit summary` email. This is because the public cloud edit product `edit` process does not have an `admin approval` process, instead once the changes are passed by the provisioner the `edit` changes are automatically applied. So we updated the language to be reflective of that. 