### PR TITLE
fix(3157): update delete confirmation modal

### DIFF
--- a/app/components/dropdowns/PrivateCloudProductOptions.tsx
+++ b/app/components/dropdowns/PrivateCloudProductOptions.tsx
@@ -1,6 +1,7 @@
 import { Menu, MenuItems, MenuItem, MenuButton, Transition } from '@headlessui/react';
+import { Button } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
-import { IconRepeat, IconChevronDown } from '@tabler/icons-react';
+import { IconRepeat, IconChevronDown, IconTrash } from '@tabler/icons-react';
 import { useMutation } from '@tanstack/react-query';
 import classNames from 'classnames';
 import { useParams } from 'next/navigation';
@@ -150,7 +151,20 @@ export default function PrivateCloudProductOptions({
                 )}
                 {canDelete && (
                   <MenuItem>
-                    {({ active }) => <DeleteButton canDelete={canDelete} setShowModal={setShowModal} active={active} />}
+                    {({ active }) => (
+                      <button
+                        disabled={!canDelete}
+                        type="button"
+                        onClick={() => setShowModal(true)}
+                        className={classNames(
+                          'group flex items-center px-4 py-2 text-sm w-full',
+                          active && canDelete ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
+                        )}
+                      >
+                        <IconTrash className="inlick-block mr-2" />
+                        Delete
+                      </button>
+                    )}
                   </MenuItem>
                 )}
               </div>

--- a/app/components/modal/PublicCloudDelete.tsx
+++ b/app/components/modal/PublicCloudDelete.tsx
@@ -79,7 +79,6 @@ export default function PublicCloudDeleteModal({
             <div className="flex items-center justify-between">
               <span className="flex items-center text-sm text-yellow-600">
                 <div className="flex">
-                  <IconExclamationCircle className="h-5 w-5 mr-2 flex-shrink-0" aria-hidden="true" />
                   <ExternalLink href="https://digital.gov.bc.ca/cloud/services/public/intro/#closure">
                     Account closure and project set deletion
                   </ExternalLink>


### PR DESCRIPTION
**Additional fixes**

-   Removed the info badge in the delete confirmation modal in the Public Cloud Landing Zone
-   Retained the old style for the delete button in the private cloud page
-   the _DeleteButton_ component is a common component and when used in the private cloud page (dropdown), it will distort the preferred style of the delete button. Hence, I reverted to a component/style that is consonance with the re-provision button already in the dropdown. In the future, this will be revisited since we are considering using _mantine_ button across all our components.