### PR TITLE
feat(3191): add admin tooltip and notification

### DIFF
--- a/app/app/private-cloud/products/(product)/[licencePlate]/comments/page.tsx
+++ b/app/app/private-cloud/products/(product)/[licencePlate]/comments/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { Alert } from '@mantine/core';
+import { IconInfoCircle } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
 import React from 'react';
 import { useSnapshot } from 'valtio';
@@ -59,6 +61,9 @@ export default privateCloudProductComments(({ pathParams, queryParams, session }
 
   return (
     <div>
+      <Alert variant="light" color="blue" title="" icon={<IconInfoCircle />} mb={20}>
+        This page is for admin only; users do not have access.
+      </Alert>
       <CommentForm
         licencePlate={licencePlate}
         projectId={snap.currentProduct?.id ?? ''}

--- a/app/app/private-cloud/products/(product)/[licencePlate]/layout.tsx
+++ b/app/app/private-cloud/products/(product)/[licencePlate]/layout.tsx
@@ -60,6 +60,7 @@ export default privateCloudProductLayout(({ pathParams, queryParams, session, ch
       label: 'ADMIN NOTES',
       name: 'comments',
       href: `/private-cloud/products/${licencePlate}/comments`,
+      tooltip: 'Admin only',
     });
   }
 

--- a/app/app/private-cloud/requests/(request)/[id]/comments/page.tsx
+++ b/app/app/private-cloud/requests/(request)/[id]/comments/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { Alert } from '@mantine/core';
+import { IconInfoCircle } from '@tabler/icons-react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import React, { useEffect } from 'react';
 import { z } from 'zod';
@@ -58,6 +60,9 @@ export default privateCloudRequestComments(({ pathParams, session }) => {
 
   return (
     <div>
+      <Alert variant="light" color="blue" title="" icon={<IconInfoCircle />} mb={20}>
+        This page is for admin only; users do not have access.
+      </Alert>
       <CommentForm
         licencePlate={privateSnap.licencePlate}
         requestId={requestId}

--- a/app/app/private-cloud/requests/(request)/[id]/layout.tsx
+++ b/app/app/private-cloud/requests/(request)/[id]/layout.tsx
@@ -92,6 +92,7 @@ export default privateCloudProductSecurityACS(({ pathParams, queryParams, sessio
       label: 'ADMIN COMMENTS',
       name: 'comments',
       href: `/private-cloud/requests/${id}/comments`,
+      tooltip: 'Admin Only',
     });
   }
 

--- a/app/components/comments/CommentForm.tsx
+++ b/app/components/comments/CommentForm.tsx
@@ -105,7 +105,7 @@ function CommentForm({
   };
 
   return (
-    <div className="flex flex-col items-center w-full">
+    <div className="flex flex-col items-start w-full">
       <div className="w-full max-w-xl px-4">
         {!showCommentBox && (
           <div className="flex justify-end mb-2 transition-opacity duration-500 ease-in-out">

--- a/app/components/generic/tabs/BasicTabs.tsx
+++ b/app/components/generic/tabs/BasicTabs.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@mantine/core';
 import classNames from 'classnames';
 import _lowerCase from 'lodash-es/lowerCase';
 import _startCase from 'lodash-es/startCase';
@@ -11,6 +12,7 @@ export interface ITab {
   label: string;
   href: string;
   ignoreSegments?: number;
+  tooltip?: string;
 }
 
 export default function BasicTabs({ tabs, children }: { tabs: ITab[]; children?: React.ReactNode }) {
@@ -38,20 +40,26 @@ export default function BasicTabs({ tabs, children }: { tabs: ITab[]; children?:
         <div className="border-b border-gray-200">
           <div className="w-full -mb-px flex justify-between items-center" aria-label="Tabs">
             <div className=" -mb-px flex justify-start">
-              {tabs.map((tab) => (
-                <Link
-                  href={tab.href}
-                  key={tab.name}
-                  className={classNames(
-                    'first:ml-0 lg:ml-20 w-50 py-5 text-center text-lg font-bold',
-                    compareUrlsIgnoreLastSegments(tab.href, pathname, tab.ignoreSegments ?? 0)
-                      ? "relative border-bcorange text-bcblue before:content-[''] before:absolute before:w-full before:border-b-3 before:border-bcorange before:bottom-0 before:left-1/2 before:-translate-x-1/2"
-                      : "relative border-transparent text-gray-300 hover:before:content-[''] hover:before:absolute hover:before:w-full hover:before:border-b-3 hover:before:border-gray-300 hover:before:bottom-0 hover:before:left-1/2 hover:before:-translate-x-1/2",
-                  )}
-                >
-                  {tab.label}
-                </Link>
-              ))}
+              {tabs.map((tab) => {
+                const linkingClassNames = classNames(
+                  'first:ml-0 lg:ml-20 w-50 py-5 text-center text-lg font-bold',
+                  compareUrlsIgnoreLastSegments(tab.href, pathname, tab.ignoreSegments ?? 0)
+                    ? "relative border-bcorange text-bcblue before:content-[''] before:absolute before:w-full before:border-b-3 before:border-bcorange before:bottom-0 before:left-1/2 before:-translate-x-1/2"
+                    : "relative border-transparent text-gray-300 hover:before:content-[''] hover:before:absolute hover:before:w-full hover:before:border-b-3 hover:before:border-gray-300 hover:before:bottom-0 hover:before:left-1/2 hover:before:-translate-x-1/2",
+                );
+                const linkingComponent = (
+                  <Link href={tab.href} key={tab.name} className={linkingClassNames}>
+                    {tab.label}
+                  </Link>
+                );
+                return tab.tooltip ? (
+                  <Tooltip label={tab.tooltip} key={tab.name}>
+                    {linkingComponent}
+                  </Tooltip>
+                ) : (
+                  linkingComponent
+                );
+              })}
             </div>
             <div>{children}</div>
           </div>


### PR DESCRIPTION
**Admin Tooltip**

- added admin tooltip (with text _Admin Only_') to the `Admin Notes` and `Admin Comment` tabs.
- added notification (with text _This page is for admin only; users do not have access._) to the `Admin Notes` and `Admin Comment` tabs 