### PR TITLE
Replace public cloud email RC channel link

### DIFF
--- a/emails/_templates/public-cloud/Provisioned.tsx
+++ b/emails/_templates/public-cloud/Provisioned.tsx
@@ -39,8 +39,8 @@ const ProvisionedTemplate = ({ product }: EmailProp) => {
                 <Text className="">
                   Your request for your product on the Public Cloud platform is complete. If you have any more questions
                   reach out to the Public Cloud team in the Rocket.Chat channel{' '}
-                  <Link className="mt-0 h-4" href={`https://chat.developer.gov.bc.ca/channel/devops-operations`}>
-                    #devops-operations
+                  <Link className="mt-0 h-4" href={`https://chat.developer.gov.bc.ca/group/aws-tenant-requests`}>
+                    #aws-tenant-requests
                   </Link>
                   .
                 </Text>


### PR DESCRIPTION
link for public product email RC channel changed to #aws-tenant-requests