### PR TITLE
fix(1680): fix comments in emails

### DIFF
--- a/app/(product)/private-cloud/(product)/product/[licencePlate]/@decision/page.tsx
+++ b/app/(product)/private-cloud/(product)/product/[licencePlate]/@decision/page.tsx
@@ -54,7 +54,7 @@ export default function RequestDecision({ params }: { params: { licencePlate: st
 
   const methods = useForm({
     resolver: zodResolver(PrivateCloudDecisionRequestBodySchema),
-    values: { humanCommnet: '', decision: '', ...data?.requestedProject },
+    values: { humanComment: '', decision: '', ...data?.requestedProject },
   });
 
   useEffect(() => {
@@ -100,8 +100,8 @@ export default function RequestDecision({ params }: { params: { licencePlate: st
     }
   };
 
-  const setComment = (comment: string) => {
-    onSubmit({ ...methods.getValues(), comment });
+  const setComment = (humanComment: string) => {
+    onSubmit({ ...methods.getValues(), humanComment });
   };
 
   useEffect(() => {

--- a/app/(product)/public-cloud/(product)/product/[licencePlate]/@decision/page.tsx
+++ b/app/(product)/public-cloud/(product)/product/[licencePlate]/@decision/page.tsx
@@ -101,8 +101,8 @@ export default function RequestDecision({ params }: { params: { licencePlate: st
     }
   };
 
-  const setComment = (comment: string) => {
-    onSubmit({ ...methods.getValues(), comment });
+  const setComment = (adminComment: string) => {
+    onSubmit({ ...methods.getValues(), adminComment });
   };
 
   useEffect(() => {

--- a/app/(product)/public-cloud/(product)/product/[licencePlate]/@edit/page.tsx
+++ b/app/(product)/public-cloud/(product)/product/[licencePlate]/@edit/page.tsx
@@ -135,8 +135,8 @@ export default function EditProject({ params }: { params: { licencePlate: string
     }
   }, [data]);
 
-  const setComment = (userComment: string) => {
-    onSubmit({ ...methods.getValues(), userComment });
+  const setComment = (adminComment: string) => {
+    onSubmit({ ...methods.getValues(), adminComment });
   };
 
   return (

--- a/app/api/private-cloud/decision/[licencePlate]/route.ts
+++ b/app/api/private-cloud/decision/[licencePlate]/route.ts
@@ -18,7 +18,7 @@ const ParamsSchema = z.object({
 type Params = z.infer<typeof ParamsSchema>;
 
 export async function POST(req: NextRequest, { params }: { params: Params }) {
-  // Athentication
+  // Authentication
   const session = await getServerSession(authOptions);
 
   if (!session) {

--- a/app/api/private-cloud/edit/[licencePlate]/route.ts
+++ b/app/api/private-cloud/edit/[licencePlate]/route.ts
@@ -74,7 +74,7 @@ export async function POST(req: NextRequest, { params }: { params: Params }) {
   );
 
   if (request.decisionStatus !== DecisionStatus.APPROVED) {
-    sendEditRequestEmails(request, formData.userComment);
+    sendEditRequestEmails(request);
     return new NextResponse(
       'Successfully edited project, admin approval will be required for this request to be provisioned ',
       { status: 200 },
@@ -108,7 +108,7 @@ export async function POST(req: NextRequest, { params }: { params: Params }) {
 
   await subscribeUsersToMautic(users, request.requestedProject.cluster, 'Private');
 
-  sendEditRequestEmails(request, formData.userComment);
+  sendEditRequestEmails(request);
 
   return new NextResponse('success', { status: 200 });
 }

--- a/app/api/public-cloud/decision/[licencePlate]/route.ts
+++ b/app/api/public-cloud/decision/[licencePlate]/route.ts
@@ -18,7 +18,7 @@ const ParamsSchema = z.object({
 type Params = z.infer<typeof ParamsSchema>;
 
 export async function POST(req: NextRequest, { params }: { params: Params }) {
-  // Athentication
+  // Authentication
   const session = await getServerSession(authOptions);
 
   if (!session) {
@@ -52,12 +52,12 @@ export async function POST(req: NextRequest, { params }: { params: Params }) {
   }
 
   const { licencePlate } = parsedParams.data;
-  const { decision, humanComment, ...requestedProjectFormData } = parsedBody.data;
+  const { decision, adminComment, ...requestedProjectFormData } = parsedBody.data;
 
   const request: PublicCloudRequestWithProjectAndRequestedProject = await makeDecisionRequest(
     licencePlate,
     decision,
-    humanComment,
+    adminComment,
     requestedProjectFormData,
     authEmail,
   );
@@ -69,7 +69,7 @@ export async function POST(req: NextRequest, { params }: { params: Params }) {
   }
 
   if (request.decisionStatus !== DecisionStatus.APPROVED) {
-    sendRequestRejectionEmails(request.requestedProject, humanComment);
+    sendRequestRejectionEmails(request.requestedProject, adminComment);
     return new Response(
       `Decision request for ${request.licencePlate} successfully created. Admin approval is required`,
       {

--- a/app/api/public-cloud/edit/[licencePlate]/route.ts
+++ b/app/api/public-cloud/edit/[licencePlate]/route.ts
@@ -41,7 +41,6 @@ export async function POST(req: NextRequest, { params }: { params: Params }) {
   if (!parsedBody.success) {
     return new NextResponse(parsedBody.error.message, { status: 400 });
   }
-
   const formData: PublicCloudEditRequestBody = parsedBody.data;
   const { licencePlate } = parsedParams.data;
 

--- a/ches/private-cloud/emailHandler.ts
+++ b/ches/private-cloud/emailHandler.ts
@@ -37,7 +37,7 @@ export const sendCreateRequestEmails = async (request: PrivateCloudRequestWithRe
         request.requestedProject.primaryTechnicalLead.email,
         request.requestedProject.secondaryTechnicalLead?.email,
       ],
-      subject: 'Rrovisioning request received',
+      subject: 'Provisioning request received',
     });
 
     await Promise.all([contacts, admins]);
@@ -46,19 +46,16 @@ export const sendCreateRequestEmails = async (request: PrivateCloudRequestWithRe
   }
 };
 
-export const sendEditRequestEmails = async (
-  request: PrivateCloudRequestWithProjectAndRequestedProject,
-  comment?: string,
-) => {
+export const sendEditRequestEmails = async (request: PrivateCloudRequestWithProjectAndRequestedProject) => {
   try {
     const adminEmail = render(AdminEditRequestTemplate({ request }), { pretty: true });
-    const userEmail = render(EditRequestTemplate({ request, comment }), { pretty: true });
+    const userEmail = render(EditRequestTemplate({ request }), { pretty: true });
 
     const admins = sendEmail({
       bodyType: 'html',
       body: adminEmail,
       to: adminEmails,
-      subject: 'Request has been approved',
+      subject: 'Edit request submitted',
     });
 
     const contacts = sendEmail({
@@ -71,7 +68,7 @@ export const sendEditRequestEmails = async (
         request.project?.primaryTechnicalLead.email,
         request.project?.secondaryTechnicalLead?.email,
       ].filter(Boolean),
-      subject: 'Request has been approved',
+      subject: 'Edit request submitted',
     });
 
     await Promise.all([contacts, admins]);
@@ -82,6 +79,7 @@ export const sendEditRequestEmails = async (
 };
 
 export const sendRequestApprovalEmails = async (request: PrivateCloudRequestWithRequestedProject) => {
+  console.log(request);
   try {
     const email = render(RequestApprovalTemplate({ request }), { pretty: true });
 
@@ -101,16 +99,16 @@ export const sendRequestApprovalEmails = async (request: PrivateCloudRequestWith
 
 export const sendRequestRejectionEmails = async (
   request: PrivateCloudRequestedProjectWithContacts,
-  comment?: string,
+  humanComment?: string,
 ) => {
   try {
-    const email = render(RequestRejectionTemplate({ productName: request.name, comment }), {
+    const email = render(RequestRejectionTemplate({ productName: request.name, humanComment }), {
       pretty: true,
     });
     await sendEmail({
       body: email,
       to: [request.projectOwner.email, request.primaryTechnicalLead.email, request.secondaryTechnicalLead?.email],
-      subject: 'Request has been approved',
+      subject: 'Request has been rejected',
     });
   } catch (error) {
     console.error('ERROR SENDING REQUEST REJECTION EMAIL');
@@ -124,7 +122,7 @@ export const sendDeleteRequestEmails = async (product: PrivateCloudRequestedProj
     await sendEmail({
       body: email,
       to: [product.projectOwner.email, product.primaryTechnicalLead.email, product.secondaryTechnicalLead?.email],
-      subject: 'Request deletion request has been received',
+      subject: 'Request to delete product received',
     });
   } catch (error) {
     console.error('ERROR SENDING NEW DELETE REQUEST EMAIL');
@@ -138,7 +136,7 @@ export const sendDeleteRequestApprovalEmails = async (product: PrivateCloudReque
     await sendEmail({
       body: email,
       to: [product.projectOwner.email, product.primaryTechnicalLead.email, product.secondaryTechnicalLead?.email],
-      subject: 'Deletion request has been approved',
+      subject: 'Delete request has been approved',
     });
   } catch (error) {
     console.error('ERROR SENDING NEW DELETE REQUEST APPROVAL EMAIL');

--- a/ches/public-cloud/emailHandler.ts
+++ b/ches/public-cloud/emailHandler.ts
@@ -38,7 +38,7 @@ export const sendCreateRequestEmails = async (request: PublicCloudRequestWithReq
         request.requestedProject.primaryTechnicalLead.email,
         request.requestedProject.secondaryTechnicalLead?.email,
       ],
-      subject: `${request.requestedProject.name} provisioning request received`,
+      subject: 'Provisioning request received',
     });
 
     await Promise.all([contacts, admins]);
@@ -75,7 +75,7 @@ export const sendEditRequestEmails = async (request: PublicCloudRequestWithProje
         request.project?.primaryTechnicalLead.email,
         request.project?.secondaryTechnicalLead?.email,
       ].filter(Boolean),
-      subject: `${request.requestedProject.name} has been approved`,
+      subject: 'Edit summary',
     });
   } catch (error) {
     console.error('ERROR SENDING EDIT REQUEST EMAIL');
@@ -93,7 +93,7 @@ export const sendRequestApprovalEmails = async (request: PublicCloudRequestWithR
         request.requestedProject.primaryTechnicalLead.email,
         request.requestedProject.secondaryTechnicalLead?.email,
       ],
-      subject: `${request.requestedProject.name} has been approved`,
+      subject: 'Request has been approved',
     });
   } catch (error) {
     console.error('ERROR SENDING REQUEST APPROVAL EMAIL');
@@ -102,16 +102,17 @@ export const sendRequestApprovalEmails = async (request: PublicCloudRequestWithR
 
 export const sendRequestRejectionEmails = async (
   request: PublicCloudRequestedProjectWithContacts,
-  comment?: string,
+  adminComment?: string,
 ) => {
+  console.log(request);
   try {
-    const email = render(RequestRejectionTemplate({ productName: request.name, comment }), {
+    const email = render(RequestRejectionTemplate({ productName: request.name, adminComment }), {
       pretty: true,
     });
     await sendEmail({
       body: email,
       to: [request.projectOwner.email, request.primaryTechnicalLead.email, request.secondaryTechnicalLead?.email],
-      subject: `${request.name} has been approved`,
+      subject: 'Request has been rejected',
     });
   } catch (error) {
     console.error('ERROR SENDING REQUEST REJECTION EMAIL');
@@ -125,7 +126,7 @@ export const sendDeleteRequestEmails = async (product: PublicCloudRequestedProje
     await sendEmail({
       body: email,
       to: [product.projectOwner.email, product.primaryTechnicalLead.email, product.secondaryTechnicalLead?.email],
-      subject: `${product.name} deletion request has been received`,
+      subject: 'Request to delete product received',
     });
   } catch (error) {
     console.error('ERROR SENDING NEW DELETE REQUEST EMAIL');
@@ -139,7 +140,7 @@ export const sendDeleteRequestApprovalEmails = async (product: PublicCloudReques
     await sendEmail({
       body: email,
       to: [product.projectOwner.email, product.primaryTechnicalLead.email, product.secondaryTechnicalLead?.email],
-      subject: `${product.name} deletion request has been approved`,
+      subject: 'Delete request has been approved',
     });
   } catch (error) {
     console.error('ERROR SENDING NEW DELETE REQUEST APPROVAL EMAIL');
@@ -153,7 +154,7 @@ export const sendProvisionedEmails = async (product: PublicCloudRequestedProject
     await sendEmail({
       body: email,
       to: [product.projectOwner.email, product.primaryTechnicalLead.email, product.secondaryTechnicalLead?.email],
-      subject: `${product.name} has been provisioned`,
+      subject: `Product has been provisioned`,
     });
   } catch (error) {
     console.error('ERROR SENDING NEW PROVISIONED EMAIL');

--- a/emails/PrivateCloudEditRequest.tsx
+++ b/emails/PrivateCloudEditRequest.tsx
@@ -3,7 +3,7 @@ import { samplePrivateEditRequest } from './_components/Params';
 import EditRequestTemplate from './_templates/private-cloud/EditRequest';
 
 export const EditRequest = () => {
-  return <EditRequestTemplate request={samplePrivateEditRequest} comment="SAMPLE COMMENT" />;
+  return <EditRequestTemplate request={samplePrivateEditRequest} />;
 };
 
 export default EditRequest;

--- a/emails/PrivateCloudRequestRejection.tsx
+++ b/emails/PrivateCloudRequestRejection.tsx
@@ -3,7 +3,10 @@ import { samplePrivateRequest } from './_components/Params';
 import RequestRejectionTemplate from './_templates/private-cloud/RequestRejection';
 
 export const RequestRejection = () => {
-  return <RequestRejectionTemplate productName={samplePrivateRequest.requestedProject.name} comment="SAMPLE COMMENT" />;
+  const productName = samplePrivateRequest.requestedProject.name;
+  const humanComment = samplePrivateRequest.humanComment || undefined;
+
+  return <RequestRejectionTemplate productName={productName} humanComment={humanComment} />;
 };
 
 export default RequestRejection;

--- a/emails/PublicCloudEditRequest.tsx
+++ b/emails/PublicCloudEditRequest.tsx
@@ -3,7 +3,7 @@ import { samplePublicEditRequest } from './_components/Params';
 import EditSummaryTemplate from './_templates/public-cloud/EditSummary';
 
 const EditRequest = () => {
-  return <EditSummaryTemplate request={samplePublicEditRequest} comment="SAMPLE COMMENT" />;
+  return <EditSummaryTemplate request={samplePublicEditRequest} />;
 };
 
 export default EditRequest;

--- a/emails/PublicCloudRequestRejection.tsx
+++ b/emails/PublicCloudRequestRejection.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
-import { samplePrivateRequest } from './_components/Params';
+import { samplePublicRequest } from './_components/Params';
 import RequestRejectionTemplate from './_templates/public-cloud/RequestRejection';
 
 export const RequestRejection = () => {
-  return <RequestRejectionTemplate productName={samplePrivateRequest.requestedProject.name} comment="SAMPLE COMMENT" />;
+  // Extract the product name and human comment from the samplePublicRequest
+  const productName = samplePublicRequest.requestedProject.name;
+  const adminComment = samplePublicRequest.adminComment || undefined;
+
+  return <RequestRejectionTemplate productName={productName} adminComment={adminComment} />;
 };
 
 export default RequestRejection;

--- a/emails/_components/Comment.tsx
+++ b/emails/_components/Comment.tsx
@@ -1,0 +1,24 @@
+import { Text } from '@react-email/components';
+
+interface CommentProps {
+  userComment?: string | null;
+  adminComment?: string | null;
+}
+
+export default function Comment({ userComment, adminComment }: CommentProps) {
+  return (
+    <div>
+      {userComment && (
+        <div>
+          <Text>{userComment}</Text>
+        </div>
+      )}
+      {adminComment && (
+        <div>
+          <Text className="font-semibold">Admin Comment:</Text>
+          <Text>{adminComment}</Text>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/emails/_components/NamespaceDetails.tsx
+++ b/emails/_components/NamespaceDetails.tsx
@@ -1,9 +1,17 @@
 import { Heading, Text, Link } from '@react-email/components';
 
-export default function NamespaceDetails({ cluster, licencePlate }: { cluster: string; licencePlate?: string }) {
+export default function NamespaceDetails({
+  cluster,
+  licencePlate,
+  showNamespaceDetailsTitle = true,
+}: {
+  cluster: string;
+  licencePlate?: string;
+  showNamespaceDetailsTitle?: boolean;
+}) {
   return (
     <div>
-      <Heading className="text-lg">Namespace Details</Heading>
+      {showNamespaceDetailsTitle && <Heading className="text-lg">Namespace Details</Heading>}
       <div>
         <Text className="mb-1 font-semibold h-4">OpenShift Cluster: </Text>
         <Text className="mt-1 h-4">{cluster}</Text>

--- a/emails/_components/Params.ts
+++ b/emails/_components/Params.ts
@@ -20,7 +20,7 @@ export const samplePublicRequest: PublicCloudRequestWithRequestedProject = {
   decisionMakerEmail: 'manager@example.com',
   type: 'CREATE', // or EDIT
   decisionStatus: 'PENDING', // or APPROVED, REJECTED, PROVISIONED
-  humanComment: 'This is a sample request',
+  adminComment: 'This is a sample request',
   active: true,
   created: new Date('2023-11-30T00:00:00Z'),
   decisionDate: new Date('2023-12-01T00:00:00Z'),
@@ -83,7 +83,7 @@ export const samplePublicEditRequest: PublicCloudRequestWithProjectAndRequestedP
   decisionMakerEmail: 'decider@example.com',
   type: 'CREATE', // or EDIT
   decisionStatus: 'PENDING', // or APPROVED, REJECTED, PROVISIONED
-  humanComment: 'This is an example request',
+  adminComment: 'This is an example request',
   active: true,
   created: new Date('2023-11-30T00:00:00Z'),
   decisionDate: new Date('2023-12-01T00:00:00Z'),
@@ -259,7 +259,7 @@ export const samplePrivateRequest: PrivateCloudRequestWithRequestedProject = {
   decisionDate: sampleDate,
   isQuotaChanged: false,
   projectId: null,
-  userComment: 'Some comment',
+  userComment: 'Some comment regarding a request by the user',
   requestedProjectId: 'f',
   userRequestedProjectId: 'e',
   requestedProject: {
@@ -349,7 +349,7 @@ export const samplePrivateEditRequest: PrivateCloudRequestWithProjectAndRequeste
   created: sampleDate,
   isQuotaChanged: false,
   decisionDate: sampleDate,
-  userComment: 'Some comment',
+  userComment: 'Some comment made by the user',
   projectId: null,
   requestedProjectId: 'f',
   userRequestedProjectId: 'e',

--- a/emails/_templates/private-cloud/AdminCreateRequest.tsx
+++ b/emails/_templates/private-cloud/AdminCreateRequest.tsx
@@ -19,7 +19,7 @@ const NewRequestTemplate = ({ request }: EmailProp) => {
       <Tailwind config={TailwindConfig}>
         <div className="border border-solid border-[#eaeaea] rounded my-4 mx-auto p-4 max-w-xl">
           <Header />
-          <Body className="bg-white my-auto mx-auto font-sans text-xs">
+          <Body className="bg-white my-auto mx-auto font-sans text-xs text-darkergrey">
             <div className="m-12">
               <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">
                 <Heading className="text-lg">New Request!</Heading>
@@ -36,7 +36,7 @@ const NewRequestTemplate = ({ request }: EmailProp) => {
                   Review Request
                 </Button>
               </div>
-              <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">
+              <div>
                 <ProductDetails
                   name={request.requestedProject.name}
                   description={request.requestedProject.description}
@@ -47,7 +47,7 @@ const NewRequestTemplate = ({ request }: EmailProp) => {
                 />
               </div>
               <div>
-                <NamespaceDetails cluster={request.requestedProject.cluster} />
+                <NamespaceDetails cluster={request.requestedProject.cluster} showNamespaceDetailsTitle={false} />
               </div>
             </div>
           </Body>

--- a/emails/_templates/private-cloud/AdminEditRequest.tsx
+++ b/emails/_templates/private-cloud/AdminEditRequest.tsx
@@ -19,7 +19,7 @@ const NewRequestTemplate = ({ request }: EmailProp) => {
       <Tailwind config={TailwindConfig}>
         <div className="border border-solid border-[#eaeaea] rounded my-4 mx-auto p-4 max-w-xl">
           <Header />
-          <Body className="bg-white my-auto mx-auto font-sans text-xs">
+          <Body className="bg-white my-auto mx-auto font-sans text-xs text-darkergrey">
             <div className="m-12">
               <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">
                 <Heading className="text-lg">New Request!</Heading>
@@ -36,7 +36,7 @@ const NewRequestTemplate = ({ request }: EmailProp) => {
                   Review Request
                 </Button>
               </div>
-              <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">
+              <div>
                 <ProductDetails
                   name={request.requestedProject.name}
                   description={request.requestedProject.description}
@@ -47,7 +47,7 @@ const NewRequestTemplate = ({ request }: EmailProp) => {
                 />
               </div>
               <div>
-                <NamespaceDetails cluster={request.requestedProject.cluster} />
+                <NamespaceDetails cluster={request.requestedProject.cluster} showNamespaceDetailsTitle={false} />
               </div>
             </div>
           </Body>

--- a/emails/_templates/private-cloud/CreateRequest.tsx
+++ b/emails/_templates/private-cloud/CreateRequest.tsx
@@ -20,7 +20,7 @@ const NewRequestTemplate = ({ request }: EmailProp) => {
       <Tailwind config={TailwindConfig}>
         <div className="border border-solid border-[#eaeaea] rounded my-4 mx-auto p-4 max-w-xl">
           <Header />
-          <Body className="bg-white my-auto mx-auto font-sans text-xs">
+          <Body className="bg-white my-auto mx-auto font-sans text-xs text-darkergrey">
             <div className="m-12">
               <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">
                 <Heading className="text-lg">New Request!</Heading>
@@ -36,7 +36,7 @@ const NewRequestTemplate = ({ request }: EmailProp) => {
                   Review Request
                 </Button>
               </div>
-              <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">
+              <div>
                 <ProductDetails
                   name={request.requestedProject.name}
                   description={request.requestedProject.description}
@@ -47,7 +47,7 @@ const NewRequestTemplate = ({ request }: EmailProp) => {
                 />
               </div>
               <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">
-                <NamespaceDetails cluster={request.requestedProject.cluster} />
+                <NamespaceDetails cluster={request.requestedProject.cluster} showNamespaceDetailsTitle={false} />
               </div>
               <div>
                 <Closing />

--- a/emails/_templates/private-cloud/DeleteApproval.tsx
+++ b/emails/_templates/private-cloud/DeleteApproval.tsx
@@ -20,7 +20,7 @@ const DeleteApprovalTemplate = ({ product }: EmailProp) => {
       <Tailwind config={TailwindConfig}>
         <div className="border border-solid border-[#eaeaea] rounded my-4 mx-auto p-4 max-w-xl">
           <Header />
-          <Body className="bg-white my-auto mx-auto font-sans text-xs lassName='text-darkergrey'">
+          <Body className="bg-white my-auto mx-auto font-sans text-xs text-darkergrey">
             <div className="m-12">
               <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">
                 <Heading className="text-lg text-black">Your deletion request has been completed!</Heading>

--- a/emails/_templates/private-cloud/DeleteRequest.tsx
+++ b/emails/_templates/private-cloud/DeleteRequest.tsx
@@ -20,7 +20,7 @@ const DeleteRequestTemplate = ({ product }: EmailProp) => {
       <Tailwind config={TailwindConfig}>
         <div className="border border-solid border-[#eaeaea] rounded my-4 mx-auto p-4 max-w-xl">
           <Header />
-          <Body className="bg-white my-auto mx-auto font-sans text-xs lassName='text-darkergrey'">
+          <Body className="bg-white my-auto mx-auto font-sans text-xs text-darkergrey">
             <div className="m-12">
               <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">
                 <Heading className="text-lg text-black">

--- a/emails/_templates/private-cloud/EditRequest.tsx
+++ b/emails/_templates/private-cloud/EditRequest.tsx
@@ -10,24 +10,25 @@ import ContactChanges from '../../_components/Edit/ContactChanges';
 import QuotaChanges from '../../_components/Edit/QuotaChanges';
 import DescriptionChanges from '../../_components/Edit/DescriptionChanges';
 import { BASE_URL } from '@/config';
+import Comment from '@/emails/_components/Comment';
 
 interface EmailProp {
   request: PrivateCloudRequestWithProjectAndRequestedProject;
-  comment?: string;
 }
 
-const EditRequestTemplate = ({ request, comment }: EmailProp) => {
+const EditRequestTemplate = ({ request }: EmailProp) => {
   if (!request || !request.project || !request.requestedProject) return <></>;
   const current = request.project;
   const requested = request.requestedProject;
   const changed = comparePrivateCloudProjects(current, requested);
+  const userComment = request.userComment ?? undefined;
 
   return (
     <Html>
       <Tailwind config={TailwindConfig}>
         <div className="border border-solid border-[#eaeaea] rounded my-4 mx-auto p-4 max-w-xl">
           <Header />
-          <Body className="bg-white my-auto mx-auto font-sans text-xs lassName='text-darkergrey'">
+          <Body className="bg-white my-auto mx-auto font-sans text-xs text-darkergrey">
             <div className="m-12">
               <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">
                 <Heading className="text-lg text-black">New Edit Product Request!</Heading>
@@ -42,7 +43,7 @@ const EditRequestTemplate = ({ request, comment }: EmailProp) => {
               </div>
               <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">
                 <Heading className="text-lg text-black">Comments</Heading>
-                <Text className="mb-0">{comment}</Text>
+                <Comment userComment={userComment} />
               </div>
               {(changed.name || changed.description || changed.ministry || changed.cluster) && (
                 <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">

--- a/emails/_templates/private-cloud/Provisioned.tsx
+++ b/emails/_templates/private-cloud/Provisioned.tsx
@@ -20,16 +20,13 @@ const ProvisionedTemplate = ({ product }: EmailProp) => {
       <Tailwind config={TailwindConfig}>
         <div className="border border-solid border-[#eaeaea] rounded my-4 mx-auto p-4 max-w-xl">
           <Header />
-          <Body className="bg-white my-auto mx-auto font-sans text-xs lassName='text-darkergrey'">
+          <Body className="bg-white my-auto mx-auto font-sans text-xs text-darkergrey">
             <div className="m-12">
               <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">
-                <Heading className="text-lg text-black">
-                  Hurray! Your Edit Product request was approved and completed!
-                </Heading>
+                <Heading className="text-lg text-black">Hurray! Your request was approved and completed!</Heading>
                 <Text>Hi {product.name} Team, </Text>
                 <Text className="">
-                  Your request for a new project set for your product on the Private Cloud Openshift platform is
-                  complete.{' '}
+                  Your request for your product on the Private Cloud Openshift platform is complete.{' '}
                   <Link className="mt-0 h-4" href={`https://console.apps.${product.cluster}.devops.gov.bc.ca/`}>
                     Log in to the cluster console
                   </Link>{' '}
@@ -41,10 +38,10 @@ const ProvisionedTemplate = ({ product }: EmailProp) => {
                 </Text>
                 <Text className="">
                   The Product Owner and the Technical Lead have been provisioned with admin access to the namespaces
-                  below and can add other users as necessary. Please note that if a Product Owner or a Technical Lead is
-                  removed as a project contact in the Platform Registry, they will lose their access to the project set
-                  namespaces in Openshift. The new Product or Technical Lead provided on the product details page will
-                  gain the administrative access to the namespaces.
+                  below, and can add other users as necessary. Please note that if a Product Owner or a Technical Lead
+                  is removed as a project contact in the Platform Registry, they will lose their access to the project
+                  set namespaces in Openshift. The new Product or Technical Lead provided on the product details page
+                  will gain the administrative access to the namespaces.
                 </Text>
                 <Button
                   href={`https://console.apps.${product.cluster}.devops.gov.bc.ca/`}

--- a/emails/_templates/private-cloud/RequestRejection.tsx
+++ b/emails/_templates/private-cloud/RequestRejection.tsx
@@ -4,21 +4,21 @@ import { Body, Button, Heading, Html, Text } from '@react-email/components';
 import { Tailwind } from '@react-email/tailwind';
 import Closing from '../../_components/Closing';
 import { TailwindConfig } from '../../_components/TailwindConfig';
+import Comment from '@/emails/_components/Comment';
 
 interface EmailProp {
   productName: string;
-  comment?: string;
+  humanComment?: string;
 }
 
-const RequestRejectionTemplate = ({ productName, comment }: EmailProp) => {
+const RequestRejectionTemplate = ({ productName, humanComment }: EmailProp) => {
   if (!productName) return <></>;
-
   return (
     <Html>
       <Tailwind config={TailwindConfig}>
         <div className="border border-solid border-[#eaeaea] rounded my-4 mx-auto p-4 max-w-xl">
           <Header />
-          <Body className="bg-white my-auto mx-auto font-sans text-xs">
+          <Body className="bg-white my-auto mx-auto font-sans text-xs text-darkergrey">
             <div className="m-12">
               <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">
                 <Heading className="text-lg text-black">Sorry, your request was rejected</Heading>
@@ -27,7 +27,7 @@ const RequestRejectionTemplate = ({ productName, comment }: EmailProp) => {
                   Your request regarding the product {productName} on the Private Cloud Openshift platform has been
                   rejected due to the following reason(s):
                 </Text>
-                <Text className="">{comment}</Text>
+                <Comment adminComment={humanComment} />
                 <Text>
                   Log in to your registry account and raise a new request if the above rejection reason no longer
                   applies

--- a/emails/_templates/public-cloud/EditSummary.tsx
+++ b/emails/_templates/public-cloud/EditSummary.tsx
@@ -44,7 +44,7 @@ const EditSummaryTemplate = ({ request, comment }: EmailProp) => {
               </div>
               <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">
                 <Heading className="text-lg text-black">Comments</Heading>
-                <Text className="mb-0">{comment}</Text>
+                <Text className="mb-0">{request.adminComment}</Text>
               </div>
               {(changed.name || changed.description || changed.ministry) && (
                 <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">

--- a/emails/_templates/public-cloud/Provisioned.tsx
+++ b/emails/_templates/public-cloud/Provisioned.tsx
@@ -33,23 +33,21 @@ const ProvisionedTemplate = ({ product }: EmailProp) => {
           <Body className="bg-white my-auto mx-auto font-sans text-xs text-darkergrey">
             <div className="m-12">
               <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">
-                <Heading className="text-lg text-black">
-                  Hurray! Your Edit Product request was approved and completed!
-                </Heading>
+                <Heading className="text-lg text-black">Hurray! Your request was approved and completed!</Heading>
                 <Text>Hi {product.name} Team, </Text>
                 <Text className="">
-                  Your request for a new project set for your product on the Public Cloud platform is complete. If you
-                  have any more questions reach out to the Platform Services team in the RocketChat channel{' '}
+                  Your request for your product on the Public Cloud platform is complete. If you have any more questions
+                  reach out to the Platform Services team in the RocketChat channel{' '}
                   <Link className="mt-0 h-4" href={`https://chat.developer.gov.bc.ca/channel/devops-operations`}>
                     #devops&#8209;operations
                   </Link>
                 </Text>
                 <Text className="">
-                  The Product Owner and the Technical Lead have been provisioned with admin access and can add other
-                  users as necessary. Please note that if a Product Owner or a Technical Lead is removed as a project
-                  contact in the Platform Registry, they will lose their access to the project set namespaces. The new
-                  Product or Technical Lead provided on the product details page will gain the administrative access to
-                  the namespaces.
+                  The Product Owner and the Technical Lead have been provisioned with access, and can add other users as
+                  necessary. Please note that if a Product Owner or a Technical Lead is removed as a project contact in
+                  the Platform Registry, they will lose their access to the project set namespaces. The new Product or
+                  Technical Lead provided on the product details page will gain the administrative access to the
+                  namespaces.
                 </Text>
               </div>
               <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">

--- a/emails/_templates/public-cloud/RequestApproval.tsx
+++ b/emails/_templates/public-cloud/RequestApproval.tsx
@@ -75,8 +75,8 @@ const RequestApprovalTemplate = ({ request }: EmailProp) => {
               </div>
               <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">
                 <div>
-                  <Heading className="text-lg">Comment</Heading>
-                  <div> {request.humanComment}</div>
+                  <Heading className="text-lg">Comments</Heading>
+                  <div> {request.adminComment}</div>
                 </div>
               </div>
               <div>

--- a/emails/_templates/public-cloud/RequestRejection.tsx
+++ b/emails/_templates/public-cloud/RequestRejection.tsx
@@ -4,15 +4,15 @@ import { Body, Button, Heading, Html, Text } from '@react-email/components';
 import { Tailwind } from '@react-email/tailwind';
 import Closing from '../../_components/Closing';
 import { TailwindConfig } from '../../_components/TailwindConfig';
+import Comment from '@/emails/_components/Comment';
 
 interface EmailProp {
   productName: string;
-  comment?: string;
+  adminComment?: string;
 }
 
-const RequestRejectionTemplate = ({ productName, comment }: EmailProp) => {
+const RequestRejectionTemplate = ({ productName, adminComment }: EmailProp) => {
   if (!productName) return <></>;
-
   return (
     <Html>
       <Tailwind config={TailwindConfig}>
@@ -27,7 +27,7 @@ const RequestRejectionTemplate = ({ productName, comment }: EmailProp) => {
                   Your request for the product on the Public Cloud Landing Zone has been rejected due to the following
                   reason(s):
                 </Text>
-                <Text className="">{comment}</Text>
+                <Comment adminComment={adminComment} />
                 <Text>
                   Log in to your registry account and raise a new request if the above rejection reason no longer
                   applies
@@ -38,10 +38,6 @@ const RequestRejectionTemplate = ({ productName, comment }: EmailProp) => {
                 >
                   Log in to Registry
                 </Button>
-              </div>
-              <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">
-                <Heading className="text-lg text-black">Comments</Heading>
-                <Text className="mb-0">{comment}</Text>
               </div>
               <div>
                 <Closing email="Cloud.Pathfinder@gov.bc.ca" />

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -113,7 +113,7 @@ model PublicCloudRequest {
   decisionMakerEmail     String?
   type                   PublicCloudRequestType
   decisionStatus         DecisionStatus
-  humanComment           String?
+  adminComment           String?
   active                 Boolean                      @default(true)
   created                DateTime                     @default(now())
   decisionDate           DateTime?

--- a/requestActions/public-cloud/decisionRequest.ts
+++ b/requestActions/public-cloud/decisionRequest.ts
@@ -101,7 +101,7 @@ export default async function makeDecisionRequest(
     },
     data: {
       decisionStatus: decision,
-      humanComment: comment,
+      adminComment: comment,
       active: decision === DecisionStatus.APPROVED,
       decisionDate: new Date(),
       decisionMakerEmail: authEmail,

--- a/requestActions/public-cloud/editRequest.ts
+++ b/requestActions/public-cloud/editRequest.ts
@@ -42,9 +42,11 @@ export default async function editRequest(
     throw new Error('Project does not exist.');
   }
 
-  // merge the form data with the existing project data
+  const { adminComment, ...rest } = formData;
+
+  // Merge the form data with the existing project data
   const requestedProject: Prisma.PublicCloudRequestedProjectCreateInput = {
-    ...formData,
+    ...rest,
     licencePlate: project.licencePlate,
     status: project.status,
     created: project.created,
@@ -83,6 +85,7 @@ export default async function editRequest(
       active: true,
       createdByEmail: authEmail,
       licencePlate: project.licencePlate,
+      adminComment,
       requestedProject: {
         create: requestedProject,
       },

--- a/schema.ts
+++ b/schema.ts
@@ -127,6 +127,7 @@ export const PublicCloudCreateRequestBodySchema = z.object({
   projectOwner: UserInputSchema,
   primaryTechnicalLead: UserInputSchema,
   secondaryTechnicalLead: UserInputSchema.optional(),
+  adminComment: string().optional(),
 });
 
 export const PrivateCloudEditRequestBodySchema = PrivateCloudCreateRequestBodySchema.merge(
@@ -151,7 +152,7 @@ export const PrivateCloudDecisionRequestBodySchema = PrivateCloudEditRequestBody
 export const PublicCloudDecisionRequestBodySchema = PublicCloudEditRequestBodySchema.merge(
   z.object({
     decision: DecisionOptionsSchema,
-    humanComment: string().optional(),
+    adminComment: string().optional(),
   }),
 );
 


### PR DESCRIPTION
This PR has fixed the issue of `comments` not appearing in emails when an `edit`, `approval`, or `rejection` is made in both Public and Private Clouds. All email subjects are now consistent and generic. Refactored the schema in Public cloud to now be `adminComment` instead of `humanComment`