### PR TITLE
fix(3157): update UI delete confirmation modal

### DIFF
--- a/app/components/buttons/DeleteButton.tsx
+++ b/app/components/buttons/DeleteButton.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@mantine/core';
 import { IconTrash } from '@tabler/icons-react';
 import classNames from 'classnames';
 
@@ -11,17 +12,9 @@ export default function DeleteButton({
   active: boolean;
 }) {
   return (
-    <button
-      disabled={!canDelete}
-      type="button"
-      onClick={() => setShowModal(true)}
-      className={classNames(
-        'group flex items-center px-4 py-2 text-sm w-full',
-        active && canDelete ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
-      )}
-    >
+    <Button color="danger" size="sm" disabled={!canDelete} onClick={() => setShowModal(true)}>
       <IconTrash className="inlick-block mr-2" />
       Delete
-    </button>
+    </Button>
   );
 }

--- a/app/components/modal/PrivateCloudDelete.tsx
+++ b/app/components/modal/PrivateCloudDelete.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@mantine/core';
 import { IconExclamationCircle, IconCircleCheck } from '@tabler/icons-react';
 import classNames from 'classnames';
 import { useEffect, useRef, useState } from 'react';
@@ -172,7 +173,7 @@ export default function PrivateCloudDeleteModal({
         {deletionCheckData !== 'OK_TO_DELETE' ? (
           <p className="text-sm text-gray-500">You are unable to delete this product.</p>
         ) : (
-          <p className="text-sm text-gray-500">This operation cannot be undone.</p>
+          <p className="text-sm text-red-500 font-bold">This operation cannot be undone.</p>
         )}
         {isSubmitLoading ? (
           <button
@@ -182,19 +183,9 @@ export default function PrivateCloudDeleteModal({
             Deleting...
           </button>
         ) : (
-          <button
-            disabled={isDisabled || deletionCheckData !== 'OK_TO_DELETE'}
-            type="button"
-            onClick={onSubmit}
-            className={classNames(
-              'inline-flex justify-center rounded-md border border-transparent py-2 px-4 text-sm font-medium shadow-sm',
-              isDisabled || deletionCheckData !== 'OK_TO_DELETE'
-                ? 'bg-gray-400 text-white cursor-not-allowed'
-                : 'bg-red-600 text-white hover:bg-red-700',
-            )}
-          >
+          <Button color="danger" disabled={isDisabled || deletionCheckData !== 'OK_TO_DELETE'} onClick={onSubmit}>
             Delete
-          </button>
+          </Button>
         )}
       </div>
     </Modal>

--- a/app/components/modal/PublicCloudDelete.tsx
+++ b/app/components/modal/PublicCloudDelete.tsx
@@ -1,8 +1,10 @@
+import { Button } from '@mantine/core';
 import { IconExclamationCircle } from '@tabler/icons-react';
 import classNames from 'classnames';
 import { Fragment, useEffect, useRef, useState } from 'react';
 import Modal from '@/components/generic/modal/Modal';
 import { usePublicProductState } from '@/states/global';
+import ExternalLink from '../generic/button/ExternalLink';
 
 export default function PublicCloudDeleteModal({
   open,
@@ -78,7 +80,9 @@ export default function PublicCloudDeleteModal({
               <span className="flex items-center text-sm text-yellow-600">
                 <div className="flex">
                   <IconExclamationCircle className="h-5 w-5 mr-2 flex-shrink-0" aria-hidden="true" />
-                  This will permanently delete your product.
+                  <ExternalLink href="https://digital.gov.bc.ca/cloud/services/public/intro/#closure">
+                    Account closure and project set deletion
+                  </ExternalLink>
                 </div>
               </span>
             </div>
@@ -139,7 +143,7 @@ export default function PublicCloudDeleteModal({
             </div>
           </div>
           <div className="mt-8 flex items-center justify-between">
-            <p className="text-sm text-gray-500">This operation cannot be undone.</p>
+            <p className="text-sm text-red-500 font-bold">This operation cannot be undone.</p>
 
             {isSubmitLoading ? (
               <button
@@ -149,17 +153,9 @@ export default function PublicCloudDeleteModal({
                 Deleting...
               </button>
             ) : (
-              <button
-                disabled={isDisabled}
-                type="button"
-                onClick={onSubmit}
-                className={classNames(
-                  'inline-flex justify-center rounded-md border border-transparent py-2 px-4 text-sm font-medium shadow-sm',
-                  isDisabled ? 'bg-gray-400 text-white cursor-not-allowed' : 'bg-red-600 text-white hover:bg-red-700',
-                )}
-              >
+              <Button color="danger" disabled={isDisabled} onClick={onSubmit}>
                 Delete
-              </button>
+              </Button>
             )}
           </div>
         </>

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -16184,6 +16184,111 @@
       "peerDependencies": {
         "zod": "^3.18.0"
       }
+    },
+    "node_modules/react-email/node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.5.tgz",
+      "integrity": "sha512-/9zVxJ+K9lrzSGli1///ujyRfon/ZneeZ+v4ptpiPoOU+GKZnm8Wj8ELWU1Pm7GHltYRBklmXMTUqM/DqQ99FQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/react-email/node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.5.tgz",
+      "integrity": "sha512-vXHOPCwfDe9qLDuq7U1OYM2wUY+KQ4Ex6ozwsKxp26BlJ6XXbHleOUldenM67JRyBfVjv371oneEvYd3H2gNSA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/react-email/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.5.tgz",
+      "integrity": "sha512-vlhB8wI+lj8q1ExFW8lbWutA4M2ZazQNvMWuEDqZcuJJc78iUnLdPPunBPX8rC4IgT6lIx/adB+Cwrl99MzNaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/react-email/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.5.tgz",
+      "integrity": "sha512-NpDB9NUR2t0hXzJJwQSGu1IAOYybsfeB+LxpGsXrRIb7QOrYmidJz3shzY8cM6+rO4Aojuef0N/PEaX18pi9OA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/react-email/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.5.tgz",
+      "integrity": "sha512-1GpG2VhbspO+aYoMOQPQiqc/tG3LzmsdBH0LhnDS3JrtDx2QmzXe0B6mSZZiN3Bq7IOMXxv1nlsjzoS1+9mzZw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/react-email/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.5.tgz",
+      "integrity": "sha512-Igh9ZlxwvCDsu6438FXlQTHlRno4gFpJzqPjSIBZooD22tKeI4fE/YMRoHVJHmrQ2P5YL1DoZ0qaOKkbeFWeMg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/react-email/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.5.tgz",
+      "integrity": "sha512-tEQ7oinq1/CjSG9uSTerca3v4AZ+dFa+4Yu6ihaG8Ud8ddqLQgFGcnwYls13H5X5CPDPZJdYxyeMui6muOLd4g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }


### PR DESCRIPTION
Private Cloud Registry

- Modified the warning text `This operation cannot be undone` in the confirm deletion UI modal, changing its text to red and bolding it's font 
- Changing the Delete Buttons on the Private and Public Registry to red, animating and adding on-hover effect.

Public Cloud Registry

- Modified the warning text `This operation cannot be undone` in the confirm deletion UI modal, changing its text to red and bolding it's font
- Changing the Delete Buttons on the Private and Public Registry to red, animating and adding on-hover effect. 
- Replacing the info link: `this will permanently delete your product` with the link: https://digital.gov.bc.ca/cloud/services/public/intro/#closure



