### PR TITLE
feat(3663): add graphic for when there are no comments to display

### DIFF
--- a/app/app/private-cloud/products/(product)/[licencePlate]/comments/page.tsx
+++ b/app/app/private-cloud/products/(product)/[licencePlate]/comments/page.tsx
@@ -8,6 +8,7 @@ import { useSnapshot } from 'valtio';
 import { z } from 'zod';
 import CommentBubble from '@/components/comments/CommentBubble';
 import CommentForm from '@/components/comments/CommentForm';
+import EmptySearch from '@/components/table/EmptySearch';
 import createClientPage from '@/core/client-page';
 import { getAllPrivateCloudComments } from '@/services/backend/private-cloud/products';
 import { privateProductState } from '@/states/global';
@@ -93,7 +94,7 @@ export default privateCloudProductComments(({ pathParams, queryParams, session }
           ))}
         </ul>
       ) : (
-        <p>No comments found.</p>
+        !commentsLoading && <EmptySearch cloud="private-cloud" type="notes" />
       )}
     </div>
   );

--- a/app/app/private-cloud/requests/(request)/[id]/comments/page.tsx
+++ b/app/app/private-cloud/requests/(request)/[id]/comments/page.tsx
@@ -7,6 +7,7 @@ import React, { useEffect } from 'react';
 import { z } from 'zod';
 import CommentBubble from '@/components/comments/CommentBubble';
 import CommentForm from '@/components/comments/CommentForm';
+import EmptySearch from '@/components/table/EmptySearch';
 import createClientPage from '@/core/client-page';
 import { getAllPrivateCloudComments } from '@/services/backend/private-cloud/products';
 import { usePrivateProductState } from '@/states/global';
@@ -94,7 +95,7 @@ export default privateCloudRequestComments(({ pathParams, session }) => {
           ))}
         </ul>
       ) : (
-        !commentsLoading && <p>No comments found.</p>
+        !commentsLoading && <EmptySearch cloud="private-cloud" type="comments" />
       )}
     </div>
   );

--- a/app/components/table/EmptySearch.tsx
+++ b/app/components/table/EmptySearch.tsx
@@ -3,7 +3,7 @@
 import _truncate from 'lodash-es/truncate';
 import Image from 'next/image';
 import Link from 'next/link';
-import React, { useState } from 'react';
+import React from 'react';
 import Empty from '@/components/assets/empty.svg';
 
 export default function EmptySearch({
@@ -11,8 +11,25 @@ export default function EmptySearch({
   type,
 }: {
   cloud: 'private-cloud' | 'public-cloud';
-  type: 'product' | 'request';
+  type: 'product' | 'request' | 'comments' | 'notes';
 }) {
+  let displayText = '';
+
+  switch (type) {
+    case 'comments':
+      displayText = 'There are no comments to be displayed';
+      break;
+    case 'notes':
+      displayText = 'There are no notes to be displayed';
+      break;
+    case 'product':
+      displayText = 'There are no products to be displayed';
+      break;
+    case 'request':
+      displayText = 'There are no requests to be displayed';
+      break;
+  }
+
   return (
     <div className="flex flex-col items-center justify-center py-12 mt-12">
       <Image
@@ -25,10 +42,12 @@ export default function EmptySearch({
           height: 'auto',
         }}
       />
-      <span className="text-xl font-bold text-mediumgrey mt-4">There are no {type}s to be displayed</span>
-      <Link className="underline text-lg font-extralight text-linkblue mt-4" href={`/${cloud}/products/create`}>
-        REQUEST A NEW PRODUCT
-      </Link>
+      <span className="text-xl font-bold text-mediumgrey mt-4">{displayText}</span>
+      {type === 'product' && (
+        <Link className="underline text-lg font-extralight text-linkblue mt-4" href={`/${cloud}/products/create`}>
+          REQUEST A NEW PRODUCT
+        </Link>
+      )}
     </div>
   );
 }

--- a/app/components/table/EmptySearch.tsx
+++ b/app/components/table/EmptySearch.tsx
@@ -6,6 +6,13 @@ import Link from 'next/link';
 import React from 'react';
 import Empty from '@/components/assets/empty.svg';
 
+const displayTextMap: Record<'product' | 'request' | 'comments' | 'notes', string> = {
+  comments: 'There are no comments to be displayed',
+  notes: 'There are no notes to be displayed',
+  product: 'There are no products to be displayed',
+  request: 'There are no requests to be displayed',
+};
+
 export default function EmptySearch({
   cloud,
   type,
@@ -13,22 +20,7 @@ export default function EmptySearch({
   cloud: 'private-cloud' | 'public-cloud';
   type: 'product' | 'request' | 'comments' | 'notes';
 }) {
-  let displayText = '';
-
-  switch (type) {
-    case 'comments':
-      displayText = 'There are no comments to be displayed';
-      break;
-    case 'notes':
-      displayText = 'There are no notes to be displayed';
-      break;
-    case 'product':
-      displayText = 'There are no products to be displayed';
-      break;
-    case 'request':
-      displayText = 'There are no requests to be displayed';
-      break;
-  }
+  const displayText = displayTextMap[type];
 
   return (
     <div className="flex flex-col items-center justify-center py-12 mt-12">


### PR DESCRIPTION
**Before**
<img width="1720" alt="Screenshot 2024-09-05 at 3 03 53 PM" src="https://github.com/user-attachments/assets/482c072d-5dbf-4431-9983-219c24d212c0">
**After**
<img width="1720" alt="Screenshot 2024-09-05 at 3 01 12 PM" src="https://github.com/user-attachments/assets/a648db1e-cb72-4ab6-9173-9fc2693a3489">
