### PR TITLE
Fix: Scenario #2 for Email refactoring/improving according to docs (Private Cloud)

### DIFF
--- a/app/api/private-cloud/decision/[licencePlate]/route.ts
+++ b/app/api/private-cloud/decision/[licencePlate]/route.ts
@@ -40,7 +40,7 @@ export const POST = apiHandler(async ({ pathParams, body, session }) => {
 
   if (request.decisionStatus !== DecisionStatus.APPROVED) {
     // Send rejection email, message will need to be passed
-    wrapAsync(() => sendRequestRejectionEmails(request.requestedProject, decisionComment));
+    wrapAsync(() => sendRequestRejectionEmails(request, decisionComment));
 
     return OkResponse(`Request for ${request.licencePlate} successfully created as rejected.`);
   }

--- a/app/api/private-cloud/provision/[licencePlate]/route.ts
+++ b/app/api/private-cloud/provision/[licencePlate]/route.ts
@@ -15,7 +15,7 @@ const apiHandler = createApiHandler({
   roles: [],
   validations: { pathParams: pathParamSchema },
 });
-export const PUT = apiHandler(async ({ pathParams, session }) => {
+export const PUT = apiHandler(async ({ pathParams }) => {
   const { licencePlate } = pathParams;
 
   const request = await prisma.privateCloudRequest.findFirst({
@@ -30,7 +30,7 @@ export const PUT = apiHandler(async ({ pathParams, session }) => {
   });
 
   if (!request) {
-    return NotFoundResponse('No requetst found for this licece plate.');
+    return NotFoundResponse('No request found for this license plate.');
   }
 
   const updateRequest = prisma.privateCloudRequest.update({
@@ -75,6 +75,8 @@ export const PUT = apiHandler(async ({ pathParams, session }) => {
     },
   });
 
-  wrapAsync(() => sendProvisionedEmails(project as PrivateCloudRequestedProjectWithContacts));
+  if (request.type == 'CREATE') {
+    await wrapAsync(() => sendProvisionedEmails(project as PrivateCloudRequestedProjectWithContacts));
+  }
   return OkResponse(`Successfully marked ${licencePlate} as provisioned.`);
 });

--- a/components/modal/Comment.tsx
+++ b/components/modal/Comment.tsx
@@ -24,6 +24,14 @@ export default function Modal({
     setComment(comm);
   };
 
+  const showCommentsBox = () => {
+    if (action === 'APPROVE' && (type?.toLowerCase() === 'create' || type?.toLowerCase() === 'edit')) {
+      return false;
+    }
+
+    return true;
+  };
+
   return (
     <Transition.Root show={open} as={Fragment}>
       <Dialog
@@ -68,7 +76,7 @@ export default function Modal({
                       : `Are you sure you want to reject this ${type?.toLocaleLowerCase()} product request?`}
                   </Dialog.Title>
                 </div>
-                {!(action === 'APPROVE' && type?.toLowerCase() === 'create') && (
+                {showCommentsBox() && (
                   <>
                     <p className="pt-2 font-bcsans text-sm text-gray-900">
                       Please provide your final comments to be shared.

--- a/docs/email-scenarios-private-cloud.md
+++ b/docs/email-scenarios-private-cloud.md
@@ -65,18 +65,14 @@ flowchart LR
 - **3a. Approval sent to PO/TLs** containing:
    <ol type="a">
       <li>Product Details (Name, Description, Ministry, Contacts of PO/TL(s))</li>
-      <li>Namespace Details (Cluster, Link to all four namespaces, Default values of namespaces)</li>
-      <li>Security Tools Info</li>
-      <li>Artifactory Info</li>
-      <li>Vault Info</li>
-      <li>ACS Info</li>
-      <li>Sysdig Info</li>
+      <li>Namespace Details with Previous and Approved values (Cluster, Link to all four namespaces)</li>
       </ol>
 
 - **3b. Rejection Sub-Scenario** containing:
    <ol type="a">
       <li>Product Details (Name, Description, Ministry, Contacts of PO/TL(s))</li>
       <li>Admin review comments</li>
+      <li>Namespace Details with Previous and Rejected values (Cluster, Link to all four namespaces)</li>
    </ol>
 
 ```mermaid

--- a/emails/PrivateCloudAdminRequest.tsx
+++ b/emails/PrivateCloudAdminRequest.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { samplePrivateRequest } from './_components/Params';
+import { samplePrivateEditRequest } from './_components/Params';
 import NewRequestTemplate from './_templates/private-cloud/AdminEditRequest';
 
 export default function NewRequest() {
-  return <NewRequestTemplate request={samplePrivateRequest} />;
+  return <NewRequestTemplate request={samplePrivateEditRequest} />;
 }

--- a/emails/PrivateCloudRequestApproval.tsx
+++ b/emails/PrivateCloudRequestApproval.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { samplePrivateRequest } from './_components/Params';
+import { samplePrivateEditRequest } from './_components/Params';
 import RequestApprovalTemplate from './_templates/private-cloud/RequestApproval';
 
 export default function RequestApproval() {
-  return <RequestApprovalTemplate request={samplePrivateRequest} />;
+  return <RequestApprovalTemplate request={samplePrivateEditRequest} />;
 }

--- a/emails/PrivateCloudRequestRejection.tsx
+++ b/emails/PrivateCloudRequestRejection.tsx
@@ -1,10 +1,16 @@
 import * as React from 'react';
-import { samplePrivateRequest } from './_components/Params';
+import { samplePrivateEditRequest } from './_components/Params';
 import RequestRejectionTemplate from './_templates/private-cloud/RequestRejection';
 
 export default function RequestRejection() {
-  const productName = samplePrivateRequest.requestedProject.name;
-  const decisionComment = samplePrivateRequest.decisionComment || undefined;
+  const productName = samplePrivateEditRequest.requestedProject.name;
+  const decisionComment = samplePrivateEditRequest.decisionComment || undefined;
 
-  return <RequestRejectionTemplate productName={productName} decisionComment={decisionComment} />;
+  return (
+    <RequestRejectionTemplate
+      request={samplePrivateEditRequest}
+      productName={productName}
+      decisionComment={decisionComment}
+    />
+  );
 }

--- a/emails/_components/Comment.tsx
+++ b/emails/_components/Comment.tsx
@@ -10,6 +10,7 @@ export default function Comment({ requestComment, decisionComment }: CommentProp
     <div>
       {requestComment && (
         <div>
+          <Text className="font-semibold">User Comment:</Text>
           <Text>{requestComment}</Text>
         </div>
       )}

--- a/emails/_components/Edit/QuotaChanges.tsx
+++ b/emails/_components/Edit/QuotaChanges.tsx
@@ -2,19 +2,25 @@ import { Heading, Link, Text } from '@react-email/components';
 import { QuotaInput } from '@/schema';
 import { defaultCpuOptionsLookup, defaultMemoryOptionsLookup, defaultStorageOptionsLookup } from './quotaLookup';
 
+interface QuotaChangesProps {
+  licencePlate: string;
+  quotaCurrent: QuotaInput;
+  quotaRequested: QuotaInput;
+  type: string;
+  cluster: string;
+  currentLabel?: string;
+  requestedLabel?: string;
+}
+
 export default function QuotaChanges({
   licencePlate,
   quotaCurrent,
   quotaRequested,
   type,
   cluster,
-}: {
-  licencePlate: string;
-  quotaCurrent: QuotaInput;
-  quotaRequested: QuotaInput;
-  type: string;
-  cluster: string;
-}) {
+  currentLabel = 'Current',
+  requestedLabel = 'Requested',
+}: QuotaChangesProps) {
   cluster = cluster.toLowerCase();
   return (
     <div className="mb-4 mr-16">
@@ -28,27 +34,27 @@ export default function QuotaChanges({
       {quotaCurrent.cpu !== quotaRequested.cpu && (
         <div>
           <Text className="mt-4 mb-0 font-semibold h-4">CPU</Text>
-          <Text className="mt-2 mb-0 font-medium h-3">Current Quota</Text>
+          <Text className="mt-2 mb-0 font-medium h-3">{currentLabel} Quota</Text>
           <Text className="mt-1 mb-0 h-4">{defaultCpuOptionsLookup[quotaCurrent.cpu]}</Text>
-          <Text className="mt-2 mb-0 font-medium h-3">Requested Quota</Text>
+          <Text className="mt-2 mb-0 font-medium h-3">{requestedLabel} Quota</Text>
           <Text className="mt-1 mb-0 h-4">{defaultCpuOptionsLookup[quotaRequested.cpu]}</Text>
         </div>
       )}
       {quotaCurrent.memory !== quotaRequested.memory && (
         <div>
           <Text className="mt-6 mb-0 font-semibold h-4">Memory</Text>
-          <Text className="mt-2 mb-0 font-medium h-3">Current Memory</Text>
+          <Text className="mt-2 mb-0 font-medium h-3">{currentLabel} Memory</Text>
           <Text className="mt-1 mb-0 h-4">{defaultMemoryOptionsLookup[quotaCurrent.memory]}</Text>
-          <Text className="mt-2 mb-0 font-medium h-3">Requested Memory</Text>
+          <Text className="mt-2 mb-0 font-medium h-3">{requestedLabel} Memory</Text>
           <Text className="mt-1 mb-0 h-4">{defaultMemoryOptionsLookup[quotaRequested.memory]}</Text>
         </div>
       )}
       {quotaCurrent.storage !== quotaRequested.storage && (
         <div>
           <Text className="mt-6 mb-0 font-semibold h-4">Storage</Text>
-          <Text className="mt-2 mb-0 font-medium h-3">Current Storage</Text>
+          <Text className="mt-2 mb-0 font-medium h-3">{currentLabel} Storage</Text>
           <Text className="mt-1 mb-0 h-4">{defaultStorageOptionsLookup[quotaCurrent.storage]}</Text>
-          <Text className="mt-2 mb-0 font-medium h-3">Requested Storage</Text>
+          <Text className="mt-2 mb-0 font-medium h-3">{requestedLabel} Storage</Text>
           <Text className="mt-1 mb-0 h-4">{defaultStorageOptionsLookup[quotaRequested.storage]}</Text>
         </div>
       )}

--- a/emails/_templates/private-cloud/RequestApproval.tsx
+++ b/emails/_templates/private-cloud/RequestApproval.tsx
@@ -1,4 +1,4 @@
-import { PrivateCloudRequestWithRequestedProject } from '@/request-actions/private-cloud/decision-request';
+import { PrivateCloudRequestWithProjectAndRequestedProject } from '@/request-actions/private-cloud/decision-request';
 import * as React from 'react';
 import Header from '../../_components/Header';
 import ProductDetails from '../../_components/ProductDetails';
@@ -6,13 +6,18 @@ import { Body, Button, Heading, Html, Text, Link } from '@react-email/components
 import NamespaceDetails from '../../_components/NamespaceDetails';
 import Closing from '../../_components/Closing';
 import TailwindWrapper from '../../_components/TailwindWrapper';
+import QuotaChanges from '../../_components/Edit/QuotaChanges';
+import { comparePrivateCloudProjects } from '@/emails/_components/Edit/utils/compare-projects';
 
 interface EmailProp {
-  request: PrivateCloudRequestWithRequestedProject;
+  request: PrivateCloudRequestWithProjectAndRequestedProject;
 }
 
 const RequestApprovalTemplate = ({ request }: EmailProp) => {
-  if (!request) return <></>;
+  if (!request || !request.project || !request.requestedProject) return <></>;
+  const current = request.project;
+  const requested = request.requestedProject;
+  const changed = comparePrivateCloudProjects(current, requested);
 
   return (
     <Html>
@@ -60,14 +65,57 @@ const RequestApprovalTemplate = ({ request }: EmailProp) => {
                 />
               </div>
               <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">
-                <NamespaceDetails cluster={request.requestedProject.cluster} licencePlate={request.licencePlate} />
-              </div>
-              <div className="pb-6 mt-4 mb-4 border-solid border-0 border-b-1 border-slate-300">
-                <div>
-                  <Heading className="text-lg">Comment</Heading>
-                  <div> {request.decisionComment}</div>
+                {(changed.productionQuota || changed.testQuota || changed.developmentQuota || changed.toolsQuota) && (
+                  <h3 className="mb-0 text-black">Resource quota changes</h3>
+                )}
+                <div className="flex flex-row flex-wrap">
+                  {changed.productionQuota && (
+                    <QuotaChanges
+                      licencePlate={`${request.licencePlate}-prod`}
+                      quotaCurrent={current.productionQuota}
+                      quotaRequested={requested.productionQuota}
+                      type="Production"
+                      cluster={current.cluster}
+                      currentLabel="Previous"
+                      requestedLabel="Updated"
+                    />
+                  )}
+                  {changed.testQuota && (
+                    <QuotaChanges
+                      licencePlate={`${request.licencePlate}-test`}
+                      quotaCurrent={current.testQuota}
+                      quotaRequested={requested.testQuota}
+                      type="Test"
+                      cluster={current.cluster}
+                      currentLabel="Previous"
+                      requestedLabel="Updated"
+                    />
+                  )}
+                  {changed.developmentQuota && (
+                    <QuotaChanges
+                      licencePlate={`${request.licencePlate}-dev`}
+                      quotaCurrent={current.testQuota}
+                      quotaRequested={requested.testQuota}
+                      type="Development"
+                      cluster={current.cluster}
+                      currentLabel="Previous"
+                      requestedLabel="Updated"
+                    />
+                  )}
+                  {changed.toolsQuota && (
+                    <QuotaChanges
+                      licencePlate={`${request.licencePlate}-tools`}
+                      quotaCurrent={current.testQuota}
+                      quotaRequested={requested.testQuota}
+                      type="Tools"
+                      cluster={current.cluster}
+                      currentLabel="Previous"
+                      requestedLabel="Updated"
+                    />
+                  )}
                 </div>
               </div>
+
               <div>
                 <Closing />
               </div>

--- a/emails/_templates/private-cloud/RequestRejection.tsx
+++ b/emails/_templates/private-cloud/RequestRejection.tsx
@@ -5,14 +5,21 @@ import { Tailwind } from '@react-email/tailwind';
 import Closing from '../../_components/Closing';
 import { TailwindConfig } from '../../_components/TailwindConfig';
 import Comment from '@/emails/_components/Comment';
+import QuotaChanges from '../../_components/Edit/QuotaChanges';
+import { PrivateCloudRequestWithProjectAndRequestedProject } from '@/request-actions/private-cloud/decision-request';
+import { comparePrivateCloudProjects } from '@/emails/_components/Edit/utils/compare-projects';
 
 interface EmailProp {
   productName: string;
   decisionComment?: string;
+  request: PrivateCloudRequestWithProjectAndRequestedProject;
 }
 
-const RequestRejectionTemplate = ({ productName, decisionComment }: EmailProp) => {
-  if (!productName) return <></>;
+const RequestRejectionTemplate = ({ request, productName, decisionComment }: EmailProp) => {
+  if (!request || !request.project || !request.requestedProject) return <></>;
+  const current = request.project;
+  const requested = request.requestedProject;
+  const changed = comparePrivateCloudProjects(current, requested);
   return (
     <Html>
       <Tailwind config={TailwindConfig}>
@@ -36,6 +43,53 @@ const RequestRejectionTemplate = ({ productName, decisionComment }: EmailProp) =
                   Log in to Registry
                 </Button>
               </div>
+              <div className="flex flex-row flex-wrap">
+                {changed.productionQuota && (
+                  <QuotaChanges
+                    licencePlate={`${request.licencePlate}-prod`}
+                    quotaCurrent={current.productionQuota}
+                    quotaRequested={requested.productionQuota}
+                    type="Production"
+                    cluster={current.cluster}
+                    currentLabel="Current"
+                    requestedLabel="Rejected"
+                  />
+                )}
+                {changed.testQuota && (
+                  <QuotaChanges
+                    licencePlate={`${request.licencePlate}-test`}
+                    quotaCurrent={current.testQuota}
+                    quotaRequested={requested.testQuota}
+                    type="Test"
+                    cluster={current.cluster}
+                    currentLabel="Current"
+                    requestedLabel="Rejected"
+                  />
+                )}
+                {changed.developmentQuota && (
+                  <QuotaChanges
+                    licencePlate={`${request.licencePlate}-dev`}
+                    quotaCurrent={current.testQuota}
+                    quotaRequested={requested.testQuota}
+                    type="Development"
+                    cluster={current.cluster}
+                    currentLabel="Current"
+                    requestedLabel="Rejected"
+                  />
+                )}
+                {changed.toolsQuota && (
+                  <QuotaChanges
+                    licencePlate={`${request.licencePlate}-tools`}
+                    quotaCurrent={current.testQuota}
+                    quotaRequested={requested.testQuota}
+                    type="Tools"
+                    cluster={current.cluster}
+                    currentLabel="Current"
+                    requestedLabel="Rejected"
+                  />
+                )}
+              </div>
+
               <div>
                 <Closing />
               </div>

--- a/services/ches/private-cloud/email-handler.ts
+++ b/services/ches/private-cloud/email-handler.ts
@@ -96,17 +96,21 @@ export const sendRequestApprovalEmails = async (request: PrivateCloudRequestWith
 };
 
 export const sendRequestRejectionEmails = async (
-  request: PrivateCloudRequestedProjectWithContacts,
+  request: PrivateCloudRequestWithProjectAndRequestedProject,
   decisionComment?: string,
 ) => {
   try {
-    const email = render(RequestRejectionTemplate({ productName: request.name, decisionComment }), {
+    const email = render(RequestRejectionTemplate({ request, productName: request.project!.name, decisionComment }), {
       pretty: true,
     });
     await sendEmail({
       body: email,
-      to: [request.projectOwner.email, request.primaryTechnicalLead.email, request.secondaryTechnicalLead?.email],
-      subject: `Request for ${request.name} has been rejected`,
+      to: [
+        request.project!.projectOwner.email,
+        request.project!.primaryTechnicalLead.email,
+        request.project!.secondaryTechnicalLead?.email,
+      ],
+      subject: `Request for ${request.project!.name} has been rejected`,
     });
   } catch (error) {
     console.error('ERROR SENDING REQUEST REJECTION EMAIL');

--- a/services/ches/private-cloud/email-handler.ts
+++ b/services/ches/private-cloud/email-handler.ts
@@ -54,7 +54,7 @@ export const sendEditRequestEmails = async (request: PrivateCloudRequestWithProj
       bodyType: 'html',
       body: adminEmail,
       to: adminPrivateEmails,
-      subject: 'Edit request submitted',
+      subject: 'New edit request awaiting review',
     });
 
     const contacts = sendEmail({

--- a/services/ches/private-cloud/email-handler.ts
+++ b/services/ches/private-cloud/email-handler.ts
@@ -77,8 +77,7 @@ export const sendEditRequestEmails = async (request: PrivateCloudRequestWithProj
   }
 };
 
-export const sendRequestApprovalEmails = async (request: PrivateCloudRequestWithRequestedProject) => {
-  console.log(request);
+export const sendRequestApprovalEmails = async (request: PrivateCloudRequestWithProjectAndRequestedProject) => {
   try {
     const email = render(RequestApprovalTemplate({ request }), { pretty: true });
 


### PR DESCRIPTION
1. Fixed subject line for admin email
2. fixed punctuation in edit request email
3. admins now see comments from user for an edit request
4. added logic for sending the correct email based on type of request (edit vs create)
5. updated the documentation for scenario 2 approval and rejection emails
6. rejection email now shows what was rejected (what quota was rejected)