### PR TITLE
update UI Delete confirmation modal

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
   "WillLuke.nextjs.addTypesOnSave": true,
-  "WillLuke.nextjs.hasPrompted": true
+  "WillLuke.nextjs.hasPrompted": true,
+  "files.associations": {
+    "plyconfig.json": "jsonc"
+  }
 }

--- a/app/components/buttons/DeleteButton.tsx
+++ b/app/components/buttons/DeleteButton.tsx
@@ -16,8 +16,10 @@ export default function DeleteButton({
       type="button"
       onClick={() => setShowModal(true)}
       className={classNames(
-        'group flex items-center px-4 py-2 text-sm w-full',
-        active && canDelete ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
+        'group flex items-center px-4 py-2 text-sm w-full rounded-md',
+        active && canDelete
+          ? 'bg-red-500 font-bold text-gray-100 hover:bg-red-700 transition-colors duration-300 ease-in-out'
+          : 'bg-gray-100 text-gray-900',
       )}
     >
       <IconTrash className="inlick-block mr-2" />

--- a/app/components/modal/PrivateCloudDelete.tsx
+++ b/app/components/modal/PrivateCloudDelete.tsx
@@ -172,7 +172,7 @@ export default function PrivateCloudDeleteModal({
         {deletionCheckData !== 'OK_TO_DELETE' ? (
           <p className="text-sm text-gray-500">You are unable to delete this product.</p>
         ) : (
-          <p className="text-sm text-gray-500">This operation cannot be undone.</p>
+          <p className="text-sm text-red-500 font-bold">This operation cannot be undone.</p>
         )}
         {isSubmitLoading ? (
           <button
@@ -190,7 +190,7 @@ export default function PrivateCloudDeleteModal({
               'inline-flex justify-center rounded-md border border-transparent py-2 px-4 text-sm font-medium shadow-sm',
               isDisabled || deletionCheckData !== 'OK_TO_DELETE'
                 ? 'bg-gray-400 text-white cursor-not-allowed'
-                : 'bg-red-600 text-white hover:bg-red-700',
+                : 'bg-red-600 text-white hover:bg-blue-700',
             )}
           >
             Delete

--- a/app/components/modal/PublicCloudDelete.tsx
+++ b/app/components/modal/PublicCloudDelete.tsx
@@ -78,7 +78,13 @@ export default function PublicCloudDeleteModal({
               <span className="flex items-center text-sm text-yellow-600">
                 <div className="flex">
                   <IconExclamationCircle className="h-5 w-5 mr-2 flex-shrink-0" aria-hidden="true" />
-                  This will permanently delete your product.
+                  <a
+                    href="https://digital.gov.bc.ca/cloud/services/public/intro/#closure"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    https://digital.gov.bc.ca/cloud/services/public/intro/#closure
+                  </a>
                 </div>
               </span>
             </div>
@@ -139,7 +145,7 @@ export default function PublicCloudDeleteModal({
             </div>
           </div>
           <div className="mt-8 flex items-center justify-between">
-            <p className="text-sm text-gray-500">This operation cannot be undone.</p>
+            <p className="text-sm text-red-500 font-bold">This operation cannot be undone!</p>
 
             {isSubmitLoading ? (
               <button


### PR DESCRIPTION
**Private Cloud OpenShift Platform**
- Changed the font in the font and color of the phrase "This operation cannot be undone" in the Delete modal view to bold and red, respectively.


**Public Cloud OpenShift Platform**
- Changed the font in the font and color of the phrase "This operation cannot be undone" in the Delete modal view to bold and red, respectively.
- Removed  the "this will permanently delete your product info" in the Delete Modal View and replaced it with data about decommission of the product and link to documentation (https://digital.gov.bc.ca/cloud/services/public/intro/#closure) to Deletion Popup 
 