### PR TITLE
feat: expand request pages

### DIFF
--- a/app/api/private-cloud/requests/[id]/route.ts
+++ b/app/api/private-cloud/requests/[id]/route.ts
@@ -1,9 +1,7 @@
-import { Prisma } from '@prisma/client';
 import { z } from 'zod';
 import createApiHandler from '@/core/api-handler';
-import prisma from '@/core/prisma';
-import { OkResponse } from '@/core/responses';
-import { PrivateCloudRequestDecorate } from '@/types/doc-decorate';
+import { OkResponse, UnauthorizedResponse } from '@/core/responses';
+import { getPrivateCloudRequest } from '@/queries/private-cloud-requests';
 
 const pathParamSchema = z.object({
   id: z.string(),
@@ -16,45 +14,11 @@ const apiHandler = createApiHandler({
 export const GET = apiHandler(async ({ pathParams, queryParams, session }) => {
   const { id } = pathParams;
 
-  const request = await prisma.privateCloudRequest.findFirst({
-    where: { id },
-    include: {
-      project: {
-        include: {
-          projectOwner: true,
-          primaryTechnicalLead: true,
-          secondaryTechnicalLead: true,
-        },
-      },
-      decisionData: {
-        include: {
-          projectOwner: true,
-          primaryTechnicalLead: true,
-          secondaryTechnicalLead: true,
-        },
-      },
-    },
-    session: session as never,
-  });
+  const request = await getPrivateCloudRequest(session, id);
+
+  if (!request?._permissions.view) {
+    return UnauthorizedResponse();
+  }
+
   return OkResponse(request);
 });
-
-export type PrivateCloudRequestGetPayload = Prisma.PrivateCloudRequestGetPayload<{
-  include: {
-    project: {
-      include: {
-        projectOwner: true;
-        primaryTechnicalLead: true;
-        secondaryTechnicalLead: true;
-      };
-    };
-    decisionData: {
-      include: {
-        projectOwner: true;
-        primaryTechnicalLead: true;
-        secondaryTechnicalLead: true;
-      };
-    };
-  };
-}> &
-  PrivateCloudRequestDecorate;

--- a/app/api/private-cloud/requests/_operations/search.ts
+++ b/app/api/private-cloud/requests/_operations/search.ts
@@ -5,6 +5,7 @@ import { searchPrivateCloudRequests } from '@/queries/private-cloud-requests';
 
 export default async function searchOp({
   session,
+  licencePlate,
   search,
   page,
   pageSize,
@@ -15,6 +16,7 @@ export default async function searchOp({
   sortOrder,
 }: {
   session: Session;
+  licencePlate: string;
   search: string;
   page: number;
   pageSize: number;
@@ -30,6 +32,7 @@ export default async function searchOp({
     session: session as Session,
     skip,
     take,
+    licencePlate,
     ministry,
     cluster,
     search,

--- a/app/api/private-cloud/requests/search/route.ts
+++ b/app/api/private-cloud/requests/search/route.ts
@@ -7,6 +7,7 @@ import { processEnumString, processUpperEnumString } from '@/utils/zod';
 import searchOp from '../_operations/search';
 
 const bodySchema = z.object({
+  licencePlate: z.string().optional(),
   search: z.string().optional(),
   page: z.number().optional(),
   pageSize: z.number().optional(),
@@ -22,6 +23,7 @@ export const POST = createApiHandler({
   validations: { body: bodySchema },
 })(async ({ session, body }) => {
   const {
+    licencePlate = '',
     search = '',
     page = 1,
     pageSize = 5,
@@ -33,6 +35,7 @@ export const POST = createApiHandler({
   } = body;
 
   const data = await searchOp({
+    licencePlate,
     session,
     search,
     page,

--- a/app/api/public-cloud/requests/_operations/search.ts
+++ b/app/api/public-cloud/requests/_operations/search.ts
@@ -5,6 +5,7 @@ import { searchPublicCloudRequests } from '@/queries/public-cloud-requests';
 
 export default async function searchOp({
   session,
+  licencePlate,
   search,
   page,
   pageSize,
@@ -15,6 +16,7 @@ export default async function searchOp({
   sortOrder,
 }: {
   session: Session;
+  licencePlate: string;
   search: string;
   page: number;
   pageSize: number;
@@ -30,6 +32,7 @@ export default async function searchOp({
     session: session as Session,
     skip,
     take,
+    licencePlate,
     ministry,
     provider,
     search,

--- a/app/api/public-cloud/requests/search/route.ts
+++ b/app/api/public-cloud/requests/search/route.ts
@@ -7,6 +7,7 @@ import { processEnumString, processUpperEnumString } from '@/utils/zod';
 import searchOp from '../_operations/search';
 
 const bodySchema = z.object({
+  licencePlate: z.string().optional(),
   search: z.string().optional(),
   page: z.number().optional(),
   pageSize: z.number().optional(),
@@ -22,6 +23,7 @@ export const POST = createApiHandler({
   validations: { body: bodySchema },
 })(async ({ session, body }) => {
   const {
+    licencePlate = '',
     search = '',
     page = 1,
     pageSize = 5,
@@ -33,6 +35,7 @@ export const POST = createApiHandler({
   } = body;
 
   const data = await searchOp({
+    licencePlate,
     session,
     search,
     page,

--- a/app/globals.css
+++ b/app/globals.css
@@ -15,27 +15,3 @@
     --background-end-rgb: 0, 0, 0;
   }
 }
-
-@font-face {
-  font-family: 'BCSans';
-  src: url('../fonts/bcsans-regular.woff') format('woff');
-  font-weight: 400;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: 'BCSans';
-  src: url('../fonts/bcsans-bold.woff') format('woff');
-  font-weight: 700;
-  font-style: normal;
-}
-
-/* body {
-  color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
-} */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,7 @@ import '@mantine/core/styles.css';
 import './globals.css';
 import { MantineProvider } from '@mantine/core';
 import { useQuery } from '@tanstack/react-query';
-import { Inter } from 'next/font/google';
+import localFont from 'next/font/local';
 import { useEffect } from 'react';
 import Footer from '@/components/Footer';
 import Nav from '@/components/nav/Nav';
@@ -14,9 +14,29 @@ import { getInfo } from '@/services/backend';
 import { useAppState } from '@/states/global';
 import classNames from '@/utils/classnames';
 
-const inter = Inter({
-  subsets: ['latin'],
-  display: 'swap',
+const bcsans = localFont({
+  src: [
+    {
+      path: '../fonts/bcsans-regular.woff',
+      weight: '400',
+      style: 'normal',
+    },
+    {
+      path: '../fonts/bcsans-regular.woff',
+      weight: '400',
+      style: 'italic',
+    },
+    {
+      path: '../fonts/bcsans-bold.woff',
+      weight: '700',
+      style: 'normal',
+    },
+    {
+      path: '../fonts/bcsans-bold.woff',
+      weight: '700',
+      style: 'italic',
+    },
+  ],
 });
 
 function MainBody({ children }: { children: React.ReactNode }) {
@@ -32,7 +52,7 @@ function MainBody({ children }: { children: React.ReactNode }) {
   }, [appState, info]);
 
   return (
-    <body className={classNames('flex flex-col min-h-screen', inter.className)}>
+    <body className={classNames('flex flex-col min-h-screen', bcsans.className)}>
       <Nav />
       <main className="flex-grow h-100">
         <div className="mt-8 mb-8 h-full mx-4 lg:mx-20">{children}</div>
@@ -45,9 +65,10 @@ function MainBody({ children }: { children: React.ReactNode }) {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
+      <head></head>
       <Provider>
         <MainBody>
-          <MantineProvider>{children}</MantineProvider>
+          <MantineProvider theme={{}}>{children}</MantineProvider>
         </MainBody>
       </Provider>
     </html>

--- a/app/private-cloud/products/(product)/[licencePlate]/edit/page.tsx
+++ b/app/private-cloud/products/(product)/[licencePlate]/edit/page.tsx
@@ -1,8 +1,11 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import { Alert } from '@mantine/core';
 import { PrivateCloudProject } from '@prisma/client';
+import { IconInfoCircle } from '@tabler/icons-react';
 import { useQuery, useMutation } from '@tanstack/react-query';
+import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useSnapshot } from 'valtio';
@@ -18,7 +21,7 @@ import ReturnModal from '@/components/modal/Return';
 import { AGMinistries } from '@/constants';
 import createClientPage from '@/core/client-page';
 import { PrivateCloudEditRequestBodySchema } from '@/schema';
-import { getPriviateCloudProject, editPriviateCloudProject } from '@/services/backend/private-cloud/products';
+import { getPrivateCloudProject, editPrivateCloudProject } from '@/services/backend/private-cloud/products';
 import { privateProductState } from '@/states/global';
 
 const pathParamSchema = z.object({
@@ -45,7 +48,7 @@ export default privateCloudProductEdit(({ pathParams, queryParams, session }) =>
     isError: isEditError,
     error: editError,
   } = useMutation({
-    mutationFn: (data: any) => editPriviateCloudProject(licencePlate, data),
+    mutationFn: (data: any) => editPrivateCloudProject(licencePlate, data),
     onSuccess: () => {
       setOpenComment(false);
       setOpenReturn(true);
@@ -71,7 +74,7 @@ export default privateCloudProductEdit(({ pathParams, queryParams, session }) =>
       ),
     ),
     defaultValues: async () => {
-      const response = await getPriviateCloudProject(licencePlate);
+      const response = await getPrivateCloudProject(licencePlate);
       return { ...response, isAgMinistryChecked: true };
     },
   });
@@ -102,15 +105,26 @@ export default privateCloudProductEdit(({ pathParams, queryParams, session }) =>
 
   const isSubmitEnabled = formState.isDirty || isSecondaryTechLeadRemoved;
 
+  if (!snap.currentProduct) {
+    return null;
+  }
+
   return (
     <div>
       <FormProvider {...methods}>
         <form autoComplete="off" onSubmit={methods.handleSubmit(() => setOpenComment(true))}>
           <div className="mb-12 mt-8">
-            {isDisabled && (
-              <h3 className="font-bcsans text-base lg:text-md 2xl:text-lg text-gray-600 mb-5">
-                There is already an active request for this project. You can not edit this project at this time.
-              </h3>
+            {isDisabled && snap.currentProduct.requests.length > 0 && (
+              <Alert variant="light" color="blue" title="" icon={<IconInfoCircle />}>
+                There is already an{' '}
+                <Link
+                  className="underline text-blue-500 text-bold text-lg"
+                  href={`/private-cloud/requests/${snap.currentProduct.requests[0].id}/decision`}
+                >
+                  active request
+                </Link>{' '}
+                for this project. You can not edit this project at this time.
+              </Alert>
             )}
             <ProjectDescription disabled={isDisabled} clusterDisabled={true} mode="edit" />
             <TeamContacts
@@ -119,7 +133,7 @@ export default privateCloudProductEdit(({ pathParams, queryParams, session }) =>
               secondTechLeadOnClick={secondTechLeadOnClick}
             />
             <Quotas
-              licensePlate={snap.currentProduct?.licencePlate as string}
+              licencePlate={snap.currentProduct?.licencePlate as string}
               disabled={isDisabled}
               currentProject={snap.currentProduct as PrivateCloudProject}
             />

--- a/app/private-cloud/products/(product)/[licencePlate]/history/page.tsx
+++ b/app/private-cloud/products/(product)/[licencePlate]/history/page.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { z } from 'zod';
 import HistoryItem from '@/components/history/PrivateHistoryItem';
 import createClientPage from '@/core/client-page';
-import { getPriviateCloudProductRequests } from '@/services/backend/private-cloud/products';
+import { getPrivateCloudProductRequests } from '@/services/backend/private-cloud/products';
 
 const pathParamSchema = z.object({
   licencePlate: z.string(),
@@ -24,7 +24,7 @@ export default privateCloudProductHistory(({ pathParams, queryParams, session })
     error: requestsError,
   } = useQuery({
     queryKey: ['requests', licencePlate],
-    queryFn: () => getPriviateCloudProductRequests(licencePlate),
+    queryFn: () => getPrivateCloudProductRequests(licencePlate),
     enabled: !!licencePlate,
   });
 

--- a/app/private-cloud/products/(product)/[licencePlate]/layout.tsx
+++ b/app/private-cloud/products/(product)/[licencePlate]/layout.tsx
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import PrivateCloudProductOptions from '@/components/dropdowns/PrivateCloudProductOptions';
 import Tabs, { ITab } from '@/components/generic/tabs/BasicTabs';
 import createClientPage from '@/core/client-page';
-import { getPriviateCloudProject } from '@/services/backend/private-cloud/products';
+import { getPrivateCloudProject } from '@/services/backend/private-cloud/products';
 import { privateProductState } from '@/states/global';
 
 const pathParamSchema = z.object({
@@ -24,7 +24,7 @@ export default privateCloudProductSecurityACS(({ pathParams, queryParams, sessio
 
   const { data: currentProduct } = useQuery({
     queryKey: ['currentProduct', licencePlate],
-    queryFn: () => getPriviateCloudProject(licencePlate),
+    queryFn: () => getPrivateCloudProject(licencePlate),
     enabled: !!licencePlate,
   });
 
@@ -36,16 +36,16 @@ export default privateCloudProductSecurityACS(({ pathParams, queryParams, sessio
     privateProductState.licencePlate = licencePlate;
   }, [licencePlate]);
 
-  let mode = 'decision';
-  if (currentProduct) {
-    mode = currentProduct.requests.length > 0 ? 'decision' : 'edit';
-  }
-
   const tabs: ITab[] = [
     {
       label: 'PRODUCT',
       name: 'product',
-      href: `/private-cloud/products/${licencePlate}/${mode}`,
+      href: `/private-cloud/products/${licencePlate}/edit`,
+    },
+    {
+      label: 'REQUESTS',
+      name: 'requests',
+      href: `/private-cloud/products/${licencePlate}/requests`,
     },
   ];
 
@@ -83,7 +83,7 @@ export default privateCloudProductSecurityACS(({ pathParams, queryParams, sessio
           canDelete={currentProduct?._permissions?.delete}
         />
       </Tabs>
-      <div className="mt-14">{children}</div>
+      <div className="mt-8">{children}</div>
       <ToastContainer />
     </div>
   );

--- a/app/private-cloud/products/(product)/[licencePlate]/requests/FilterPanel.tsx
+++ b/app/private-cloud/products/(product)/[licencePlate]/requests/FilterPanel.tsx
@@ -1,0 +1,123 @@
+import { $Enums, Prisma } from '@prisma/client';
+import { useEffect, useRef, useState } from 'react';
+import { useSnapshot, subscribe } from 'valtio';
+import FormToggle from '@/components/generic/checkbox/FormToggle';
+import FormSelect from '@/components/generic/select/FormSelect';
+import { clusters, productSorts, ministryOptions } from '@/constants';
+import { pageState } from './state';
+
+const productSortsNoLicencePlate = productSorts.filter((v) => v.sortKey !== 'licencePlate');
+
+export default function FilterPanel() {
+  const pageSnapshot = useSnapshot(pageState);
+  const clusterProviderRef = useRef<HTMLSelectElement>(null);
+  const ministryRef = useRef<HTMLSelectElement>(null);
+  const sortRef = useRef<HTMLSelectElement>(null);
+  const toggleText = 'Show Resolved Requests';
+
+  const handleSortChange = (value: string) => {
+    const selectedOption = productSortsNoLicencePlate.find(
+      (privateSortName) => privateSortName.humanFriendlyName === value,
+    );
+    if (selectedOption) {
+      pageState.sortKey = selectedOption.sortKey;
+      pageState.sortOrder = selectedOption.sortOrder;
+    } else {
+      pageState.sortKey = '';
+      pageState.sortOrder = Prisma.SortOrder.desc;
+    }
+  };
+
+  const handleToggleChange = () => {
+    pageState.includeInactive = !pageSnapshot.includeInactive;
+  };
+
+  const handleClusterChange = (value: string) => {
+    pageState.cluster = value;
+  };
+
+  const handleMinistryChange = (value: string) => {
+    pageState.ministry = value;
+  };
+
+  const clearFilters = () => {
+    if (clusterProviderRef.current) {
+      clusterProviderRef.current.value = '';
+    }
+    if (ministryRef.current) {
+      ministryRef.current.value = '';
+    }
+    if (sortRef.current) {
+      sortRef.current.value = '';
+    }
+
+    pageState.cluster = '';
+    pageState.ministry = '';
+    pageState.sortKey = '';
+    pageState.sortOrder = '';
+    pageState.includeInactive = false;
+  };
+
+  return (
+    <div className="flex gap-8 mr-10">
+      <div className="grid auto-rows-min grid-cols-1 gap-y-8 md:grid-cols-3 md:gap-x-6">
+        <fieldset className="w-full md:w-48 2xl:w-96">
+          <FormSelect
+            ref={sortRef}
+            id="id"
+            label="Sort By"
+            options={productSortsNoLicencePlate.map((v) => ({
+              label: v.humanFriendlyName,
+              value: v.humanFriendlyName,
+            }))}
+            defaultValue={
+              productSortsNoLicencePlate.find(
+                (v) => v.sortKey === pageSnapshot.sortKey && v.sortOrder === pageSnapshot.sortOrder,
+              )?.humanFriendlyName
+            }
+            onChange={handleSortChange}
+          />
+        </fieldset>
+        <fieldset className="w-full md:w-48 2xl:w-96">
+          <div className="mt-2 md:mt-0 md:ml-4">
+            <FormSelect
+              ref={clusterProviderRef}
+              id="cluster"
+              label="Cluster"
+              options={[{ label: 'All Clusters', value: '' }, ...clusters.map((v) => ({ label: v, value: v }))]}
+              defaultValue={pageSnapshot.cluster}
+              onChange={handleClusterChange}
+            />
+          </div>
+        </fieldset>
+        <fieldset className="w-full md:w-48 2xl:w-96">
+          <div className="mt-2 md:mt-0 md:ml-4">
+            <FormSelect
+              ref={ministryRef}
+              id="ministry"
+              label="Ministry"
+              options={[{ label: `All Ministries`, value: '' }, ...ministryOptions]}
+              defaultValue={pageSnapshot.ministry}
+              onChange={handleMinistryChange}
+            />
+          </div>
+        </fieldset>
+        <div></div>
+        <FormToggle
+          id="includeInactive"
+          label={toggleText}
+          checked={pageSnapshot.includeInactive}
+          onChange={handleToggleChange}
+        />
+        <div className="mt-8 md:mt-7 md:ml-4">
+          <button
+            className="min-w-max w-1/2 h-9 inline-flex items-center justify-center gap-x-2 rounded-md bg-bcblue text-white px-3 text-sm font-semibold shadow-sm ring-1 ring-inset transition-all duration-500 ring-gray-300 hover:bg-[#CCCCCE]"
+            onClick={clearFilters}
+          >
+            Clear Filters
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/private-cloud/products/(product)/[licencePlate]/requests/page.tsx
+++ b/app/private-cloud/products/(product)/[licencePlate]/requests/page.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { proxy, useSnapshot } from 'valtio';
+import { z } from 'zod';
+import Table from '@/components/generic/table/Table';
+import TableBody from '@/components/table/TableBodyRequests';
+import createClientPage from '@/core/client-page';
+import { privateCloudProjectDataToRow } from '@/helpers/row-mapper';
+import { searchPrivateCloudRequests } from '@/services/backend/private-cloud/requests';
+import FilterPanel from './FilterPanel';
+import { pageState } from './state';
+
+const pathParamSchema = z.object({
+  licencePlate: z.string(),
+});
+
+const privateCloudProductRequests = createClientPage({
+  roles: ['user'],
+  validations: { pathParams: pathParamSchema },
+  fallbackUrl: '/login?callbackUrl=/private-cloud/products/all',
+});
+export default privateCloudProductRequests(({ pathParams, queryParams, session }) => {
+  const snap = useSnapshot(pageState);
+  const { licencePlate } = pathParams;
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['requests', snap],
+    queryFn: () => searchPrivateCloudRequests({ ...snap, licencePlate }),
+    enabled: !!licencePlate,
+  });
+
+  let requests = [];
+  let totalCount = 0;
+
+  if (!isLoading && data) {
+    const transformActiveRequests = data.docs.map((request) => ({
+      ...request.requestData,
+      created: request.created,
+      updatedAt: request.updatedAt,
+      requests: [request],
+      id: request.id,
+    }));
+
+    requests = transformActiveRequests.map(privateCloudProjectDataToRow);
+    totalCount = data.totalCount;
+  }
+
+  return (
+    <Table
+      totalCount={totalCount}
+      page={snap.page}
+      pageSize={snap.pageSize}
+      search={snap.search}
+      onPagination={(page: number, pageSize: number) => {
+        pageState.page = page;
+        pageState.pageSize = pageSize;
+      }}
+      onSearch={(searchTerm: string) => {
+        pageState.page = 1;
+        pageState.search = searchTerm;
+      }}
+      filters={<FilterPanel />}
+      isLoading={isLoading}
+    >
+      <TableBody rows={requests} isLoading={isLoading} />
+    </Table>
+  );
+});

--- a/app/private-cloud/products/(product)/[licencePlate]/requests/state.ts
+++ b/app/private-cloud/products/(product)/[licencePlate]/requests/state.ts
@@ -1,0 +1,14 @@
+import { $Enums, Prisma } from '@prisma/client';
+import { proxy, useSnapshot } from 'valtio';
+import { PrivateCloudProductSearchCriteria } from '@/services/backend/private-cloud/products';
+
+export const pageState = proxy<Omit<PrivateCloudProductSearchCriteria, 'licencePlate'>>({
+  search: '',
+  page: 1,
+  pageSize: 10,
+  ministry: '',
+  cluster: '',
+  includeInactive: true,
+  sortKey: '',
+  sortOrder: Prisma.SortOrder.desc,
+});

--- a/app/private-cloud/products/(product)/create/page.tsx
+++ b/app/private-cloud/products/(product)/create/page.tsx
@@ -14,7 +14,7 @@ import ReturnModal from '@/components/modal/Return';
 import { AGMinistries } from '@/constants';
 import createClientPage from '@/core/client-page';
 import { PrivateCloudCreateRequestBodySchema } from '@/schema';
-import { createPriviateCloudProject } from '@/services/backend/private-cloud/products';
+import { createPrivateCloudProject } from '@/services/backend/private-cloud/products';
 
 const privateCloudProductNew = createClientPage({
   roles: ['user'],
@@ -30,7 +30,7 @@ export default privateCloudProductNew(({ pathParams, queryParams, session }) => 
     isError: isCreateError,
     error: createError,
   } = useMutation({
-    mutationFn: (data: any) => createPriviateCloudProject(data),
+    mutationFn: (data: any) => createPrivateCloudProject(data),
     onSuccess: () => {
       setOpenCreate(false);
       setOpenReturn(true);

--- a/app/private-cloud/products/all/page.tsx
+++ b/app/private-cloud/products/all/page.tsx
@@ -6,7 +6,7 @@ import Table from '@/components/generic/table/Table';
 import TableBody from '@/components/table/TableBodyProducts';
 import createClientPage from '@/core/client-page';
 import { privateCloudProjectDataToRow } from '@/helpers/row-mapper';
-import { searchPriviateCloudProducts, downloadPriviateCloudProducts } from '@/services/backend/private-cloud/products';
+import { searchPrivateCloudProducts, downloadPrivateCloudProducts } from '@/services/backend/private-cloud/products';
 import FilterPanel from './FilterPanel';
 import { pageState } from './state';
 
@@ -19,7 +19,7 @@ export default privateCloudProducts(({ pathParams, queryParams, session }) => {
 
   const { data, isLoading } = useQuery({
     queryKey: ['products', snap],
-    queryFn: () => searchPriviateCloudProducts(snap),
+    queryFn: () => searchPrivateCloudProducts(snap),
   });
 
   let products = [];
@@ -48,7 +48,7 @@ export default privateCloudProducts(({ pathParams, queryParams, session }) => {
           pageState.search = searchTerm;
         }}
         onExport={async () => {
-          const result = await downloadPriviateCloudProducts(snap);
+          const result = await downloadPrivateCloudProducts(snap);
           return result;
         }}
         filters={<FilterPanel />}

--- a/app/private-cloud/products/all/state.ts
+++ b/app/private-cloud/products/all/state.ts
@@ -6,6 +6,7 @@ export const pageState = proxy<PrivateCloudProductSearchCriteria>({
   search: '',
   page: 1,
   pageSize: 10,
+  licencePlate: '',
   ministry: '',
   cluster: '',
   includeInactive: false,

--- a/app/private-cloud/requests/(request)/[id]/decision/page.tsx
+++ b/app/private-cloud/requests/(request)/[id]/decision/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import { Alert } from '@mantine/core';
 import { $Enums, PrivateCloudProject } from '@prisma/client';
+import { IconInfoCircle } from '@tabler/icons-react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -15,7 +17,7 @@ import Comment from '@/components/modal/Comment';
 import ReturnModal from '@/components/modal/ReturnDecision';
 import createClientPage from '@/core/client-page';
 import { PrivateCloudDecisionRequestBodySchema } from '@/schema';
-import { makePriviateCloudRequestDecision } from '@/services/backend/private-cloud/requests';
+import { makePrivateCloudRequestDecision } from '@/services/backend/private-cloud/requests';
 import { usePrivateProductState } from '@/states/global';
 
 const pathParamSchema = z.object({
@@ -27,7 +29,7 @@ const privateCloudRequestDecision = createClientPage({
   validations: { pathParams: pathParamSchema },
 });
 export default privateCloudRequestDecision(({ pathParams, queryParams, session, router }) => {
-  const [privateCloudState, privateCloudStateSnap] = usePrivateProductState();
+  const [privateState, privateSnap] = usePrivateProductState();
   const { id } = pathParams;
   const [openReturn, setOpenReturn] = useState(false);
   const [openComment, setOpenComment] = useState(false);
@@ -40,7 +42,7 @@ export default privateCloudRequestDecision(({ pathParams, queryParams, session, 
     isError: isDecisionError,
     error: decisionError,
   } = useMutation({
-    mutationFn: (data: any) => makePriviateCloudRequestDecision(id, data),
+    mutationFn: (data: any) => makePrivateCloudRequestDecision(id, data),
     onSuccess: () => {
       setOpenComment(false);
       setOpenReturn(true);
@@ -48,21 +50,21 @@ export default privateCloudRequestDecision(({ pathParams, queryParams, session, 
   });
 
   useEffect(() => {
-    if (!privateCloudStateSnap.currentRequest) return;
+    if (!privateSnap.currentRequest) return;
 
-    if (!privateCloudStateSnap.currentRequest.active || !privateCloudStateSnap.currentRequest._permissions.review) {
-      router.push(`/private-cloud/requests/${privateCloudStateSnap.currentRequest.id}/view`);
+    if (privateSnap.currentRequest.active && !privateSnap.currentRequest._permissions.review) {
+      router.push(`/private-cloud/requests/${privateSnap.currentRequest.id}/summary`);
       return;
     }
 
-    if (privateCloudStateSnap.currentRequest.decisionData.secondaryTechnicalLead) {
+    if (privateSnap.currentRequest.decisionData.secondaryTechnicalLead) {
       setSecondTechLead(true);
     }
-  }, [privateCloudStateSnap.currentRequest, router]);
+  }, [privateSnap.currentRequest, router]);
 
   const methods = useForm({
     resolver: (...args) => {
-      const isDeleteRequest = privateCloudStateSnap.currentRequest?.type === $Enums.RequestType.DELETE;
+      const isDeleteRequest = privateSnap.currentRequest?.type === $Enums.RequestType.DELETE;
 
       // Ignore form validation if a DELETE request
       if (isDeleteRequest) {
@@ -77,8 +79,8 @@ export default privateCloudRequestDecision(({ pathParams, queryParams, session, 
     values: {
       decisionComment: '',
       decision: '',
-      type: privateCloudStateSnap.currentRequest?.type,
-      ...privateCloudStateSnap.currentRequest?.decisionData,
+      type: privateSnap.currentRequest?.type,
+      ...privateSnap.currentRequest?.decisionData,
     },
   });
 
@@ -93,11 +95,11 @@ export default privateCloudRequestDecision(({ pathParams, queryParams, session, 
     makeDecision({ ...methods.getValues(), decisionComment });
   };
 
-  if (!privateCloudStateSnap.currentRequest) {
+  if (!privateSnap.currentRequest) {
     return null;
   }
 
-  const isDisabled = !privateCloudStateSnap.currentRequest._permissions.edit;
+  const isDisabled = !privateSnap.currentRequest._permissions.edit;
 
   return (
     <div>
@@ -110,14 +112,14 @@ export default privateCloudRequestDecision(({ pathParams, queryParams, session, 
           })}
         >
           <div className="mb-12 mt-8">
-            {privateCloudStateSnap.currentRequest.decisionStatus !== 'PENDING' && (
-              <h3 className="font-bcsans text-base lg:text-md 2xl:text-lg text-gray-400 mb-3">
-                A decision has already been made for this product
-              </h3>
+            {privateSnap.currentRequest.decisionStatus !== 'PENDING' && (
+              <Alert variant="light" color="blue" title="" icon={<IconInfoCircle />}>
+                A decision has already been made for this product.
+              </Alert>
             )}
             <ProjectDescription
               disabled={isDisabled}
-              clusterDisabled={privateCloudStateSnap.currentRequest.type !== 'CREATE'}
+              clusterDisabled={privateSnap.currentRequest.type !== 'CREATE'}
               mode="decision"
             />
             <TeamContacts
@@ -126,26 +128,26 @@ export default privateCloudRequestDecision(({ pathParams, queryParams, session, 
               secondTechLeadOnClick={secondTechLeadOnClick}
             />
             <Quotas
-              licensePlate={privateCloudStateSnap.currentRequest.licencePlate as string}
+              licencePlate={privateSnap.currentRequest.licencePlate as string}
               disabled={isDisabled}
-              currentProject={privateCloudStateSnap.currentRequest.project as PrivateCloudProject}
+              currentProject={privateSnap.currentRequest.project as PrivateCloudProject}
             />
           </div>
 
-          {privateCloudStateSnap.currentRequest.requestComment && (
+          {privateSnap.currentRequest.requestComment && (
             <div className="border-b border-gray-900/10 pb-14">
               <h2 className="font-bcsans text-base lg:text-lg 2xl:text-2xl font-semibold leading-6 text-gray-900 2xl:mt-14">
                 4. User Comments
               </h2>
               <p className="font-bcsans mt-4 text-base leading-6 text-gray-600">
-                {privateCloudStateSnap.currentRequest.requestComment}
+                {privateSnap.currentRequest.requestComment}
               </p>
             </div>
           )}
 
           <div className="mt-10 flex items-center justify-start gap-x-6">
             <PreviousButton />
-            {privateCloudStateSnap.currentRequest._permissions.review && (
+            {privateSnap.currentRequest._permissions.review && (
               <div className="flex items-center justify-start gap-x-6">
                 <SubmitButton
                   text="REJECT REQUEST"
@@ -171,7 +173,7 @@ export default privateCloudRequestDecision(({ pathParams, queryParams, session, 
         setOpen={setOpenComment}
         onSubmit={setComment}
         isLoading={isMakingDecision}
-        type={privateCloudStateSnap.currentRequest.type}
+        type={privateSnap.currentRequest.type}
         action={currentAction}
       />
       <ReturnModal open={openReturn} setOpen={setOpenReturn} redirectUrl="/private-cloud/requests/active" />

--- a/app/private-cloud/requests/(request)/[id]/original/page.tsx
+++ b/app/private-cloud/requests/(request)/[id]/original/page.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { $Enums, PrivateCloudProject } from '@prisma/client';
+import { useEffect, useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { z } from 'zod';
+import PreviousButton from '@/components/buttons/Previous';
+import ProjectDescription from '@/components/form/ProjectDescriptionPrivate';
+import Quotas from '@/components/form/Quotas';
+import TeamContacts from '@/components/form/TeamContacts';
+import createClientPage from '@/core/client-page';
+import { PrivateCloudDecisionRequestBodySchema } from '@/schema';
+import { usePrivateProductState } from '@/states/global';
+
+const pathParamSchema = z.object({
+  id: z.string(),
+});
+
+const privateCloudRequestOriginal = createClientPage({
+  roles: ['user'],
+  validations: { pathParams: pathParamSchema },
+});
+export default privateCloudRequestOriginal(({ pathParams, queryParams, session, router }) => {
+  const [privateState, privateSnap] = usePrivateProductState();
+  const { id } = pathParams;
+  const [secondTechLead, setSecondTechLead] = useState(false);
+
+  useEffect(() => {
+    if (!privateSnap.currentRequest) return;
+
+    if (privateSnap.currentRequest.originalData?.secondaryTechnicalLead) {
+      setSecondTechLead(true);
+    }
+  }, [privateSnap.currentRequest, router]);
+
+  const methods = useForm({
+    values: {
+      decisionComment: '',
+      decision: '',
+      type: privateSnap.currentRequest?.type,
+      ...privateSnap.currentRequest?.originalData,
+    },
+  });
+
+  const secondTechLeadOnClick = () => {
+    setSecondTechLead(!secondTechLead);
+    if (secondTechLead) {
+      methods.unregister('secondaryTechnicalLead');
+    }
+  };
+
+  if (!privateSnap.currentRequest) {
+    return null;
+  }
+
+  const isDisabled = true;
+
+  return (
+    <div>
+      <FormProvider {...methods}>
+        <form autoComplete="off">
+          <div className="mb-12 mt-8">
+            <ProjectDescription
+              disabled={isDisabled}
+              clusterDisabled={privateSnap.currentRequest.type !== 'CREATE'}
+              mode="decision"
+            />
+            <TeamContacts
+              disabled={isDisabled}
+              secondTechLead={secondTechLead}
+              secondTechLeadOnClick={secondTechLeadOnClick}
+            />
+            <Quotas
+              licencePlate={privateSnap.currentRequest.licencePlate as string}
+              disabled={isDisabled}
+              currentProject={privateSnap.currentRequest.project as PrivateCloudProject}
+            />
+          </div>
+
+          <div className="mt-10 flex items-center justify-start gap-x-6">
+            <PreviousButton />
+          </div>
+        </form>
+      </FormProvider>
+    </div>
+  );
+});

--- a/app/private-cloud/requests/(request)/[id]/request/page.tsx
+++ b/app/private-cloud/requests/(request)/[id]/request/page.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { $Enums, PrivateCloudProject } from '@prisma/client';
+import { useEffect, useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { z } from 'zod';
+import PreviousButton from '@/components/buttons/Previous';
+import ProjectDescription from '@/components/form/ProjectDescriptionPrivate';
+import Quotas from '@/components/form/Quotas';
+import TeamContacts from '@/components/form/TeamContacts';
+import createClientPage from '@/core/client-page';
+import { PrivateCloudDecisionRequestBodySchema } from '@/schema';
+import { usePrivateProductState } from '@/states/global';
+
+const pathParamSchema = z.object({
+  id: z.string(),
+});
+
+const privateCloudRequestRequest = createClientPage({
+  roles: ['user'],
+  validations: { pathParams: pathParamSchema },
+});
+export default privateCloudRequestRequest(({ pathParams, queryParams, session, router }) => {
+  const [privateState, privateSnap] = usePrivateProductState();
+  const { id } = pathParams;
+  const [secondTechLead, setSecondTechLead] = useState(false);
+
+  useEffect(() => {
+    if (!privateSnap.currentRequest) return;
+
+    if (privateSnap.currentRequest.requestData?.secondaryTechnicalLead) {
+      setSecondTechLead(true);
+    }
+  }, [privateSnap.currentRequest, router]);
+
+  const methods = useForm({
+    values: {
+      decisionComment: '',
+      decision: '',
+      type: privateSnap.currentRequest?.type,
+      ...privateSnap.currentRequest?.requestData,
+    },
+  });
+
+  const secondTechLeadOnClick = () => {
+    setSecondTechLead(!secondTechLead);
+    if (secondTechLead) {
+      methods.unregister('secondaryTechnicalLead');
+    }
+  };
+
+  if (!privateSnap.currentRequest) {
+    return null;
+  }
+
+  const isDisabled = true;
+
+  return (
+    <div>
+      <FormProvider {...methods}>
+        <form autoComplete="off">
+          <div className="mb-12 mt-8">
+            <ProjectDescription
+              disabled={isDisabled}
+              clusterDisabled={privateSnap.currentRequest.type !== 'CREATE'}
+              mode="decision"
+            />
+            <TeamContacts
+              disabled={isDisabled}
+              secondTechLead={secondTechLead}
+              secondTechLeadOnClick={secondTechLeadOnClick}
+            />
+            <Quotas
+              licencePlate={privateSnap.currentRequest.licencePlate as string}
+              disabled={isDisabled}
+              currentProject={privateSnap.currentRequest.project as PrivateCloudProject}
+            />
+          </div>
+
+          {privateSnap.currentRequest.requestComment && (
+            <div className="border-b border-gray-900/10 pb-14">
+              <h2 className="font-bcsans text-base lg:text-lg 2xl:text-2xl font-semibold leading-6 text-gray-900 2xl:mt-14">
+                4. User Comments
+              </h2>
+              <p className="font-bcsans mt-4 text-base leading-6 text-gray-600">
+                {privateSnap.currentRequest.requestComment}
+              </p>
+            </div>
+          )}
+
+          <div className="mt-10 flex items-center justify-start gap-x-6">
+            <PreviousButton />
+          </div>
+        </form>
+      </FormProvider>
+    </div>
+  );
+});

--- a/app/private-cloud/requests/(request)/[id]/summary/page.tsx
+++ b/app/private-cloud/requests/(request)/[id]/summary/page.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { z } from 'zod';
+import createClientPage from '@/core/client-page';
+import { usePrivateProductState } from '@/states/global';
+
+const pathParamSchema = z.object({
+  id: z.string(),
+});
+
+const privateCloudRequestSummary = createClientPage({
+  roles: ['user'],
+  validations: { pathParams: pathParamSchema },
+});
+export default privateCloudRequestSummary(({ pathParams, queryParams, session, router }) => {
+  const [privateCloudState, privateCloudStateSnap] = usePrivateProductState();
+  const { id } = pathParams;
+
+  return <div>Summary</div>;
+});

--- a/app/private-cloud/requests/active/page.tsx
+++ b/app/private-cloud/requests/active/page.tsx
@@ -6,7 +6,7 @@ import Table from '@/components/generic/table/Table';
 import TableBody from '@/components/table/TableBodyRequests';
 import createClientPage from '@/core/client-page';
 import { privateCloudProjectDataToRow } from '@/helpers/row-mapper';
-import { searchPriviateCloudRequests } from '@/services/backend/private-cloud/requests';
+import { searchPrivateCloudRequests } from '@/services/backend/private-cloud/requests';
 import FilterPanel from './FilterPanel';
 import { pageState } from './state';
 
@@ -19,7 +19,7 @@ export default privateCloudRequests(({ pathParams, queryParams, session }) => {
 
   const { data, isLoading } = useQuery({
     queryKey: ['requests', snap],
-    queryFn: () => searchPriviateCloudRequests(snap),
+    queryFn: () => searchPrivateCloudRequests(snap),
   });
 
   let requests = [];

--- a/app/private-cloud/requests/active/state.ts
+++ b/app/private-cloud/requests/active/state.ts
@@ -6,6 +6,7 @@ export const pageState = proxy<PrivateCloudProductSearchCriteria>({
   search: '',
   page: 1,
   pageSize: 10,
+  licencePlate: '',
   ministry: '',
   cluster: '',
   includeInactive: false,

--- a/app/public-cloud/products/(product)/[licencePlate]/layout.tsx
+++ b/app/public-cloud/products/(product)/[licencePlate]/layout.tsx
@@ -36,16 +36,16 @@ export default publicCloudProductSecurityACS(({ pathParams, queryParams, session
     publicProductState.licencePlate = licencePlate;
   }, [licencePlate]);
 
-  let mode = 'decision';
-  if (currentProduct) {
-    mode = currentProduct.requests.length > 0 ? 'decision' : 'edit';
-  }
-
   const tabs: ITab[] = [
     {
       label: 'PRODUCT',
       name: 'product',
-      href: `/public-cloud/products/${licencePlate}/${mode}`,
+      href: `/public-cloud/products/${licencePlate}/edit`,
+    },
+    {
+      label: 'REQUESTS',
+      name: 'requests',
+      href: `/public-cloud/products/${licencePlate}/requests`,
     },
     {
       label: 'ROLES',

--- a/app/public-cloud/products/(product)/[licencePlate]/requests/FilterPanel.tsx
+++ b/app/public-cloud/products/(product)/[licencePlate]/requests/FilterPanel.tsx
@@ -1,0 +1,115 @@
+import { $Enums, Prisma } from '@prisma/client';
+import { useEffect, useRef, useState } from 'react';
+import { useSnapshot, subscribe } from 'valtio';
+import FormToggle from '@/components/generic/checkbox/FormToggle';
+import FormSelect from '@/components/generic/select/FormSelect';
+import { providers, productSorts, ministryOptions } from '@/constants';
+import { pageState } from './state';
+
+export default function FilterPanel() {
+  const pageSnapshot = useSnapshot(pageState);
+  const providerProviderRef = useRef<HTMLSelectElement>(null);
+  const ministryRef = useRef<HTMLSelectElement>(null);
+  const sortRef = useRef<HTMLSelectElement>(null);
+  const toggleText = 'Show Resolved Requests';
+
+  const handleSortChange = (value: string) => {
+    const selectedOption = productSorts.find((privateSortName) => privateSortName.humanFriendlyName === value);
+    if (selectedOption) {
+      pageState.sortKey = selectedOption.sortKey;
+      pageState.sortOrder = selectedOption.sortOrder;
+    } else {
+      pageState.sortKey = '';
+      pageState.sortOrder = Prisma.SortOrder.desc;
+    }
+  };
+
+  const handleToggleChange = () => {
+    pageState.includeInactive = !pageSnapshot.includeInactive;
+  };
+
+  const handleProviderChange = (value: string) => {
+    pageState.provider = value;
+  };
+
+  const handleMinistryChange = (value: string) => {
+    pageState.ministry = value;
+  };
+
+  const clearFilters = () => {
+    if (providerProviderRef.current) {
+      providerProviderRef.current.value = '';
+    }
+    if (ministryRef.current) {
+      ministryRef.current.value = '';
+    }
+    if (sortRef.current) {
+      sortRef.current.value = '';
+    }
+
+    pageState.provider = '';
+    pageState.ministry = '';
+    pageState.sortKey = '';
+    pageState.sortOrder = '';
+    pageState.includeInactive = false;
+  };
+
+  return (
+    <div className="flex gap-8 mr-10">
+      <div className="grid auto-rows-min grid-cols-1 gap-y-8 md:grid-cols-3 md:gap-x-6">
+        <fieldset className="w-full md:w-48 2xl:w-96">
+          <FormSelect
+            ref={sortRef}
+            id="id"
+            label="Sort By"
+            options={productSorts.map((v) => ({ label: v.humanFriendlyName, value: v.humanFriendlyName }))}
+            defaultValue={
+              productSorts.find((v) => v.sortKey === pageSnapshot.sortKey && v.sortOrder === pageSnapshot.sortOrder)
+                ?.humanFriendlyName
+            }
+            onChange={handleSortChange}
+          />
+        </fieldset>
+        <fieldset className="w-full md:w-48 2xl:w-96">
+          <div className="mt-2 md:mt-0 md:ml-4">
+            <FormSelect
+              ref={providerProviderRef}
+              id="provider"
+              label="Provider"
+              options={[{ label: 'All Providers', value: '' }, ...providers.map((v) => ({ label: v, value: v }))]}
+              defaultValue={pageSnapshot.provider}
+              onChange={handleProviderChange}
+            />
+          </div>
+        </fieldset>
+        <fieldset className="w-full md:w-48 2xl:w-96">
+          <div className="mt-2 md:mt-0 md:ml-4">
+            <FormSelect
+              ref={ministryRef}
+              id="ministry"
+              label="Ministry"
+              options={[{ label: `All Ministries`, value: '' }, ...ministryOptions]}
+              defaultValue={pageSnapshot.ministry}
+              onChange={handleMinistryChange}
+            />
+          </div>
+        </fieldset>
+        <div></div>
+        <FormToggle
+          id="includeInactive"
+          label={toggleText}
+          checked={pageSnapshot.includeInactive}
+          onChange={handleToggleChange}
+        />
+        <div className="mt-8 md:mt-7 md:ml-4">
+          <button
+            className="min-w-max w-1/2 h-9 inline-flex items-center justify-center gap-x-2 rounded-md bg-bcblue text-white px-3 text-sm font-semibold shadow-sm ring-1 ring-inset transition-all duration-500 ring-gray-300 hover:bg-[#CCCCCE]"
+            onClick={clearFilters}
+          >
+            Clear Filters
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/public-cloud/products/(product)/[licencePlate]/requests/page.tsx
+++ b/app/public-cloud/products/(product)/[licencePlate]/requests/page.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { proxy, useSnapshot } from 'valtio';
+import { z } from 'zod';
+import Table from '@/components/generic/table/Table';
+import TableBody from '@/components/table/TableBodyRequests';
+import createClientPage from '@/core/client-page';
+import { publicCloudProjectDataToRow } from '@/helpers/row-mapper';
+import { searchPublicCloudRequests } from '@/services/backend/public-cloud/requests';
+import FilterPanel from './FilterPanel';
+import { pageState } from './state';
+
+const pathParamSchema = z.object({
+  licencePlate: z.string(),
+});
+
+const publicCloudRequests = createClientPage({
+  roles: ['user'],
+  validations: { pathParams: pathParamSchema },
+  fallbackUrl: '/login?callbackUrl=/public-cloud/products/all',
+});
+export default publicCloudRequests(({ pathParams, queryParams, session }) => {
+  const snap = useSnapshot(pageState);
+  const { licencePlate } = pathParams;
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['requests', snap],
+    queryFn: () => searchPublicCloudRequests({ ...snap, licencePlate }),
+    enabled: !!licencePlate,
+  });
+
+  let requests = [];
+  let totalCount = 0;
+
+  if (!isLoading && data) {
+    const transformActiveRequests = data.docs.map((request) => ({
+      ...request.requestData,
+      created: request.created,
+      updatedAt: request.updatedAt,
+      requests: [request],
+      id: request.id,
+    }));
+
+    requests = transformActiveRequests.map(publicCloudProjectDataToRow);
+    totalCount = data.totalCount;
+  }
+
+  return (
+    <Table
+      totalCount={totalCount}
+      page={snap.page}
+      pageSize={snap.pageSize}
+      search={snap.search}
+      onPagination={(page: number, pageSize: number) => {
+        pageState.page = page;
+        pageState.pageSize = pageSize;
+      }}
+      onSearch={(searchTerm: string) => {
+        pageState.page = 1;
+        pageState.search = searchTerm;
+      }}
+      filters={<FilterPanel />}
+      isLoading={isLoading}
+    >
+      <TableBody rows={requests} isLoading={isLoading} />
+    </Table>
+  );
+});

--- a/app/public-cloud/products/(product)/[licencePlate]/requests/state.ts
+++ b/app/public-cloud/products/(product)/[licencePlate]/requests/state.ts
@@ -1,0 +1,14 @@
+import { $Enums, Prisma } from '@prisma/client';
+import { proxy, useSnapshot } from 'valtio';
+import { PublicCloudProductSearchCriteria } from '@/services/backend/public-cloud/products';
+
+export const pageState = proxy<Omit<PublicCloudProductSearchCriteria, 'licencePlate'>>({
+  search: '',
+  page: 1,
+  pageSize: 10,
+  ministry: '',
+  provider: '',
+  includeInactive: true,
+  sortKey: '',
+  sortOrder: Prisma.SortOrder.desc,
+});

--- a/app/public-cloud/products/all/state.ts
+++ b/app/public-cloud/products/all/state.ts
@@ -6,6 +6,7 @@ export const pageState = proxy<PublicCloudProductSearchCriteria>({
   search: '',
   page: 1,
   pageSize: 10,
+  licencePlate: '',
   ministry: '',
   provider: '',
   includeInactive: false,

--- a/app/public-cloud/requests/(request)/[id]/layout.tsx
+++ b/app/public-cloud/requests/(request)/[id]/layout.tsx
@@ -1,9 +1,12 @@
 'use client';
 
+import { $Enums } from '@prisma/client';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { ToastContainer } from 'react-toastify';
 import { z } from 'zod';
+import PublicCloudRequestOptions from '@/components/dropdowns/PublicCloudRequestOptions';
+import Tabs, { ITab } from '@/components/generic/tabs/BasicTabs';
 import createClientPage from '@/core/client-page';
 import { getPublicCloudRequest } from '@/services/backend/public-cloud/requests';
 import { publicProductState } from '@/states/global';
@@ -33,10 +36,45 @@ export default publicCloudProductSecurityACS(({ pathParams, queryParams, session
     }
   }, [request]);
 
+  const tabs: ITab[] = [
+    {
+      label: 'SUMMARY',
+      name: 'summary',
+      href: `/public-cloud/requests/${id}/summary`,
+    },
+  ];
+
+  if (request?.type !== $Enums.RequestType.CREATE) {
+    tabs.push({
+      label: 'ORIGINAL',
+      name: 'original',
+      href: `/public-cloud/requests/${id}/original`,
+    });
+  }
+
+  tabs.push({
+    label: 'USER REQUEST',
+    name: 'request',
+    href: `/public-cloud/requests/${id}/request`,
+  });
+
+  if (request?._permissions.review || !request?.active) {
+    tabs.push({
+      label: 'ADMIN DECISION',
+      name: 'decision',
+      href: `/public-cloud/requests/${id}/decision`,
+    });
+  }
+
+  if (isRequestLoading || !request) return null;
+
   return (
-    <>
-      {children}
+    <div>
+      <Tabs tabs={tabs}>
+        <PublicCloudRequestOptions id={request.id} />
+      </Tabs>
+      <div className="mt-8">{children}</div>
       <ToastContainer />
-    </>
+    </div>
   );
 });

--- a/app/public-cloud/requests/(request)/[id]/original/page.tsx
+++ b/app/public-cloud/requests/(request)/[id]/original/page.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { z } from 'zod';
+import PreviousButton from '@/components/buttons/Previous';
+import AccountCoding from '@/components/form/AccountCoding';
+import Budget from '@/components/form/Budget';
+import ExpenseAuthority from '@/components/form/ExpenseAuthority';
+import ProjectDescription from '@/components/form/ProjectDescriptionPublic';
+import TeamContacts from '@/components/form/TeamContacts';
+import createClientPage from '@/core/client-page';
+import { usePublicProductState } from '@/states/global';
+
+const pathParamSchema = z.object({
+  id: z.string(),
+});
+
+const publicCloudRequestOriginal = createClientPage({
+  roles: ['user'],
+  validations: { pathParams: pathParamSchema },
+});
+export default publicCloudRequestOriginal(({ pathParams, queryParams, session, router }) => {
+  const [publicState, publicSnap] = usePublicProductState();
+  const { id } = pathParams;
+  const [secondTechLead, setSecondTechLead] = useState(false);
+
+  useEffect(() => {
+    if (!publicSnap.currentRequest) return;
+
+    if (publicSnap.currentRequest.originalData?.secondaryTechnicalLead) {
+      setSecondTechLead(true);
+    }
+  }, [publicSnap.currentRequest, router]);
+
+  const methods = useForm({
+    values: {
+      decisionComment: '',
+      decision: '',
+      type: publicSnap.currentRequest?.type,
+      ...publicSnap.currentRequest?.originalData,
+    },
+  });
+
+  const secondTechLeadOnClick = () => {
+    setSecondTechLead(!secondTechLead);
+    if (secondTechLead) {
+      methods.unregister('secondaryTechnicalLead');
+    }
+  };
+
+  if (!publicSnap.currentRequest) {
+    return null;
+  }
+
+  const isDisabled = true;
+
+  return (
+    <div>
+      <FormProvider {...methods}>
+        <form autoComplete="off">
+          <div className="mb-12">
+            <ProjectDescription disabled={isDisabled} mode="decision" />
+            <TeamContacts
+              disabled={isDisabled}
+              secondTechLead={secondTechLead}
+              secondTechLeadOnClick={secondTechLeadOnClick}
+            />
+            <ExpenseAuthority disabled={isDisabled} />
+            <Budget disabled={isDisabled} />
+            <AccountCoding
+              accountCodingInitial={publicSnap.currentRequest.originalData?.accountCoding}
+              disabled={false}
+            />
+          </div>
+
+          {publicSnap.currentRequest.requestComment && (
+            <div className="border-b border-gray-900/10 pb-14">
+              <h2 className="font-bcsans text-base lg:text-lg 2xl:text-2xl font-semibold leading-6 text-gray-900 2xl:mt-14">
+                4. User Comments
+              </h2>
+              <p className="font-bcsans mt-4 text-base leading-6 text-gray-600">
+                {publicSnap.currentRequest.requestComment}
+              </p>
+            </div>
+          )}
+
+          <div className="mt-10 flex items-center justify-start gap-x-6">
+            <PreviousButton />
+          </div>
+        </form>
+      </FormProvider>
+    </div>
+  );
+});

--- a/app/public-cloud/requests/(request)/[id]/request/page.tsx
+++ b/app/public-cloud/requests/(request)/[id]/request/page.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { z } from 'zod';
+import PreviousButton from '@/components/buttons/Previous';
+import AccountCoding from '@/components/form/AccountCoding';
+import Budget from '@/components/form/Budget';
+import ExpenseAuthority from '@/components/form/ExpenseAuthority';
+import ProjectDescription from '@/components/form/ProjectDescriptionPublic';
+import TeamContacts from '@/components/form/TeamContacts';
+import createClientPage from '@/core/client-page';
+import { usePublicProductState } from '@/states/global';
+
+const pathParamSchema = z.object({
+  id: z.string(),
+});
+
+const publicCloudRequestRequest = createClientPage({
+  roles: ['user'],
+  validations: { pathParams: pathParamSchema },
+});
+export default publicCloudRequestRequest(({ pathParams, queryParams, session, router }) => {
+  const [publicState, publicSnap] = usePublicProductState();
+  const { id } = pathParams;
+  const [secondTechLead, setSecondTechLead] = useState(false);
+
+  useEffect(() => {
+    if (!publicSnap.currentRequest) return;
+
+    if (publicSnap.currentRequest.requestData?.secondaryTechnicalLead) {
+      setSecondTechLead(true);
+    }
+  }, [publicSnap.currentRequest, router]);
+
+  const methods = useForm({
+    values: {
+      decisionComment: '',
+      decision: '',
+      type: publicSnap.currentRequest?.type,
+      ...publicSnap.currentRequest?.requestData,
+    },
+  });
+
+  const secondTechLeadOnClick = () => {
+    setSecondTechLead(!secondTechLead);
+    if (secondTechLead) {
+      methods.unregister('secondaryTechnicalLead');
+    }
+  };
+
+  if (!publicSnap.currentRequest) {
+    return null;
+  }
+
+  const isDisabled = true;
+
+  return (
+    <div>
+      <FormProvider {...methods}>
+        <form autoComplete="off">
+          <div className="mb-12">
+            <ProjectDescription disabled={isDisabled} mode="decision" />
+            <TeamContacts
+              disabled={isDisabled}
+              secondTechLead={secondTechLead}
+              secondTechLeadOnClick={secondTechLeadOnClick}
+            />
+            <ExpenseAuthority disabled={isDisabled} />
+            <Budget disabled={isDisabled} />
+            <AccountCoding
+              accountCodingInitial={publicSnap.currentRequest.requestData?.accountCoding}
+              disabled={false}
+            />
+          </div>
+
+          {publicSnap.currentRequest.requestComment && (
+            <div className="border-b border-gray-900/10 pb-14">
+              <h2 className="font-bcsans text-base lg:text-lg 2xl:text-2xl font-semibold leading-6 text-gray-900 2xl:mt-14">
+                4. User Comments
+              </h2>
+              <p className="font-bcsans mt-4 text-base leading-6 text-gray-600">
+                {publicSnap.currentRequest.requestComment}
+              </p>
+            </div>
+          )}
+
+          <div className="mt-10 flex items-center justify-start gap-x-6">
+            <PreviousButton />
+          </div>
+        </form>
+      </FormProvider>
+    </div>
+  );
+});

--- a/app/public-cloud/requests/(request)/[id]/summary/page.tsx
+++ b/app/public-cloud/requests/(request)/[id]/summary/page.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { z } from 'zod';
+import createClientPage from '@/core/client-page';
+import { usePublicProductState } from '@/states/global';
+
+const pathParamSchema = z.object({
+  id: z.string(),
+});
+
+const publicCloudRequestSummary = createClientPage({
+  roles: ['user'],
+  validations: { pathParams: pathParamSchema },
+});
+export default publicCloudRequestSummary(({ pathParams, queryParams, session, router }) => {
+  const [publicCloudState, publicCloudStateSnap] = usePublicProductState();
+  const { id } = pathParams;
+
+  return <div>Summary</div>;
+});

--- a/app/public-cloud/requests/active/state.ts
+++ b/app/public-cloud/requests/active/state.ts
@@ -6,6 +6,7 @@ export const pageState = proxy<PublicCloudProductSearchCriteria>({
   search: '',
   page: 1,
   pageSize: 10,
+  licencePlate: '',
   ministry: '',
   provider: '',
   includeInactive: false,

--- a/components/dropdowns/PrivateCloudProductOptions.tsx
+++ b/components/dropdowns/PrivateCloudProductOptions.tsx
@@ -9,9 +9,9 @@ import DeleteButton from '@/components/buttons/DeleteButton';
 import ErrorModal from '@/components/modal/Error';
 import PrivateCloudDeleteModal from '@/components/modal/PrivateCloudDelete';
 import ReturnModal from '@/components/modal/Return';
-import { deletePrivateCloudProject, reprovisionPriviateCloudProduct } from '@/services/backend/private-cloud/products';
+import { deletePrivateCloudProject, reprovisionPrivateCloudProduct } from '@/services/backend/private-cloud/products';
 
-export default function Dropdown({
+export default function PrivateCloudProductOptions({
   licensePlace = '',
   canReprovision = false,
   canDelete = false,
@@ -34,7 +34,7 @@ export default function Dropdown({
     isError: isReprovisionError,
     error: reprovisionError,
   } = useMutation({
-    mutationFn: () => reprovisionPriviateCloudProduct(licensePlace),
+    mutationFn: () => reprovisionPrivateCloudProduct(licensePlace),
     onSuccess: () => {
       toast.success('Successfully reprovisioned!');
     },

--- a/components/dropdowns/PrivateCloudRequestOptions.tsx
+++ b/components/dropdowns/PrivateCloudRequestOptions.tsx
@@ -1,19 +1,19 @@
 import { Menu, Transition } from '@headlessui/react';
-import { ChevronDownIcon, TrashIcon, PlayCircleIcon } from '@heroicons/react/20/solid';
+import { ChevronDownIcon, PlayCircleIcon } from '@heroicons/react/20/solid';
 import { useMutation } from '@tanstack/react-query';
 import classNames from 'classnames';
 import { useParams } from 'next/navigation';
 import { useState, Fragment } from 'react';
 import { toast } from 'react-toastify';
-import ErrorModal from '@/components/modal/Error';
-import ReturnModal from '@/components/modal/Return';
-import { resendPriviateCloudRequest } from '@/services/backend/private-cloud/requests';
+import { resendPrivateCloudRequest } from '@/services/backend/private-cloud/requests';
 
-export default function Dropdown({ id = '', canResend = false }: { id?: string; canResend?: boolean }) {
-  const [showReturnModal, setShowReturnModal] = useState(false);
-  const [showErrorModal, setShowErrorModal] = useState(false);
-  const [errorMessage, setErrorMessage] = useState('');
-
+export default function PrivateCloudRequestOptions({
+  id = '',
+  canResend = false,
+}: {
+  id?: string;
+  canResend?: boolean;
+}) {
   const params = useParams();
 
   const {
@@ -22,7 +22,7 @@ export default function Dropdown({ id = '', canResend = false }: { id?: string; 
     isError: isResendError,
     error: resendError,
   } = useMutation({
-    mutationFn: () => resendPriviateCloudRequest(id),
+    mutationFn: () => resendPrivateCloudRequest(id),
     onSuccess: () => {
       toast.success('Successfully resent!');
     },
@@ -32,19 +32,6 @@ export default function Dropdown({ id = '', canResend = false }: { id?: string; 
 
   return (
     <>
-      <ReturnModal
-        open={showReturnModal}
-        setOpen={setShowReturnModal}
-        redirectUrl="/private-cloud/products/all"
-        modalTitle="Thank you! We have received your delete request."
-        modalMessage="We have received your delete request for this product. The Product Owner and Technical Lead(s) will receive an update via email."
-      />
-      <ErrorModal
-        open={showErrorModal}
-        setOpen={setShowErrorModal}
-        errorMessage={errorMessage}
-        redirectUrl="/private-cloud/products/all"
-      />
       <Menu as="div" className="relative inline-block text-left">
         <div>
           <Menu.Button className="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">

--- a/components/dropdowns/PublicCloudProductOptions.tsx
+++ b/components/dropdowns/PublicCloudProductOptions.tsx
@@ -6,7 +6,7 @@ import PublicCloudDeleteModal from '@/components/modal/PublicCloudDelete';
 import ReturnModal from '@/components/modal/Return';
 import { deletePublicCloudProject } from '@/services/backend/public-cloud/products';
 
-export default function Dropdown({ disabled = false }: { disabled?: boolean }) {
+export default function PublicCloudProductOptions({ disabled = false }: { disabled?: boolean }) {
   const [showModal, setShowModal] = useState(false);
   const [showReturnModal, setShowReturnModal] = useState(false);
   const [showErrorModal, setShowErrorModal] = useState(false);

--- a/components/dropdowns/PublicCloudRequestOptions.tsx
+++ b/components/dropdowns/PublicCloudRequestOptions.tsx
@@ -1,0 +1,7 @@
+import { useParams } from 'next/navigation';
+
+export default function PublicCloudRequestOptions({ id }: { id: string }) {
+  const params = useParams();
+
+  return <></>;
+}

--- a/components/form/ProductBadge.tsx
+++ b/components/form/ProductBadge.tsx
@@ -1,36 +1,42 @@
+import { Badge } from '@mantine/core';
 import { $Enums } from '@prisma/client';
 import classNames from 'classnames';
-import { FieldValues } from 'react-hook-form';
+import CopyableButton from '@/components/generic/button/CopyableButton';
 
-export default function ProductBadge({ values }: { values: FieldValues }) {
-  // Request Document
-  if (values.type) {
-    return (
-      <span
-        className={classNames('text-sm font-medium me-2 px-2.5 py-0.5 rounded no-underline ml-1 float-right', {
-          'bg-green-100 text-green-800': values.type === $Enums.RequestType.CREATE,
-          'bg-blue-100 text-blue-800': values.type === $Enums.RequestType.EDIT,
-          'bg-red-100 text-red-800': values.type === $Enums.RequestType.DELETE,
-        })}
-      >
-        {values.type}
-      </span>
-    );
+export default function ProductBadge({
+  data,
+  className,
+}: {
+  data?: { licencePlate: string; status: $Enums.ProjectStatus };
+  className?: string;
+}) {
+  if (!data || !data.licencePlate) return null;
+
+  let color = 'gray';
+
+  switch (data.status) {
+    case $Enums.ProjectStatus.ACTIVE:
+      color = 'green';
+      break;
+    case $Enums.ProjectStatus.INACTIVE:
+      color = 'red';
+      break;
   }
 
-  // Product Document
-  if (values.status) {
-    return (
-      <span
-        className={classNames(
-          'text-sm font-medium me-2 px-2.5 py-0.5 rounded no-underline ml-1 float-right',
-          values.status === $Enums.ProjectStatus.ACTIVE ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800',
-        )}
-      >
-        {values.status}
-      </span>
-    );
-  }
+  const badge = (
+    <Badge color={color} radius="sm" className="ml-1">
+      {data.status}
+    </Badge>
+  );
 
-  return null;
+  return (
+    <div className={classNames('inline-block', className)}>
+      <CopyableButton value={data.licencePlate}>
+        <Badge color="gray" radius="sm">
+          {data.licencePlate}
+        </Badge>
+      </CopyableButton>
+      {badge}
+    </div>
+  );
 }

--- a/components/form/ProjectDescriptionPrivate.tsx
+++ b/components/form/ProjectDescriptionPrivate.tsx
@@ -8,7 +8,9 @@ import ExternalLink from '@/components/generic/button/ExternalLink';
 import MailLink from '@/components/generic/button/MailLink';
 import FormSelect from '@/components/generic/select/FormSelect';
 import { clusters, ministryOptions } from '@/constants';
+import { usePrivateProductState } from '@/states/global';
 import ProductBadge from './ProductBadge';
+import RequestBadge from './RequestBadge';
 
 export default function ProjectDescriptionPrivate({
   mode,
@@ -19,6 +21,8 @@ export default function ProjectDescriptionPrivate({
   disabled?: boolean;
   clusterDisabled?: boolean;
 }) {
+  const [privateState, privateSnap] = usePrivateProductState();
+
   const {
     register,
     formState: { errors },
@@ -41,9 +45,13 @@ export default function ProjectDescriptionPrivate({
 
   return (
     <div className="border-b border-gray-900/10 pb-14">
-      <h1 className="font-bcsans text-xl lg:text-2xl 2xl:text-4xl font-semibold leading-7 text-gray-900 mb-8 lg:mt-4">
+      <h1 className="flex justify-between text-xl lg:text-2xl 2xl:text-4xl font-semibold leading-7 text-gray-900 mb-8 lg:mt-4">
         Private Cloud OpenShift Platform
-        <ProductBadge values={values} />
+        {privateSnap.currentRequest ? (
+          <RequestBadge data={privateSnap.currentRequest} className="ml-1" />
+        ) : (
+          <ProductBadge data={privateSnap.currentProduct} className="ml-1" />
+        )}
       </h1>
       <h2 className="font-bcsans text-base lg:text-lg 2xl:text-2xl font-semibold leading-6 text-gray-900 2xl:mt-14">
         1. Product Description

--- a/components/form/ProjectDescriptionPublic.tsx
+++ b/components/form/ProjectDescriptionPublic.tsx
@@ -3,7 +3,9 @@ import { useFormContext } from 'react-hook-form';
 import AGMinistryCheckBox from '@/components/form/AGMinistryCheckBox';
 import FormSelect from '@/components/generic/select/FormSelect';
 import { providers, ministryOptions } from '@/constants';
+import { usePublicProductState } from '@/states/global';
 import ProductBadge from './ProductBadge';
+import RequestBadge from './RequestBadge';
 
 function stripSpecialCharacters(text: string) {
   const pattern = /[^A-Za-z0-9///.:+=@_ ]/g;
@@ -19,6 +21,8 @@ export default function ProjectDescriptionPublic({
   disabled?: boolean;
   providerDisabled?: boolean;
 }) {
+  const [publicState, publicSnap] = usePublicProductState();
+
   const {
     register,
     formState: { errors },
@@ -30,9 +34,13 @@ export default function ProjectDescriptionPublic({
 
   return (
     <div className="border-b border-gray-900/10 pb-14">
-      <h1 className="font-bcsans text-xl lg:text-2xl 2xl:text-4xl font-semibold leading-7 text-gray-900 mb-8 lg:mt-4">
-        BC Gov’s Landing Zone in AWS
-        <ProductBadge values={values} />
+      <h1 className="flex justify-between text-xl lg:text-2xl 2xl:text-4xl font-semibold leading-7 text-gray-900 mb-8 lg:mt-4">
+        BC Gov’s Landing Zone in {values.provider}
+        {publicSnap.currentRequest ? (
+          <RequestBadge data={publicSnap.currentRequest} className="ml-1" />
+        ) : (
+          <ProductBadge data={publicSnap.currentProduct} className="ml-1" />
+        )}
       </h1>
       <h2 className="font-bcsans text-base lg:text-lg 2xl:text-2xl font-semibold leading-4 text-gray-900 2xl:mt-14">
         1. Product Description

--- a/components/form/QuotaInput.tsx
+++ b/components/form/QuotaInput.tsx
@@ -14,7 +14,7 @@ export default function QuotaInput({
 }: {
   quotaName: 'cpu' | 'memory' | 'storage';
   nameSpace: 'production' | 'test' | 'development' | 'tools';
-  licensePlate: string;
+  licencePlate: string;
   selectOptions: SelectOptions;
   disabled: boolean;
   quota: string | null;

--- a/components/form/Quotas.tsx
+++ b/components/form/Quotas.tsx
@@ -10,11 +10,11 @@ const quotaOptionsLookup = {
 };
 
 export default function Quotas({
-  licensePlate,
+  licencePlate,
   disabled,
   currentProject,
 }: {
-  licensePlate: string;
+  licencePlate: string;
   disabled: boolean;
   currentProject?: PrivateCloudProject | null | undefined;
 }) {
@@ -45,9 +45,9 @@ export default function Quotas({
               {nameSpace.charAt(0).toUpperCase() + nameSpace.slice(1)} Namespace
             </h3>
             <ExternalLink
-              href={`https://console.apps.${currentProject?.cluster}.devops.gov.bc.ca/k8s/cluster/projects/${licensePlate}${namespaceSuffixes[nameSpace]}`}
+              href={`https://console.apps.${currentProject?.cluster}.devops.gov.bc.ca/k8s/cluster/projects/${licencePlate}${namespaceSuffixes[nameSpace]}`}
             >
-              {licensePlate}
+              {licencePlate}
               {namespaceSuffixes[nameSpace] || ''}
             </ExternalLink>
             {(['cpu', 'memory', 'storage'] as const).map((quotaName) => (
@@ -55,7 +55,7 @@ export default function Quotas({
                 key={quotaName}
                 quotaName={quotaName}
                 selectOptions={quotaOptionsLookup[quotaName]}
-                licensePlate={licensePlate}
+                licencePlate={licencePlate}
                 nameSpace={nameSpace}
                 disabled={disabled}
                 quota={(currentProject as { [key: string]: any })?.[nameSpace + 'Quota'][quotaName]}

--- a/components/form/RequestBadge.tsx
+++ b/components/form/RequestBadge.tsx
@@ -1,0 +1,50 @@
+import { Badge } from '@mantine/core';
+import { $Enums } from '@prisma/client';
+import classNames from 'classnames';
+import CopyableButton from '@/components/generic/button/CopyableButton';
+
+export default function RequestBadge({
+  data,
+  className,
+}: {
+  data?: { licencePlate: string; type: $Enums.RequestType; active: boolean };
+  className?: string;
+}) {
+  if (!data || !data.licencePlate) return null;
+
+  let color = 'gray';
+
+  switch (data.type) {
+    case $Enums.RequestType.CREATE:
+      color = 'green';
+      break;
+    case $Enums.RequestType.EDIT:
+      color = 'blue';
+      break;
+    case $Enums.RequestType.DELETE:
+      color = 'red';
+      break;
+  }
+
+  const badge = (
+    <>
+      <Badge color={color} radius="sm" className="ml-1">
+        {data.type}
+      </Badge>
+      <Badge color={data.active ? 'lime' : 'pink'} radius="sm" className="ml-1">
+        {data.active ? 'ACTIVE' : 'INACTIVE'}
+      </Badge>
+    </>
+  );
+
+  return (
+    <div className={classNames('inline-block', className)}>
+      <CopyableButton value={data.licencePlate}>
+        <Badge color="gray" radius="sm">
+          {data.licencePlate}
+        </Badge>
+      </CopyableButton>
+      {badge}
+    </div>
+  );
+}

--- a/components/generic/button/CopyableButton.tsx
+++ b/components/generic/button/CopyableButton.tsx
@@ -1,6 +1,8 @@
 import { Tooltip, UnstyledButton } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import { IconClipboardCopy } from '@tabler/icons-react';
+import classNames from 'classnames';
+import _isString from 'lodash-es/isString';
 import React from 'react';
 
 export default function CopyableButton({ children, value }: { children: React.ReactNode; value?: string }) {
@@ -17,9 +19,13 @@ export default function CopyableButton({ children, value }: { children: React.Re
           clipboard.copy(value ?? String(children));
         }}
       >
-        <div className="flex hover:underline">
+        <div
+          className={classNames('flex', {
+            'hover:underline': _isString(children),
+          })}
+        >
           {children}
-          <IconClipboardCopy className="" />
+          {_isString(children) && <IconClipboardCopy className="" />}
         </div>
       </UnstyledButton>
     </Tooltip>

--- a/components/generic/checkbox/FormCheckbox.tsx
+++ b/components/generic/checkbox/FormCheckbox.tsx
@@ -66,7 +66,7 @@ export default function FormCheckbox({
 
   return (
     <>
-      <div className="flex font-bcsans">
+      <div className="flex">
         <input
           type="checkbox"
           id={id}
@@ -75,7 +75,8 @@ export default function FormCheckbox({
           {...inputProps}
           onChange={handleChange}
           className={classnames(
-            'h-4 w-4 mt-1 border-black-400 text-indigo-600 focus:ring-indigo-600',
+            'h-4 w-4 mt-1 border-black-400',
+            disabled ? 'text-gray-600 focus:ring-gray-600 cursor-not-allowed' : 'text-indigo-600 focus:ring-indigo-600',
             className?.input ?? '',
           )}
           // Required to bind three potential refs:
@@ -99,7 +100,11 @@ export default function FormCheckbox({
         <div className="ml-3">
           <label
             htmlFor={id}
-            className={classnames('text-gray-900 select-none cursor-pointer', className?.label ?? '')}
+            className={classnames(
+              'text-gray-900 select-none',
+              className?.label ?? '',
+              disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+            )}
           >
             {children ?? label}
           </label>

--- a/components/generic/table/Table.tsx
+++ b/components/generic/table/Table.tsx
@@ -19,8 +19,8 @@ const defaultValue = {
 const TableContext = createContext(defaultValue);
 
 export default function Table({
-  title,
-  description,
+  title = '',
+  description = '',
   page,
   pageSize,
   totalCount,
@@ -32,8 +32,8 @@ export default function Table({
   isLoading = false,
   children,
 }: {
-  title: string;
-  description: string;
+  title?: string;
+  description?: string;
   page: number;
   pageSize: number;
   totalCount: number;
@@ -66,6 +66,7 @@ export default function Table({
             </SearchFilterExport>
           )}
         </TableHeader>
+
         <div className="h-[60vh] overflow-y-auto scroll-smooth">{children}</div>
         <TableFooter>
           <Pagination />

--- a/components/generic/table/TableHeader.tsx
+++ b/components/generic/table/TableHeader.tsx
@@ -5,20 +5,23 @@ export default function TableTop({
   description,
   children,
 }: {
-  title: string;
-  description: string;
+  title?: string;
+  description?: string;
   children?: React.ReactNode;
 }) {
   return (
     <>
-      <div className="mx-auto w-full px-4 sm:px-6 lg:px-8 pt-6 border-b-2">
-        <div className="sm:flex sm:items-center pb-5">
-          <div className="sm:flex-auto">
-            <h1 className="text-lg font-bcsans font-bold leading-6 text-gray-900">{title}</h1>
-            <p className="mt-2 text-sm font-bcsans text-gray-700">{description}</p>
+      {(title || description) && (
+        <div className="mx-auto w-full px-4 sm:px-6 lg:px-8 pt-6 border-b-2">
+          <div className="sm:flex sm:items-center pb-5">
+            <div className="sm:flex-auto">
+              {title && <h1 className="text-lg font-bcsans font-bold leading-6 text-gray-900">{title}</h1>}
+              {description && <p className="mt-2 text-sm font-bcsans text-gray-700">{description}</p>}
+            </div>
           </div>
         </div>
-      </div>
+      )}
+
       {children && <div className="flex justify-between items-center border-b-2 px-4 py-2 w-full">{children}</div>}
     </>
   );

--- a/components/modal/PrivateCloudDelete.tsx
+++ b/components/modal/PrivateCloudDelete.tsx
@@ -1,7 +1,7 @@
 import { ExclamationCircleIcon, CheckCircleIcon } from '@heroicons/react/24/outline';
 import { useEffect, useRef, useState } from 'react';
 import Modal from '@/components/generic/modal/Modal';
-import { checkPriviateCloudProductDeletionAvailability } from '@/services/backend/private-cloud/products';
+import { checkPrivateCloudProductDeletionAvailability } from '@/services/backend/private-cloud/products';
 import { usePrivateProductState } from '@/states/global';
 import classNames from '@/utils/classnames';
 
@@ -28,7 +28,7 @@ export default function PrivateCloudDeleteModal({
       const fetchDeletionCheck = async () => {
         try {
           setIsLoading(true);
-          const data = await checkPriviateCloudProductDeletionAvailability(
+          const data = await checkPrivateCloudProductDeletionAvailability(
             privateProductSnapshot.licencePlate as string,
           );
           setDeletionCheckData(data);

--- a/components/table/TableBodyProducts.tsx
+++ b/components/table/TableBodyProducts.tsx
@@ -3,6 +3,7 @@
 'use client';
 
 import path from 'path';
+import { Tooltip } from '@mantine/core';
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
@@ -143,11 +144,7 @@ export default function TableBodyProducts({ rows, isLoading = false }: TableProp
   }
 
   const onRowClickHandler = (row: any) => {
-    if (row.requests.length > 0) {
-      router.push(path.join(`/${cloud}/requests/${row.requests[0].id}/decision`));
-    } else {
-      router.push(path.join(`/${cloud}/products/${row.licencePlate}/edit`));
-    }
+    router.push(path.join(`/${cloud}/products/${row.licencePlate}/edit`));
   };
 
   return (
@@ -159,7 +156,7 @@ export default function TableBodyProducts({ rows, isLoading = false }: TableProp
             onKeyDown={(e) => e.key === 'Enter' && onRowClickHandler(row)}
             role="button" // Assign an appropriate role
             onClick={() => onRowClickHandler(row)}
-            className="hover:bg-gray-100 transition-colors duration-200 grid grid-cols-1 md:grid-cols-6 lg:grid-cols-12 gap-4 px-4 py-4 sm:px-6 lg:px-8"
+            className="hover:bg-gray-100 transition-colors duration-200 grid grid-cols-1 md:grid-cols-6 lg:grid-cols-12 gap-4 px-4 py-2 sm:px-6 lg:px-8"
           >
             <div className="md:col-span-3 lg:col-span-4">
               <div className="flex items-center gap-x-3">
@@ -189,23 +186,38 @@ export default function TableBodyProducts({ rows, isLoading = false }: TableProp
             </div>
 
             <div className="md:col-span-1 lg:col-span-2">
-              <span
-                className={classNames(
-                  requestTypes[row.requestType as keyof typeof requestTypes],
-                  'inline-flex items-center rounded-md  px-2 py-1 text-sm font-medium capitalize text-gray-700',
-                )}
-              >
-                {typeof row?.requestType === 'string' ? row?.requestType.toLocaleLowerCase() + ' request' : null}
-              </span>
-              <div>
-                <span
-                  className={classNames(
-                    'inline-flex items-center rounded-md pr-2 py-1 text-sm capitalize text-gray-700',
-                  )}
-                >
-                  {typeof row?.requestType === 'string' ? getStatus(row?.requestDecisionStatus) : null}
-                </span>
-              </div>
+              {row.requests.length > 0 && (
+                <Tooltip label="View Request" position="top" offset={10}>
+                  <button
+                    type="button"
+                    className="text-gray-900 bg-white border border-gray-300 focus:outline-none hover:bg-gray-200 focus:ring-4 focus:ring-gray-100 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+
+                      router.push(path.join(`/${cloud}/requests/${row.requests[0].id}/decision`));
+                    }}
+                  >
+                    <span
+                      className={classNames(
+                        requestTypes[row.requestType as keyof typeof requestTypes],
+                        'inline-flex items-center rounded-md px-2 py-1 text-sm capitalize text-gray-700',
+                      )}
+                    >
+                      {typeof row?.requestType === 'string' ? row?.requestType.toLocaleLowerCase() + ' request' : null}
+                    </span>
+                    <div>
+                      <span
+                        className={classNames(
+                          'inline-flex items-center rounded-md pr-2 py-1 text-sm capitalize text-gray-700',
+                        )}
+                      >
+                        {typeof row?.requestType === 'string' ? getStatus(row?.requestDecisionStatus) : null}
+                      </span>
+                    </div>
+                  </button>
+                </Tooltip>
+              )}
             </div>
 
             <div className="lg:col-span-1 hidden lg:block"></div>

--- a/cypress/support/step_definitions/delete-request.ts
+++ b/cypress/support/step_definitions/delete-request.ts
@@ -8,7 +8,7 @@ const adminEmail: string = Cypress.env('admin_login');
 const userEmail: string = Cypress.env('user_login');
 const adminPassword: string = Cypress.env('admin_password');
 const userPassword: string = Cypress.env('user_password');
-let licensePlate: string = '';
+let licencePlate: string = '';
 
 Given('I am logged in to the Registry as a User', () => {
   cy.loginToRegistry(userEmail, userPassword);
@@ -54,9 +54,9 @@ When('I create a Delete Request', () => {
     .invoke('text')
     .then((text) => {
       // Store the text content into a variable
-      licensePlate = text.trim();
+      licencePlate = text.trim();
     });
-  cy.get('input[id="license-plate"]').type(licensePlate);
+  cy.get('input[id="license-plate"]').type(licencePlate);
   cy.get('input[id="owner-email"]').type(userEmail);
   cy.contains('button', 'Delete').click();
   cy.contains('button', 'Return to Dashboard').click();

--- a/helm/main/values.yaml
+++ b/helm/main/values.yaml
@@ -1,8 +1,8 @@
 # See https://helm.sh/docs/chart_template_guide/subcharts_and_globals/#global-chart-values
 global:
-  licensePlate: 101ed4
+  licencePlate: 101ed4
   vault:
-    # licensePlate-nonprod or licensePlate-prod
+    # licencePlate-nonprod or licencePlate-prod
     role:
     # sub-path of the vault secret
     subPath:

--- a/helm/secdash/values.yaml
+++ b/helm/secdash/values.yaml
@@ -1,8 +1,8 @@
 # See https://helm.sh/docs/chart_template_guide/subcharts_and_globals/#global-chart-values
 global:
-  licensePlate: 101ed4
+  licencePlate: 101ed4
   vault:
-    # licensePlate-nonprod or licensePlate-prod
+    # licencePlate-nonprod or licencePlate-prod
     role:
     # sub-path of the vault secret
     subPath:

--- a/queries/private-cloud-requests.ts
+++ b/queries/private-cloud-requests.ts
@@ -44,6 +44,7 @@ export async function searchPrivateCloudRequests({
   session,
   skip,
   take,
+  licencePlate,
   ministry,
   cluster,
   search,
@@ -54,6 +55,7 @@ export async function searchPrivateCloudRequests({
   session: Session;
   skip: number;
   take: number;
+  licencePlate?: string;
   ministry?: string;
   cluster?: string;
   search?: string;
@@ -85,6 +87,10 @@ export async function searchPrivateCloudRequests({
       { description: productSearchcreteria },
       { licencePlate: productSearchcreteria },
     ];
+  }
+
+  if (licencePlate) {
+    decisionDatawhere.licencePlate = licencePlate;
   }
 
   if (ministry) {

--- a/queries/public-cloud-requests.ts
+++ b/queries/public-cloud-requests.ts
@@ -48,6 +48,7 @@ export async function searchPublicCloudRequests({
   session,
   skip,
   take,
+  licencePlate,
   ministry,
   provider,
   search,
@@ -58,6 +59,7 @@ export async function searchPublicCloudRequests({
   session: Session;
   skip: number;
   take: number;
+  licencePlate?: string;
   ministry?: string;
   provider?: string;
   search?: string;
@@ -89,6 +91,10 @@ export async function searchPublicCloudRequests({
       { description: productSearchcreteria },
       { licencePlate: productSearchcreteria },
     ];
+  }
+
+  if (licencePlate) {
+    decisionDatawhere.licencePlate = licencePlate;
   }
 
   if (ministry) {

--- a/services/backend/private-cloud/products.ts
+++ b/services/backend/private-cloud/products.ts
@@ -14,6 +14,7 @@ export interface PrivateCloudProductAllCriteria {
   search: string;
   page: number;
   pageSize: number;
+  licencePlate: string;
   ministry: string;
   cluster: string;
   includeInactive: boolean;
@@ -26,7 +27,7 @@ export interface PrivateCloudProductSearchCriteria extends PrivateCloudProductAl
   pageSize: number;
 }
 
-export async function searchPriviateCloudProducts(data: PrivateCloudProductSearchCriteria) {
+export async function searchPrivateCloudProducts(data: PrivateCloudProductSearchCriteria) {
   const result = await instance.post('/search', data).then((res) => {
     return res.data;
   });
@@ -34,7 +35,7 @@ export async function searchPriviateCloudProducts(data: PrivateCloudProductSearc
   return result as PrivateCloudProductSearchPayload;
 }
 
-export async function downloadPriviateCloudProducts(data: PrivateCloudProductAllCriteria) {
+export async function downloadPrivateCloudProducts(data: PrivateCloudProductAllCriteria) {
   const result = await instance.post('/download', data, { responseType: 'blob' }).then((res) => {
     if (res.status === 204) return false;
 
@@ -45,7 +46,7 @@ export async function downloadPriviateCloudProducts(data: PrivateCloudProductAll
   return result;
 }
 
-export async function getPriviateCloudProject(licencePlate: string) {
+export async function getPrivateCloudProject(licencePlate: string) {
   const result = await instance.get(`/${licencePlate}`).then((res) => {
     // Secondary technical lead should only be included if it exists
     if (res.data.secondaryTechnicalLead === null) {
@@ -58,12 +59,12 @@ export async function getPriviateCloudProject(licencePlate: string) {
   return result as PrivateCloudProjectGetPayload;
 }
 
-export async function createPriviateCloudProject(data: any) {
+export async function createPrivateCloudProject(data: any) {
   const result = await instance.post('/', data).then((res) => res.data);
   return result;
 }
 
-export async function editPriviateCloudProject(licencePlate: string, data: any) {
+export async function editPrivateCloudProject(licencePlate: string, data: any) {
   const result = await instance.put(`/${licencePlate}`, data).then((res) => res.data);
   return result;
 }
@@ -73,17 +74,17 @@ export async function deletePrivateCloudProject(licencePlate: string) {
   return result;
 }
 
-export async function checkPriviateCloudProductDeletionAvailability(licencePlate: string) {
+export async function checkPrivateCloudProductDeletionAvailability(licencePlate: string) {
   const result = await instance.get(`/${licencePlate}/deletion-check`).then((res) => res.data);
   return result;
 }
 
-export async function reprovisionPriviateCloudProduct(licencePlate: string) {
+export async function reprovisionPrivateCloudProduct(licencePlate: string) {
   const result = await instance.get(`/${licencePlate}/reprovision`).then((res) => res.data);
   return result;
 }
 
-export async function getPriviateCloudProductRequests(licencePlate: string, active = false) {
+export async function getPrivateCloudProductRequests(licencePlate: string, active = false) {
   const result = await instance.get(`/${licencePlate}/requests?active=${active}`).then((res) => res.data);
   return result as PrivateCloudProductRequestsGetPayload[];
 }

--- a/services/backend/private-cloud/requests.ts
+++ b/services/backend/private-cloud/requests.ts
@@ -1,6 +1,5 @@
 import axios from 'axios';
-import { PrivateCloudRequestGetPayload } from '@/app/api/private-cloud/requests/[id]/route';
-import { PrivateCloudRequestSearchPayload } from '@/queries/private-cloud-requests';
+import { PrivateCloudRequestGetPayload, PrivateCloudRequestSearchPayload } from '@/queries/private-cloud-requests';
 import { instance as parentInstance } from './instance';
 import { PrivateCloudProductSearchCriteria } from './products';
 
@@ -9,10 +8,17 @@ export const instance = axios.create({
   baseURL: `${parentInstance.defaults.baseURL}/requests`,
 });
 
-export async function getPriviateCloudRequest(id: string) {
+export async function getPrivateCloudRequest(id: string) {
   const result = await instance.get(`/${id}`).then((res) => {
-    // Secondary technical lead should only be included if it exists
-    if (res.data.decisionData.secondaryTechnicalLead === null) {
+    if (res.data.originalData?.secondaryTechnicalLead === null) {
+      delete res.data.decisionData.secondaryTechnicalLead;
+    }
+
+    if (res.data.requestData?.secondaryTechnicalLead === null) {
+      delete res.data.decisionData.secondaryTechnicalLead;
+    }
+
+    if (res.data.decisionData?.secondaryTechnicalLead === null) {
       delete res.data.decisionData.secondaryTechnicalLead;
     }
 
@@ -22,7 +28,7 @@ export async function getPriviateCloudRequest(id: string) {
   return result as PrivateCloudRequestGetPayload;
 }
 
-export async function searchPriviateCloudRequests(data: PrivateCloudProductSearchCriteria) {
+export async function searchPrivateCloudRequests(data: PrivateCloudProductSearchCriteria) {
   const result = await instance.post('/search', data).then((res) => {
     return res.data;
   });
@@ -30,12 +36,12 @@ export async function searchPriviateCloudRequests(data: PrivateCloudProductSearc
   return result as PrivateCloudRequestSearchPayload;
 }
 
-export async function makePriviateCloudRequestDecision(id: string, data: any) {
+export async function makePrivateCloudRequestDecision(id: string, data: any) {
   const result = await instance.post(`/${id}/decision`, data).then((res) => res.data);
   return result;
 }
 
-export async function resendPriviateCloudRequest(id: string) {
+export async function resendPrivateCloudRequest(id: string) {
   const result = await instance.get(`/${id}/resend`).then((res) => res.data);
   return result;
 }

--- a/services/backend/public-cloud/products.ts
+++ b/services/backend/public-cloud/products.ts
@@ -14,6 +14,7 @@ export interface PublicCloudProductAllCriteria {
   search: string;
   page: number;
   pageSize: number;
+  licencePlate: string;
   ministry: string;
   provider: string;
   includeInactive: boolean;

--- a/services/backend/public-cloud/requests.ts
+++ b/services/backend/public-cloud/requests.ts
@@ -1,6 +1,5 @@
 import axios from 'axios';
-import { PublicCloudRequestGetPayload } from '@/app/api/public-cloud/requests/[id]/route';
-import { PublicCloudRequestSearchPayload } from '@/queries/public-cloud-requests';
+import { PublicCloudRequestGetPayload, PublicCloudRequestSearchPayload } from '@/queries/public-cloud-requests';
 import { instance as parentInstance } from './instance';
 import { PublicCloudProductSearchCriteria } from './products';
 
@@ -11,8 +10,15 @@ export const instance = axios.create({
 
 export async function getPublicCloudRequest(id: string) {
   const result = await instance.get(`/${id}`).then((res) => {
-    // Secondary technical lead should only be included if it exists
-    if (res.data.decisionData.secondaryTechnicalLead === null) {
+    if (res.data.originalData?.secondaryTechnicalLead === null) {
+      delete res.data.decisionData.secondaryTechnicalLead;
+    }
+
+    if (res.data.requestData?.secondaryTechnicalLead === null) {
+      delete res.data.decisionData.secondaryTechnicalLead;
+    }
+
+    if (res.data.decisionData?.secondaryTechnicalLead === null) {
       delete res.data.decisionData.secondaryTechnicalLead;
     }
 

--- a/states/global.ts
+++ b/states/global.ts
@@ -1,8 +1,8 @@
-import { PrivateCloudRequestGetPayload } from '@/app/api/private-cloud/requests/[id]/route';
-import { PublicCloudRequestGetPayload } from '@/app/api/public-cloud/requests/[id]/route';
 import { createGlobalValtio } from '@/helpers/valtio';
 import { PrivateCloudProjectGetPayload } from '@/queries/private-cloud-products';
+import { PrivateCloudRequestGetPayload } from '@/queries/private-cloud-requests';
 import { PublicCloudProjectGetPayload } from '@/queries/public-cloud-products';
+import { PublicCloudRequestGetPayload } from '@/queries/public-cloud-requests';
 
 export const { state: appState, useValtioState: useAppState } = createGlobalValtio({
   info: {


### PR DESCRIPTION
1. navigate to the `product` page when clicking the product table row.
2. navigate to the `request` decision page when clicking the `active request` item of the table row.
3. add `summary (empty)`, `original`, `request` and `decision` tabs under `request` page.
4. enhance `product` and `request` badges.