### PR TITLE
fix(3093): add word wrap and character limit to description tool tips

### DIFF
--- a/app/components/table/TableBodyPrivateProducts.tsx
+++ b/app/components/table/TableBodyPrivateProducts.tsx
@@ -52,7 +52,15 @@ export default function TableBodyPrivateProducts({ rows, isLoading = false }: Ta
                 <h2 className="min-w-0 text-base text-gray-700">
                   <div className="flex gap-x-2">
                     <span className="">
-                      <Tooltip label={row.description} offset={10}>
+                      <Tooltip
+                        label={
+                          <div style={{ whiteSpace: 'pre-wrap', maxWidth: '400px', wordWrap: 'break-word' }}>
+                            {_truncate(row.description, { length: 300 })}
+                          </div>
+                        }
+                        position="top-start"
+                        withArrow
+                      >
                         <span className="font-bold">{_truncate(row.name, { length: 100 })}</span>
                       </Tooltip>
                       {row.status === $Enums.ProjectStatus.INACTIVE && (

--- a/app/components/table/TableBodyPrivateProducts.tsx
+++ b/app/components/table/TableBodyPrivateProducts.tsx
@@ -15,7 +15,6 @@ import { PrivateCloudProjectGetPayloadWithActiveRequest } from '@/queries/privat
 import { formatDate } from '@/utils/date';
 import EmptySearch from './EmptySearch';
 import TruncatedTooltip from './TruncatedTooltip';
-import './styles.css';
 interface TableProps {
   rows: PrivateCloudProjectGetPayloadWithActiveRequest[];
   isLoading: boolean;

--- a/app/components/table/TableBodyPrivateProducts.tsx
+++ b/app/components/table/TableBodyPrivateProducts.tsx
@@ -14,6 +14,8 @@ import { ministryKeyToName } from '@/helpers/product';
 import { PrivateCloudProjectGetPayloadWithActiveRequest } from '@/queries/private-cloud-products';
 import { formatDate } from '@/utils/date';
 import EmptySearch from './EmptySearch';
+import TruncatedTooltip from './TruncatedTooltip';
+import './styles.css';
 interface TableProps {
   rows: PrivateCloudProjectGetPayloadWithActiveRequest[];
   isLoading: boolean;
@@ -52,17 +54,9 @@ export default function TableBodyPrivateProducts({ rows, isLoading = false }: Ta
                 <h2 className="min-w-0 text-base text-gray-700">
                   <div className="flex gap-x-2">
                     <span className="">
-                      <Tooltip
-                        label={
-                          <div style={{ whiteSpace: 'pre-wrap', maxWidth: '400px', wordWrap: 'break-word' }}>
-                            {_truncate(row.description, { length: 300 })}
-                          </div>
-                        }
-                        position="top-start"
-                        withArrow
-                      >
+                      <TruncatedTooltip label={row.description}>
                         <span className="font-bold">{_truncate(row.name, { length: 100 })}</span>
-                      </Tooltip>
+                      </TruncatedTooltip>
                       {row.status === $Enums.ProjectStatus.INACTIVE && (
                         <Badge color="red" radius="sm" className="ml-1">
                           {$Enums.ProjectStatus.INACTIVE}

--- a/app/components/table/TableBodyPrivateRequests.tsx
+++ b/app/components/table/TableBodyPrivateRequests.tsx
@@ -53,7 +53,15 @@ export default function TableBodyPrivateRequests({ rows, isLoading = false }: Ta
                   <h2 className="min-w-0 text-base text-gray-700">
                     <div className="flex gap-x-2">
                       <span className="">
-                        <Tooltip label={row.decisionData.description} offset={10}>
+                        <Tooltip
+                          label={
+                            <div style={{ whiteSpace: 'pre-wrap', maxWidth: '400px', wordWrap: 'break-word' }}>
+                              {_truncate(row.decisionData.description, { length: 300 })}
+                            </div>
+                          }
+                          position="top-start"
+                          withArrow
+                        >
                           <span className="font-bold">{_truncate(row.decisionData.name, { length: 100 })}</span>
                         </Tooltip>
                         {!row.active && (

--- a/app/components/table/TableBodyPrivateRequests.tsx
+++ b/app/components/table/TableBodyPrivateRequests.tsx
@@ -13,6 +13,7 @@ import { ministryKeyToName } from '@/helpers/product';
 import { PrivateCloudRequestSearchedItemPayload } from '@/queries/private-cloud-requests';
 import { formatDate } from '@/utils/date';
 import EmptySearch from './EmptySearch';
+import TruncatedTooltip from './TruncatedTooltip';
 
 interface TableProps {
   rows: PrivateCloudRequestSearchedItemPayload[];
@@ -53,17 +54,9 @@ export default function TableBodyPrivateRequests({ rows, isLoading = false }: Ta
                   <h2 className="min-w-0 text-base text-gray-700">
                     <div className="flex gap-x-2">
                       <span className="">
-                        <Tooltip
-                          label={
-                            <div style={{ whiteSpace: 'pre-wrap', maxWidth: '400px', wordWrap: 'break-word' }}>
-                              {_truncate(row.decisionData.description, { length: 300 })}
-                            </div>
-                          }
-                          position="top-start"
-                          withArrow
-                        >
+                        <TruncatedTooltip label={row.decisionData.description}>
                           <span className="font-bold">{_truncate(row.decisionData.name, { length: 100 })}</span>
-                        </Tooltip>
+                        </TruncatedTooltip>
                         {!row.active && (
                           <Badge color="red" radius="sm" className="ml-1">
                             {$Enums.ProjectStatus.INACTIVE}

--- a/app/components/table/TableBodyPublicProducts.tsx
+++ b/app/components/table/TableBodyPublicProducts.tsx
@@ -12,6 +12,7 @@ import { ministryKeyToName } from '@/helpers/product';
 import { PublicCloudProjectGetPayloadWithActiveRequest } from '@/queries/public-cloud-products';
 import { formatDate } from '@/utils/date';
 import EmptySearch from './EmptySearch';
+import TruncatedTooltip from './TruncatedTooltip';
 
 interface TableProps {
   rows: PublicCloudProjectGetPayloadWithActiveRequest[];
@@ -51,17 +52,9 @@ export default function TableBodyPublicProducts({ rows, isLoading = false }: Tab
                 <h2 className="min-w-0 text-base text-gray-700">
                   <div className="flex gap-x-2">
                     <span className="">
-                      <Tooltip
-                        label={
-                          <div style={{ whiteSpace: 'pre-wrap', maxWidth: '400px', wordWrap: 'break-word' }}>
-                            {_truncate(row.description, { length: 300 })}
-                          </div>
-                        }
-                        position="top-start"
-                        withArrow
-                      >
+                      <TruncatedTooltip label={row.description}>
                         <span className="font-bold">{_truncate(row.name, { length: 100 })}</span>
-                      </Tooltip>
+                      </TruncatedTooltip>
                       {row.status === $Enums.ProjectStatus.INACTIVE && (
                         <Badge color="red" radius="sm" className="ml-1">
                           {$Enums.ProjectStatus.INACTIVE}

--- a/app/components/table/TableBodyPublicProducts.tsx
+++ b/app/components/table/TableBodyPublicProducts.tsx
@@ -51,7 +51,15 @@ export default function TableBodyPublicProducts({ rows, isLoading = false }: Tab
                 <h2 className="min-w-0 text-base text-gray-700">
                   <div className="flex gap-x-2">
                     <span className="">
-                      <Tooltip label={row.description} offset={10}>
+                      <Tooltip
+                        label={
+                          <div style={{ whiteSpace: 'pre-wrap', maxWidth: '400px', wordWrap: 'break-word' }}>
+                            {_truncate(row.description, { length: 300 })}
+                          </div>
+                        }
+                        position="top-start"
+                        withArrow
+                      >
                         <span className="font-bold">{_truncate(row.name, { length: 100 })}</span>
                       </Tooltip>
                       {row.status === $Enums.ProjectStatus.INACTIVE && (

--- a/app/components/table/TableBodyPublicRequests.tsx
+++ b/app/components/table/TableBodyPublicRequests.tsx
@@ -53,7 +53,15 @@ export default function TableBodyPublicProducts({ rows, isLoading = false }: Tab
                   <h2 className="min-w-0 text-base text-gray-700">
                     <div className="flex gap-x-2">
                       <span className="">
-                        <Tooltip label={row.decisionData.description} offset={10}>
+                        <Tooltip
+                          label={
+                            <div style={{ whiteSpace: 'pre-wrap', maxWidth: '400px', wordWrap: 'break-word' }}>
+                              {_truncate(row.decisionData.description, { length: 300 })}
+                            </div>
+                          }
+                          position="top-start"
+                          withArrow
+                        >
                           <span className="font-bold">{_truncate(row.decisionData.name, { length: 100 })}</span>
                         </Tooltip>
                         {!row.active && (

--- a/app/components/table/TableBodyPublicRequests.tsx
+++ b/app/components/table/TableBodyPublicRequests.tsx
@@ -13,6 +13,7 @@ import { PublicCloudRequestSearchedItemPayload } from '@/queries/public-cloud-re
 import { formatDate } from '@/utils/date';
 import ActiveRequestBox from '../form/ActiveRequestBox';
 import EmptySearch from './EmptySearch';
+import TruncatedTooltip from './TruncatedTooltip';
 
 interface TableProps {
   rows: PublicCloudRequestSearchedItemPayload[];
@@ -53,17 +54,9 @@ export default function TableBodyPublicProducts({ rows, isLoading = false }: Tab
                   <h2 className="min-w-0 text-base text-gray-700">
                     <div className="flex gap-x-2">
                       <span className="">
-                        <Tooltip
-                          label={
-                            <div style={{ whiteSpace: 'pre-wrap', maxWidth: '400px', wordWrap: 'break-word' }}>
-                              {_truncate(row.decisionData.description, { length: 300 })}
-                            </div>
-                          }
-                          position="top-start"
-                          withArrow
-                        >
+                        <TruncatedTooltip label={row.decisionData.description}>
                           <span className="font-bold">{_truncate(row.decisionData.name, { length: 100 })}</span>
-                        </Tooltip>
+                        </TruncatedTooltip>
                         {!row.active && (
                           <Badge color="red" radius="sm" className="ml-1">
                             {$Enums.ProjectStatus.INACTIVE}

--- a/app/components/table/TruncatedTooltip.tsx
+++ b/app/components/table/TruncatedTooltip.tsx
@@ -1,26 +1,41 @@
-import { Tooltip } from '@mantine/core';
+import { Tooltip, TooltipProps } from '@mantine/core';
 import _truncate from 'lodash-es/truncate';
 import React from 'react';
 
-interface TruncatedTooltipProps {
-  label: string;
+type TruncatedTooltipProps = TooltipProps & {
+  label: string | React.ReactNode;
   maxLength?: number;
-  children: React.ReactNode;
-}
+  maxWidth?: number;
+};
 
-const TruncatedTooltip: React.FC<TruncatedTooltipProps> = ({ label, maxLength = 300, children }) => {
+function TruncatedTooltip({
+  label,
+  maxLength = 300,
+  maxWidth = 400,
+  children,
+  ...tooltipProps
+}: TruncatedTooltipProps) {
+  const isStringLabel = typeof label === 'string';
+
   return (
     <Tooltip
       label={
-        <div className="whitespace-pre-wrap break-words max-w-[400px]">{_truncate(label, { length: maxLength })}</div>
+        isStringLabel ? (
+          <div className="tooltip-content max-w-[400px] whitespace-pre-wrap break-words">
+            {_truncate(label as string, { length: maxLength })}
+          </div>
+        ) : (
+          label
+        )
       }
       offset={10}
       position="top-start"
       withArrow
+      {...tooltipProps}
     >
       {children}
     </Tooltip>
   );
-};
+}
 
 export default TruncatedTooltip;

--- a/app/components/table/TruncatedTooltip.tsx
+++ b/app/components/table/TruncatedTooltip.tsx
@@ -1,7 +1,6 @@
 import { Tooltip } from '@mantine/core';
 import _truncate from 'lodash-es/truncate';
 import React from 'react';
-import './styles.css';
 
 interface TruncatedTooltipProps {
   label: string;
@@ -12,7 +11,9 @@ interface TruncatedTooltipProps {
 const TruncatedTooltip: React.FC<TruncatedTooltipProps> = ({ label, maxLength = 300, children }) => {
   return (
     <Tooltip
-      label={<div className="tooltip-content">{_truncate(label, { length: maxLength })}</div>}
+      label={
+        <div className="whitespace-pre-wrap break-words max-w-[400px]">{_truncate(label, { length: maxLength })}</div>
+      }
       offset={10}
       position="top-start"
       withArrow

--- a/app/components/table/TruncatedTooltip.tsx
+++ b/app/components/table/TruncatedTooltip.tsx
@@ -1,0 +1,25 @@
+import { Tooltip } from '@mantine/core';
+import _truncate from 'lodash-es/truncate';
+import React from 'react';
+import './styles.css';
+
+interface TruncatedTooltipProps {
+  label: string;
+  maxLength?: number;
+  children: React.ReactNode;
+}
+
+const TruncatedTooltip: React.FC<TruncatedTooltipProps> = ({ label, maxLength = 300, children }) => {
+  return (
+    <Tooltip
+      label={<div className="tooltip-content">{_truncate(label, { length: maxLength })}</div>}
+      offset={10}
+      position="top-start"
+      withArrow
+    >
+      {children}
+    </Tooltip>
+  );
+};
+
+export default TruncatedTooltip;

--- a/app/components/table/styles.css
+++ b/app/components/table/styles.css
@@ -1,5 +1,0 @@
-.tooltip-content {
-  white-space: pre-wrap;
-  max-width: 400px;
-  word-wrap: break-word;
-}

--- a/app/components/table/styles.css
+++ b/app/components/table/styles.css
@@ -1,0 +1,5 @@
+.tooltip-content {
+  white-space: pre-wrap;
+  max-width: 400px;
+  word-wrap: break-word;
+}


### PR DESCRIPTION
**Before**
<img width="1667" alt="Screenshot 2024-06-20 at 1 17 27 PM" src="https://github.com/bcgov/platform-services-registry/assets/145396323/2065139c-028b-4019-b02a-e1112d909953">
**After**
<img width="1667" alt="Screenshot 2024-06-20 at 1 21 43 PM" src="https://github.com/bcgov/platform-services-registry/assets/145396323/7f08803a-17e5-479d-8b70-c46175760f97">
