### PR TITLE
chore(3634): create tasks for eMOU workflows at the product level

### DIFF
--- a/app/app/api/private-cloud/nats.test.ts
+++ b/app/app/api/private-cloud/nats.test.ts
@@ -18,6 +18,9 @@ import {
 
 describe('Private Cloud NATs', () => {
   it('should send NATs message when creating a new product', async () => {
+    // @ts-ignore
+    sendNatsMessage.mockClear();
+
     const decisionData = await createPrivateCloudProduct();
 
     expect(sendNatsMessage).toHaveBeenCalled();

--- a/app/app/api/private-cloud/nats.test.ts
+++ b/app/app/api/private-cloud/nats.test.ts
@@ -24,8 +24,6 @@ describe('Private Cloud NATs', () => {
     const decisionData = await createPrivateCloudProduct();
 
     expect(sendNatsMessage).toHaveBeenCalled();
-    expect(sendNatsMessage).toHaveBeenCalledTimes(1);
-
     expect(sendNatsMessage).toHaveBeenCalledWith(
       PRIVATE_NATS_URL,
       `registry_project_provisioning_${decisionData.cluster.toLowerCase()}`,
@@ -85,8 +83,6 @@ describe('Private Cloud NATs', () => {
     const decisionData = await updatePrivateCloudProduct();
 
     expect(sendNatsMessage).toHaveBeenCalled();
-    expect(sendNatsMessage).toHaveBeenCalledTimes(2);
-
     expect(sendNatsMessage).toHaveBeenNthCalledWith(
       2,
       PRIVATE_NATS_URL,
@@ -147,8 +143,6 @@ describe('Private Cloud NATs', () => {
     const decisionData = await deletePrivateCloudProduct();
 
     expect(sendNatsMessage).toHaveBeenCalled();
-    expect(sendNatsMessage).toHaveBeenCalledTimes(2);
-
     expect(sendNatsMessage).toHaveBeenNthCalledWith(
       2,
       PRIVATE_NATS_URL,

--- a/app/app/api/public-cloud/nats.test.ts
+++ b/app/app/api/public-cloud/nats.test.ts
@@ -10,6 +10,8 @@ import { sendNatsMessage } from '@/services/nats/core';
 
 describe('Public Cloud NATs', () => {
   it('should send NATs message when creating a new product', async () => {
+    // @ts-ignore
+    sendNatsMessage.mockClear();
     const decisionData = await createPublicCloudProduct();
 
     expect(sendNatsMessage).toHaveBeenCalled();

--- a/app/app/api/public-cloud/nats.test.ts
+++ b/app/app/api/public-cloud/nats.test.ts
@@ -15,8 +15,6 @@ describe('Public Cloud NATs', () => {
     const decisionData = await createPublicCloudProduct();
 
     expect(sendNatsMessage).toHaveBeenCalled();
-    expect(sendNatsMessage).toHaveBeenCalledTimes(1);
-
     expect(sendNatsMessage).toHaveBeenCalledWith(
       PUBLIC_NATS_URL,
       `registry_project_provisioning_${decisionData.provider.toLowerCase()}`,
@@ -52,8 +50,6 @@ describe('Public Cloud NATs', () => {
     const decisionData = await updatePublicCloudProduct();
 
     expect(sendNatsMessage).toHaveBeenCalled();
-    expect(sendNatsMessage).toHaveBeenCalledTimes(2);
-
     expect(sendNatsMessage).toHaveBeenNthCalledWith(
       2,
       PUBLIC_NATS_URL,
@@ -90,8 +86,6 @@ describe('Public Cloud NATs', () => {
     const decisionData = await deletePublicCloudProduct();
 
     expect(sendNatsMessage).toHaveBeenCalled();
-    expect(sendNatsMessage).toHaveBeenCalledTimes(2);
-
     expect(sendNatsMessage).toHaveBeenNthCalledWith(
       2,
       PUBLIC_NATS_URL,

--- a/app/app/api/public-cloud/products/[licencePlate]/requests/route.test.ts
+++ b/app/app/api/public-cloud/products/[licencePlate]/requests/route.test.ts
@@ -5,12 +5,13 @@ import { createSamplePublicCloudProductData } from '@/helpers/mock-resources';
 import { mockNoRoleUsers, findMockUserByIdr, findOtherMockUsers } from '@/helpers/mock-users';
 import { mockSessionByEmail, mockSessionByRole } from '@/services/api-test/core';
 import { provisionPublicCloudProject } from '@/services/api-test/public-cloud';
-import { createPublicCloudProject, listPublicCloudProductRequests } from '@/services/api-test/public-cloud/products';
 import {
-  makePublicCloudRequestDecision,
+  createPublicCloudProject,
+  listPublicCloudProductRequests,
   signPublicCloudMou,
   reviewPublicCloudMou,
-} from '@/services/api-test/public-cloud/requests';
+} from '@/services/api-test/public-cloud/products';
+import { makePublicCloudRequestDecision } from '@/services/api-test/public-cloud/requests';
 
 const PO = mockNoRoleUsers[0];
 const TL1 = mockNoRoleUsers[1];
@@ -53,7 +54,7 @@ describe('List Public Cloud Product Requests - Permissions', () => {
 
     if (task1) {
       await mockSessionByEmail(dat1.decisionData.expenseAuthority.email);
-      await signPublicCloudMou(dat1.id, {
+      await signPublicCloudMou(dat1.licencePlate, {
         taskId: task1?.id ?? '',
         confirmed: true,
       });
@@ -65,13 +66,13 @@ describe('List Public Cloud Product Requests - Permissions', () => {
           status: TaskStatus.ASSIGNED,
           data: {
             equals: {
-              requestId: dat1.id,
+              licencePlate: dat1.licencePlate,
             },
           },
         },
       });
 
-      await reviewPublicCloudMou(dat1.id, {
+      await reviewPublicCloudMou(dat1.licencePlate, {
         taskId: task2?.id ?? '',
         decision: 'APPROVE',
       });

--- a/app/app/api/public-cloud/products/[licencePlate]/review-mou/route.ts
+++ b/app/app/api/public-cloud/products/[licencePlate]/review-mou/route.ts
@@ -8,7 +8,7 @@ import { publicCloudRequestDetailInclude } from '@/queries/public-cloud-requests
 import { sendRequestReviewEmails, sendEmouServiceAgreementEmail } from '@/services/ches/public-cloud/email-handler';
 
 const pathParamSchema = z.object({
-  id: z.string(),
+  licencePlate: z.string(),
 });
 
 const bodySchema = z.object({
@@ -21,7 +21,7 @@ const apiHandler = createApiHandler({
   validations: { pathParams: pathParamSchema, body: bodySchema },
 });
 export const POST = apiHandler(async ({ pathParams, body, session }) => {
-  const { id } = pathParams;
+  const { licencePlate } = pathParams;
   const { taskId, decision } = body;
 
   await prisma.task.update({
@@ -32,7 +32,7 @@ export const POST = apiHandler(async ({ pathParams, body, session }) => {
       OR: [{ userIds: { has: session.user.id } }, { roles: { hasSome: session.roles } }],
       data: {
         equals: {
-          requestId: id,
+          licencePlate,
         },
       },
     },
@@ -45,8 +45,8 @@ export const POST = apiHandler(async ({ pathParams, body, session }) => {
   });
 
   if (decision === 'APPROVE') {
-    const request = await prisma.publicCloudRequest.findUnique({
-      where: { id },
+    const request = await prisma.publicCloudRequest.findFirst({
+      where: { licencePlate },
       include: publicCloudRequestDetailInclude,
     });
 

--- a/app/app/api/public-cloud/products/[licencePlate]/sign-mou/route.ts
+++ b/app/app/api/public-cloud/products/[licencePlate]/sign-mou/route.ts
@@ -9,7 +9,7 @@ import { sendPublicCloudBillingReviewEmails } from '@/services/ches/public-cloud
 import { findUsersByClientRole } from '@/services/keycloak/app-realm';
 
 const pathParamSchema = z.object({
-  id: z.string(),
+  licencePlate: z.string(),
 });
 
 const bodySchema = z.object({
@@ -22,7 +22,7 @@ const apiHandler = createApiHandler({
   validations: { pathParams: pathParamSchema, body: bodySchema },
 });
 export const POST = apiHandler(async ({ pathParams, body, session }) => {
-  const { id } = pathParams;
+  const { licencePlate } = pathParams;
   const { taskId, confirmed } = body;
 
   if (!confirmed) return BadRequestResponse('not confirmed');
@@ -35,7 +35,7 @@ export const POST = apiHandler(async ({ pathParams, body, session }) => {
       OR: [{ userIds: { has: session.user.id } }, { roles: { hasSome: session.roles } }],
       data: {
         equals: {
-          requestId: id,
+          licencePlate,
         },
       },
     },
@@ -44,8 +44,8 @@ export const POST = apiHandler(async ({ pathParams, body, session }) => {
     },
   });
 
-  const request = await prisma.publicCloudRequest.findUnique({
-    where: { id },
+  const request = await prisma.publicCloudRequest.findFirst({
+    where: { licencePlate },
     include: publicCloudRequestDetailInclude,
   });
 
@@ -70,7 +70,7 @@ export const POST = apiHandler(async ({ pathParams, body, session }) => {
       status: TaskStatus.ASSIGNED,
       roles: ['billing-reviewer'],
       data: {
-        requestId: id,
+        licencePlate: request.licencePlate,
       },
     },
   });

--- a/app/app/api/public-cloud/products/_operations/delete.test.ts
+++ b/app/app/api/public-cloud/products/_operations/delete.test.ts
@@ -5,12 +5,13 @@ import { createSamplePublicCloudProductData } from '@/helpers/mock-resources';
 import { findOtherMockUsers } from '@/helpers/mock-users';
 import { mockSessionByEmail, mockSessionByRole } from '@/services/api-test/core';
 import { provisionPublicCloudProject } from '@/services/api-test/public-cloud';
-import { createPublicCloudProject, deletePublicCloudProject } from '@/services/api-test/public-cloud/products';
 import {
-  makePublicCloudRequestDecision,
+  createPublicCloudProject,
+  deletePublicCloudProject,
   signPublicCloudMou,
   reviewPublicCloudMou,
-} from '@/services/api-test/public-cloud/requests';
+} from '@/services/api-test/public-cloud/products';
+import { makePublicCloudRequestDecision } from '@/services/api-test/public-cloud/requests';
 
 const productData = {
   main: createSamplePublicCloudProductData(),
@@ -41,7 +42,7 @@ describe('Delete Public Cloud Product - Permissions', () => {
         status: TaskStatus.ASSIGNED,
         data: {
           equals: {
-            requestId: requests.create.id,
+            licencePlate: requests.create.licencePlate,
           },
         },
       },
@@ -49,7 +50,7 @@ describe('Delete Public Cloud Product - Permissions', () => {
 
     expect(task).toBeTruthy();
 
-    const response = await signPublicCloudMou(requests.create.id, {
+    const response = await signPublicCloudMou(requests.create.licencePlate, {
       taskId: task?.id ?? '',
       confirmed: true,
     });
@@ -66,7 +67,7 @@ describe('Delete Public Cloud Product - Permissions', () => {
         status: TaskStatus.ASSIGNED,
         data: {
           equals: {
-            requestId: requests.create.id,
+            licencePlate: requests.create.licencePlate,
           },
         },
       },
@@ -74,7 +75,7 @@ describe('Delete Public Cloud Product - Permissions', () => {
 
     expect(task).toBeTruthy();
 
-    const response = await reviewPublicCloudMou(requests.create.id, {
+    const response = await reviewPublicCloudMou(requests.create.licencePlate, {
       taskId: task?.id ?? '',
       decision: 'APPROVE',
     });

--- a/app/app/api/public-cloud/products/_operations/read.test.ts
+++ b/app/app/api/public-cloud/products/_operations/read.test.ts
@@ -6,12 +6,13 @@ import { findOtherMockUsers } from '@/helpers/mock-users';
 import { pickProductData } from '@/helpers/product';
 import { mockSessionByEmail, mockSessionByRole } from '@/services/api-test/core';
 import { provisionPublicCloudProject } from '@/services/api-test/public-cloud';
-import { createPublicCloudProject, getPublicCloudProject } from '@/services/api-test/public-cloud/products';
 import {
-  makePublicCloudRequestDecision,
+  createPublicCloudProject,
+  getPublicCloudProject,
   signPublicCloudMou,
   reviewPublicCloudMou,
-} from '@/services/api-test/public-cloud/requests';
+} from '@/services/api-test/public-cloud/products';
+import { makePublicCloudRequestDecision } from '@/services/api-test/public-cloud/requests';
 
 const fieldsToCompare = [
   'name',
@@ -55,7 +56,7 @@ describe('Read Public Cloud Product - Permissions', () => {
         status: TaskStatus.ASSIGNED,
         data: {
           equals: {
-            requestId: requests.create.id,
+            licencePlate: requests.create.licencePlate,
           },
         },
       },
@@ -63,7 +64,7 @@ describe('Read Public Cloud Product - Permissions', () => {
 
     expect(task).toBeTruthy();
 
-    const response = await signPublicCloudMou(requests.create.id, {
+    const response = await signPublicCloudMou(requests.create.licencePlate, {
       taskId: task?.id ?? '',
       confirmed: true,
     });
@@ -80,7 +81,7 @@ describe('Read Public Cloud Product - Permissions', () => {
         status: TaskStatus.ASSIGNED,
         data: {
           equals: {
-            requestId: requests.create.id,
+            licencePlate: requests.create.licencePlate,
           },
         },
       },
@@ -88,7 +89,7 @@ describe('Read Public Cloud Product - Permissions', () => {
 
     expect(task).toBeTruthy();
 
-    const response = await reviewPublicCloudMou(requests.create.id, {
+    const response = await reviewPublicCloudMou(requests.create.licencePlate, {
       taskId: task?.id ?? '',
       decision: 'APPROVE',
     });

--- a/app/app/api/public-cloud/products/_operations/update.test.ts
+++ b/app/app/api/public-cloud/products/_operations/update.test.ts
@@ -5,12 +5,13 @@ import { createSamplePublicCloudProductData } from '@/helpers/mock-resources';
 import { findOtherMockUsers } from '@/helpers/mock-users';
 import { mockSessionByEmail, mockSessionByRole } from '@/services/api-test/core';
 import { provisionPublicCloudProject } from '@/services/api-test/public-cloud';
-import { createPublicCloudProject, editPublicCloudProject } from '@/services/api-test/public-cloud/products';
 import {
-  makePublicCloudRequestDecision,
+  createPublicCloudProject,
+  editPublicCloudProject,
   signPublicCloudMou,
   reviewPublicCloudMou,
-} from '@/services/api-test/public-cloud/requests';
+} from '@/services/api-test/public-cloud/products';
+import { makePublicCloudRequestDecision } from '@/services/api-test/public-cloud/requests';
 
 const oldEnvironmentsEnabled = {
   production: true,
@@ -71,7 +72,7 @@ describe('Update Public Cloud Product - Permissions', () => {
         status: TaskStatus.ASSIGNED,
         data: {
           equals: {
-            requestId: requests.create.id,
+            licencePlate: requests.create.licencePlate,
           },
         },
       },
@@ -79,7 +80,7 @@ describe('Update Public Cloud Product - Permissions', () => {
 
     expect(task).toBeTruthy();
 
-    const response = await signPublicCloudMou(requests.create.id, {
+    const response = await signPublicCloudMou(requests.create.licencePlate, {
       taskId: task?.id ?? '',
       confirmed: true,
     });
@@ -96,7 +97,7 @@ describe('Update Public Cloud Product - Permissions', () => {
         status: TaskStatus.ASSIGNED,
         data: {
           equals: {
-            requestId: requests.create.id,
+            licencePlate: requests.create.licencePlate,
           },
         },
       },
@@ -104,7 +105,7 @@ describe('Update Public Cloud Product - Permissions', () => {
 
     expect(task).toBeTruthy();
 
-    const response = await reviewPublicCloudMou(requests.create.id, {
+    const response = await reviewPublicCloudMou(requests.create.licencePlate, {
       taskId: task?.id ?? '',
       decision: 'APPROVE',
     });

--- a/app/app/api/public-cloud/products/download/route.test.ts
+++ b/app/app/api/public-cloud/products/download/route.test.ts
@@ -8,12 +8,13 @@ import { ministryKeyToName, getTotalQuotaStr } from '@/helpers/product';
 import { formatFullName } from '@/helpers/user';
 import { mockSessionByEmail, mockSessionByRole } from '@/services/api-test/core';
 import { provisionPublicCloudProject } from '@/services/api-test/public-cloud';
-import { createPublicCloudProject, downloadPublicCloudProjects } from '@/services/api-test/public-cloud/products';
 import {
-  makePublicCloudRequestDecision,
+  createPublicCloudProject,
+  downloadPublicCloudProjects,
   signPublicCloudMou,
   reviewPublicCloudMou,
-} from '@/services/api-test/public-cloud/requests';
+} from '@/services/api-test/public-cloud/products';
+import { makePublicCloudRequestDecision } from '@/services/api-test/public-cloud/requests';
 import { PublicProductCsvRecord } from '@/types/csv';
 import { formatDateSimple } from '@/utils/date';
 
@@ -76,7 +77,7 @@ describe('Download Public Cloud Products - Permissions', () => {
 
     if (task1) {
       await mockSessionByEmail(dat1.decisionData.expenseAuthority.email);
-      await signPublicCloudMou(dat1.id, {
+      await signPublicCloudMou(dat1.licencePlate, {
         taskId: task1?.id ?? '',
         confirmed: true,
       });
@@ -88,13 +89,13 @@ describe('Download Public Cloud Products - Permissions', () => {
           status: TaskStatus.ASSIGNED,
           data: {
             equals: {
-              requestId: dat1.id,
+              licencePlate: dat1.licencePlate,
             },
           },
         },
       });
 
-      await reviewPublicCloudMou(dat1.id, {
+      await reviewPublicCloudMou(dat1.licencePlate, {
         taskId: task2?.id ?? '',
         decision: 'APPROVE',
       });

--- a/app/app/api/public-cloud/products/search/route.test.ts
+++ b/app/app/api/public-cloud/products/search/route.test.ts
@@ -5,12 +5,13 @@ import { createSamplePublicCloudProductData } from '@/helpers/mock-resources';
 import { mockNoRoleUsers, findMockUserByIdr, findOtherMockUsers } from '@/helpers/mock-users';
 import { mockSessionByEmail, mockSessionByRole } from '@/services/api-test/core';
 import { provisionPublicCloudProject } from '@/services/api-test/public-cloud';
-import { createPublicCloudProject, searchPublicCloudProjects } from '@/services/api-test/public-cloud/products';
 import {
-  makePublicCloudRequestDecision,
+  createPublicCloudProject,
+  searchPublicCloudProjects,
   signPublicCloudMou,
   reviewPublicCloudMou,
-} from '@/services/api-test/public-cloud/requests';
+} from '@/services/api-test/public-cloud/products';
+import { makePublicCloudRequestDecision } from '@/services/api-test/public-cloud/requests';
 
 const PO = mockNoRoleUsers[0];
 const TL1 = mockNoRoleUsers[1];
@@ -61,7 +62,7 @@ describe('Search Public Cloud Products - Permissions', () => {
 
     if (task1) {
       await mockSessionByEmail(dat1.decisionData.expenseAuthority.email);
-      await signPublicCloudMou(dat1.id, {
+      await signPublicCloudMou(dat1.licencePlate, {
         taskId: task1?.id ?? '',
         confirmed: true,
       });
@@ -73,13 +74,13 @@ describe('Search Public Cloud Products - Permissions', () => {
           status: TaskStatus.ASSIGNED,
           data: {
             equals: {
-              requestId: dat1.id,
+              licencePlate: dat1.licencePlate,
             },
           },
         },
       });
 
-      await reviewPublicCloudMou(dat1.id, {
+      await reviewPublicCloudMou(dat1.licencePlate, {
         taskId: task2?.id ?? '',
         decision: 'APPROVE',
       });

--- a/app/app/api/public-cloud/provision/[licencePlate]/route.test.ts
+++ b/app/app/api/public-cloud/provision/[licencePlate]/route.test.ts
@@ -4,12 +4,12 @@ import prisma from '@/core/prisma';
 import { createSamplePublicCloudProductData } from '@/helpers/mock-resources';
 import { mockSessionByEmail, mockSessionByRole } from '@/services/api-test/core';
 import { provisionPublicCloudProject } from '@/services/api-test/public-cloud';
-import { createPublicCloudProject } from '@/services/api-test/public-cloud/products';
 import {
-  makePublicCloudRequestDecision,
+  createPublicCloudProject,
   signPublicCloudMou,
   reviewPublicCloudMou,
-} from '@/services/api-test/public-cloud/requests';
+} from '@/services/api-test/public-cloud/products';
+import { makePublicCloudRequestDecision } from '@/services/api-test/public-cloud/requests';
 
 const productData = {
   main: createSamplePublicCloudProductData(),
@@ -38,7 +38,7 @@ describe('Provision Public Cloud Request', () => {
         status: TaskStatus.ASSIGNED,
         data: {
           equals: {
-            requestId: requests.create.id,
+            licencePlate: requests.create.licencePlate,
           },
         },
       },
@@ -46,7 +46,7 @@ describe('Provision Public Cloud Request', () => {
 
     expect(task).toBeTruthy();
 
-    const response = await signPublicCloudMou(requests.create.id, {
+    const response = await signPublicCloudMou(requests.create.licencePlate, {
       taskId: task?.id ?? '',
       confirmed: true,
     });
@@ -63,7 +63,7 @@ describe('Provision Public Cloud Request', () => {
         status: TaskStatus.ASSIGNED,
         data: {
           equals: {
-            requestId: requests.create.id,
+            licencePlate: requests.create.licencePlate,
           },
         },
       },
@@ -71,7 +71,7 @@ describe('Provision Public Cloud Request', () => {
 
     expect(task).toBeTruthy();
 
-    const response = await reviewPublicCloudMou(requests.create.id, {
+    const response = await reviewPublicCloudMou(requests.create.licencePlate, {
       taskId: task?.id ?? '',
       decision: 'APPROVE',
     });

--- a/app/app/api/public-cloud/requests/[id]/decision/route.test.ts
+++ b/app/app/api/public-cloud/requests/[id]/decision/route.test.ts
@@ -9,12 +9,10 @@ import {
   createPublicCloudProject,
   editPublicCloudProject,
   deletePublicCloudProject,
-} from '@/services/api-test/public-cloud/products';
-import {
-  makePublicCloudRequestDecision,
   signPublicCloudMou,
   reviewPublicCloudMou,
-} from '@/services/api-test/public-cloud/requests';
+} from '@/services/api-test/public-cloud/products';
+import { makePublicCloudRequestDecision } from '@/services/api-test/public-cloud/requests';
 
 const fieldsToCompare = [
   'name',
@@ -64,7 +62,7 @@ async function makeBasicProductMouReview() {
       status: TaskStatus.ASSIGNED,
       data: {
         equals: {
-          requestId,
+          licencePlate: requests.main.licencePlate,
         },
       },
     },
@@ -72,7 +70,7 @@ async function makeBasicProductMouReview() {
 
   if (task1) {
     await mockSessionByEmail(decisionData.expenseAuthority.email);
-    await signPublicCloudMou(requestId, {
+    await signPublicCloudMou(requests.main.licencePlate, {
       taskId: task1?.id ?? '',
       confirmed: true,
     });
@@ -84,13 +82,13 @@ async function makeBasicProductMouReview() {
         status: TaskStatus.ASSIGNED,
         data: {
           equals: {
-            requestId,
+            licencePlate: requests.main.licencePlate,
           },
         },
       },
     });
 
-    await reviewPublicCloudMou(requestId, {
+    await reviewPublicCloudMou(requests.main.licencePlate, {
       taskId: task2?.id ?? '',
       decision: 'APPROVE',
     });

--- a/app/app/api/public-cloud/requests/search/route.test.ts
+++ b/app/app/api/public-cloud/requests/search/route.test.ts
@@ -5,13 +5,13 @@ import { createSamplePublicCloudProductData } from '@/helpers/mock-resources';
 import { mockNoRoleUsers, findMockUserByIdr, findOtherMockUsers } from '@/helpers/mock-users';
 import { mockSessionByEmail, mockSessionByRole } from '@/services/api-test/core';
 import { provisionPublicCloudProject } from '@/services/api-test/public-cloud';
-import { createPublicCloudProject, editPublicCloudProject } from '@/services/api-test/public-cloud/products';
 import {
-  searchPublicCloudRequests,
-  makePublicCloudRequestDecision,
+  createPublicCloudProject,
+  editPublicCloudProject,
   signPublicCloudMou,
   reviewPublicCloudMou,
-} from '@/services/api-test/public-cloud/requests';
+} from '@/services/api-test/public-cloud/products';
+import { searchPublicCloudRequests, makePublicCloudRequestDecision } from '@/services/api-test/public-cloud/requests';
 
 const PO = mockNoRoleUsers[0];
 const TL1 = mockNoRoleUsers[1];
@@ -78,13 +78,13 @@ describe('Search Public Cloud Requests - Permissions', () => {
           status: TaskStatus.ASSIGNED,
           data: {
             equals: {
-              requestId: dat1.id,
+              licencePlate: dat1.licencePlate,
             },
           },
         },
       });
 
-      await reviewPublicCloudMou(dat1.id, {
+      await reviewPublicCloudMou(dat1.licencePlate, {
         taskId: task2?.id ?? '',
         decision: 'APPROVE',
       });
@@ -250,7 +250,7 @@ describe('Search Public Cloud Requests - Validations', () => {
 
         if (task1) {
           await mockSessionByEmail(dat1.decisionData.expenseAuthority.email);
-          await signPublicCloudMou(dat1.id, {
+          await signPublicCloudMou(dat1.licencePlate, {
             taskId: task1?.id ?? '',
             confirmed: true,
           });
@@ -262,13 +262,13 @@ describe('Search Public Cloud Requests - Validations', () => {
               status: TaskStatus.ASSIGNED,
               data: {
                 equals: {
-                  requestId: dat1.id,
+                  licencePlate: dat1.licencePlate,
                 },
               },
             },
           });
 
-          await reviewPublicCloudMou(dat1.id, {
+          await reviewPublicCloudMou(dat1.licencePlate, {
             taskId: task2?.id ?? '',
             decision: 'APPROVE',
           });

--- a/app/app/api/v1/public-cloud/products/route.test.ts
+++ b/app/app/api/v1/public-cloud/products/route.test.ts
@@ -10,12 +10,12 @@ import {
   mockUserServiceAccountByRole,
 } from '@/services/api-test/core';
 import { provisionPublicCloudProject } from '@/services/api-test/public-cloud';
-import { createPublicCloudProject } from '@/services/api-test/public-cloud/products';
 import {
-  makePublicCloudRequestDecision,
+  createPublicCloudProject,
   signPublicCloudMou,
   reviewPublicCloudMou,
-} from '@/services/api-test/public-cloud/requests';
+} from '@/services/api-test/public-cloud/products';
+import { makePublicCloudRequestDecision } from '@/services/api-test/public-cloud/requests';
 import { listPublicCloudProjectApi } from '@/services/api-test/v1/public-cloud/products';
 
 const PO = mockNoRoleUsers[0];
@@ -62,7 +62,7 @@ describe('API: List Public Cloud Products - Permissions', () => {
 
     if (task1) {
       await mockSessionByEmail(dat1.decisionData.expenseAuthority.email);
-      await signPublicCloudMou(dat1.id, {
+      await signPublicCloudMou(dat1.licencePlate, {
         taskId: task1?.id ?? '',
         confirmed: true,
       });
@@ -74,13 +74,13 @@ describe('API: List Public Cloud Products - Permissions', () => {
           status: TaskStatus.ASSIGNED,
           data: {
             equals: {
-              requestId: dat1.id,
+              licencePlate: dat1.licencePlate,
             },
           },
         },
       });
 
-      await reviewPublicCloudMou(dat1.id, {
+      await reviewPublicCloudMou(dat1.licencePlate, {
         taskId: task2?.id ?? '',
         decision: 'APPROVE',
       });

--- a/app/app/public-cloud/requests/(request)/[id]/request/page.tsx
+++ b/app/app/public-cloud/requests/(request)/[id]/request/page.tsx
@@ -231,7 +231,7 @@ export default publicCloudProductRequest(({ pathParams, queryParams, session, ro
                 onClick={async () => {
                   if (!publicSnap.currentRequest) return;
                   const res = await openSignPublicCloudProductModal<{ confirmed: boolean }>({
-                    requestId: publicSnap.currentRequest.id,
+                    licencePlate: publicSnap.currentRequest.licencePlate,
                     name: publicSnap.currentRequest.decisionData.name,
                     provider: publicSnap.currentRequest.decisionData.provider,
                   });
@@ -251,7 +251,7 @@ export default publicCloudProductRequest(({ pathParams, queryParams, session, ro
                 onClick={async () => {
                   if (!publicSnap.currentRequest) return;
                   const res = await openReviewPublicCloudProductModal<{ confirmed: boolean }>({
-                    requestId: publicSnap.currentRequest.id,
+                    licencePlate: publicSnap.currentRequest.licencePlate,
                     billingId: publicSnap.currentRequest.decisionData.billingId,
                   });
 

--- a/app/components/billing/PublicCloudBillingDownloadButton.tsx
+++ b/app/components/billing/PublicCloudBillingDownloadButton.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { Alert, Button } from '@mantine/core';
-import { Provider } from '@prisma/client';
 import { useState } from 'react';
+import { getEmouFileName } from '@/helpers/emou';
 import { downloadBilling } from '@/services/backend/billing';
 import { Product } from './types';
 
@@ -21,7 +21,7 @@ export default function BillingDownloadButton({ product }: { product: Product })
           product.billing.accountCoding,
           product.provider,
           product.licencePlate,
-          `OCIO and ${product.provider === Provider.AWS ? 'AWS' : 'Microsoft Azure'} MOU.pdf`,
+          getEmouFileName(product.name, product.provider),
         );
         setLoading(false);
       }}

--- a/app/components/billing/PublicCloudBillingInfo.tsx
+++ b/app/components/billing/PublicCloudBillingInfo.tsx
@@ -87,7 +87,7 @@ export default function PublicCloudBillingInfo({
             });
 
             if (res?.state.confirmed) {
-              router.push('/public-cloud/requests/all');
+              location.reload();
             }
           }}
         >
@@ -95,7 +95,10 @@ export default function PublicCloudBillingInfo({
         </Button>
       )}
       {product._permissions?.reviewMou && (
-        <button
+        <Button
+          color="primary"
+          size="xs"
+          className="mt-2"
           onClick={async () => {
             const res = await openReviewPublicCloudProductModal<{ confirmed: boolean }>({
               licencePlate: product.licencePlate,
@@ -103,14 +106,12 @@ export default function PublicCloudBillingInfo({
             });
 
             if (res?.state.confirmed) {
-              router.push('/public-cloud/requests/all');
+              location.reload();
             }
           }}
-          type="button"
-          className="flex rounded-md bg-bcorange px-4 py-2.5 text-bcblue text-sm tracking-[.2em] shadow-sm hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
         >
           Review eMOU
-        </button>
+        </Button>
       )}
     </Alert>
   );

--- a/app/components/modal/CreatePublicCloud.tsx
+++ b/app/components/modal/CreatePublicCloud.tsx
@@ -1,8 +1,11 @@
 import { Dialog, Transition } from '@headlessui/react';
+import { Alert } from '@mantine/core';
+import { IconInfoCircle } from '@tabler/icons-react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { Fragment, useRef, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import ExternalLink from '@/components/generic/button/ExternalLink';
+import MailLink from '@/components/generic/button/MailLink';
 import FormCheckbox from '@/components/generic/checkbox/FormCheckbox';
 import { getBilling } from '@/services/backend/billing';
 
@@ -103,37 +106,14 @@ export default function CreatePublicCloud({
                       regarding your product status and details.
                     </p>
                   </div>
-                  <div className="bg-blue-50 mt-4 p-4 rounded-md flex">
-                    <div className="border-2 border-blue-700 relative w-1 h-1 bg-inherit rounded-full flex justify-center items-center text-center p-2 m-2 mr-4">
-                      <span className="font-bold text-blue-700 font-sans text-xs">i</span>
+                  <Alert variant="" color="primary" title="Note:" className="mt-2" icon={<IconInfoCircle size={80} />}>
+                    <div className="text-sm text-blue-700">
+                      Ministry Teams provisioning access to BC Gov&apos;s Landing Zones in AWS and Azure are required to
+                      attend an onboarding session with the Public Cloud Team. To book an onboarding session, please
+                      email us at <MailLink to="Cloud.Pathfinder@gov.bc.ca" />.
                     </div>
-                    <div>
-                      <p className="text-sm text-blue-700 font-semibold mt-2">Note:</p>
-                      <p className="text-sm text-blue-700 mt-1">
-                        Provisioning Requests for BC Gov&apos;s Landing Zone in AWS - Ministry Product Teams are
-                        required to complete two prior steps:
-                      </p>
-                      <ol className="text-sm text-blue-700 mt-1 pl-5 list-decimal" type="I">
-                        <li className="py-2">
-                          Sign a Memorandum of Understanding (MoU) with the Public Cloud Accelerator Service Team. If
-                          you do not have a MoU in place, please email us at{' '}
-                          <a href="mailto:cloud.pathfinder@gov.bc.ca" className="underline">
-                            Cloud.Pathfinder@gov.bc.ca
-                          </a>
-                          .
-                        </li>
-                        <li className="py-2">
-                          Attend an onboarding session with the Public Cloud Accelerator Service Team. To book an
-                          onboarding session, please email us at{' '}
-                          <a href="mailto:cloud.pathfinder@gov.bc.ca" className="underline">
-                            Cloud.Pathfinder@gov.bc.ca
-                          </a>
-                          .
-                        </li>
-                      </ol>
-                    </div>
-                  </div>
-                  <div className="flex mt-8 pt-4">
+                  </Alert>
+                  <div className="pt-4">
                     <FormCheckbox
                       id="consent1"
                       checked={confirmSigned}
@@ -142,7 +122,7 @@ export default function CreatePublicCloud({
                       {eMouCheckboxContent}
                     </FormCheckbox>
                   </div>
-                  <div className="flex pt-2 pb-5">
+                  <div className="pt-2 pb-5">
                     <FormCheckbox
                       id="consent2"
                       checked={confirmLiable}

--- a/app/components/modal/reviewPublicCloudProductModal.tsx
+++ b/app/components/modal/reviewPublicCloudProductModal.tsx
@@ -15,11 +15,11 @@ import FormError from '@/components/generic/FormError';
 import { createModal, ExtraModalProps } from '@/core/modal';
 import { formatFullName } from '@/helpers/user';
 import { getBilling } from '@/services/backend/billing';
-import { reviewPublicCloudMou } from '@/services/backend/public-cloud/requests';
+import { reviewPublicCloudMou } from '@/services/backend/public-cloud/products';
 import { formatDate } from '@/utils/date';
 
 interface ModalProps {
-  requestId: string;
+  licencePlate: string;
   billingId: string;
 }
 
@@ -28,7 +28,7 @@ interface ModalState {
 }
 
 function ReviewPublicCloudProductModal({
-  requestId,
+  licencePlate,
   billingId,
   state,
   closeModal,
@@ -63,7 +63,7 @@ function ReviewPublicCloudProductModal({
     isError: isReviewError,
     error: reviewError,
   } = useMutation({
-    mutationFn: (data: { taskId: string; decision: string }) => reviewPublicCloudMou(requestId, data),
+    mutationFn: (data: { taskId: string; decision: string }) => reviewPublicCloudMou(licencePlate, data),
     onSuccess: () => {
       state.confirmed = true;
 
@@ -89,8 +89,6 @@ function ReviewPublicCloudProductModal({
 
   const { handleSubmit, register } = methods;
 
-  console.log('billing', billing);
-
   return (
     <Box pos="relative">
       <LoadingOverlay visible={billingLoading || isReviewing} zIndex={1000} overlayProps={{ radius: 'sm', blur: 2 }} />
@@ -103,7 +101,7 @@ function ReviewPublicCloudProductModal({
                 (tsk) =>
                   tsk.type === TaskType.REVIEW_MOU &&
                   tsk.status === TaskStatus.ASSIGNED &&
-                  (tsk.data as { requestId: string }).requestId === requestId,
+                  (tsk.data as { licencePlate: string }).licencePlate === licencePlate,
               );
 
               if (task) {

--- a/app/components/modal/signPublicCloudProductModal.tsx
+++ b/app/components/modal/signPublicCloudProductModal.tsx
@@ -13,10 +13,10 @@ import ExternalLink from '@/components/generic/button/ExternalLink';
 import FormCheckbox from '@/components/generic/checkbox/FormCheckbox';
 import FormError from '@/components/generic/FormError';
 import { createModal, ExtraModalProps } from '@/core/modal';
-import { signPublicCloudMou } from '@/services/backend/public-cloud/requests';
+import { signPublicCloudMou } from '@/services/backend/public-cloud/products';
 
 interface ModalProps {
-  requestId: string;
+  licencePlate: string;
   name: string;
   provider: Provider;
 }
@@ -26,7 +26,7 @@ interface ModalState {
 }
 
 function SignPublicCloudProductModal({
-  requestId,
+  licencePlate,
   name,
   provider,
   state,
@@ -51,7 +51,7 @@ function SignPublicCloudProductModal({
     isError: isSignError,
     error: signError,
   } = useMutation({
-    mutationFn: (data: { taskId: string; confirmed: boolean }) => signPublicCloudMou(requestId, data),
+    mutationFn: (data: { taskId: string; confirmed: boolean }) => signPublicCloudMou(licencePlate, data),
     onSuccess: () => {
       state.confirmed = true;
 
@@ -90,7 +90,7 @@ function SignPublicCloudProductModal({
                 (tsk) =>
                   tsk.type === TaskType.SIGN_MOU &&
                   tsk.status === TaskStatus.ASSIGNED &&
-                  (tsk.data as { requestId: string }).requestId === requestId,
+                  (tsk.data as { licencePlate: string }).licencePlate === licencePlate,
               );
 
               if (task) {

--- a/app/core/services/public-cloud-request.ts
+++ b/app/core/services/public-cloud-request.ts
@@ -63,16 +63,16 @@ export class PublicCloudRequestService extends ModelService<Prisma.PublicCloudRe
           !doc.decisionData.billing.signed &&
           this.session.tasks
             .filter((task) => task.type === TaskType.SIGN_MOU && task.status === TaskStatus.ASSIGNED)
-            .map((task) => (task.data as { requestId: string }).requestId)
-            .includes(doc.id);
+            .map((task) => (task.data as { licencePlate: string }).licencePlate)
+            .includes(doc.licencePlate);
 
         canApproveMou =
           doc.decisionData.billing.signed &&
           !doc.decisionData.billing.approved &&
           this.session.tasks
             .filter((task) => task.type === TaskType.REVIEW_MOU && task.status === TaskStatus.ASSIGNED)
-            .map((task) => (task.data as { requestId: string }).requestId)
-            .includes(doc.id);
+            .map((task) => (task.data as { licencePlate: string }).licencePlate)
+            .includes(doc.licencePlate);
 
         canReview = canReview && doc.decisionData.billing.signed && doc.decisionData.billing.approved;
       } else {

--- a/app/helpers/emou.ts
+++ b/app/helpers/emou.ts
@@ -1,0 +1,5 @@
+import { Provider } from '@prisma/client';
+
+export function getEmouFileName(productName: string, provider: Provider) {
+  return `OCIO and ${productName} - ${provider === Provider.AWS ? 'AWS' : 'Microsoft Azure'} MOU.pdf`;
+}

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -16269,6 +16269,111 @@
       "peerDependencies": {
         "zod": "^3.18.0"
       }
+    },
+    "node_modules/react-email/node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.9.tgz",
+      "integrity": "sha512-/kfQifl3uLYi3DlwFlzCkgxe6fprJNLzzTUFknq3M5wGYicDIbdGlxUl6oHpVLJpBB/CBY3Y//gO6alz/K4NWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/react-email/node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.9.tgz",
+      "integrity": "sha512-tK/RyhCmOCiXQ9IVdFrBbZOf4/1+0RSuJkebXU2uMEsusS51TjIJO4l8ZmEijH9gZa0pJClvmApRHi7JuBqsRw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/react-email/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.9.tgz",
+      "integrity": "sha512-tS5eqwsp2nO7mzywRUuFYmefNZsUKM/mTG3exK2jIHv9TEVklE1SByB1KMhFkqlit1PxS9YK1tV8BOV90Wpbrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/react-email/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.9.tgz",
+      "integrity": "sha512-8svpeTFNAMTUMKQbEzE8qRAwl9o7mNBv7LR1bmSkQvo1oy4WrNyZbhWsldOiKrc4mZ5dfQkGYsI9T75mIFMfeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/react-email/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.9.tgz",
+      "integrity": "sha512-p/v6XlOdrk06xfN9z4evLNBqftVQUWiyduQczCwSj7hNh8fWTbzdVxsEiNOcajMXJbQiaX/ZzZdFgKVmmJnnGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/react-email/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.9.tgz",
+      "integrity": "sha512-IcW9dynWDjMK/0M05E3zopbRen7v0/yEaMZbHFOSS1J/w+8YG3jKywOGZWNp/eCUVtUUXs0PW+7Lpz8uLu+KQA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/react-email/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.9.tgz",
+      "integrity": "sha512-gcbpoXyWZdVOBgNa5BRzynrL5UR1nb2ZT38yKgnphYU9UHjeecnylMHntrQiMg/QtONDcJPFC/PmsS47xIRYoA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/app/request-actions/public-cloud/create-request.ts
+++ b/app/request-actions/public-cloud/create-request.ts
@@ -114,7 +114,7 @@ export default async function createRequest(formData: PublicCloudCreateRequestBo
           status: TaskStatus.ASSIGNED,
           userIds: [request.decisionData.expenseAuthorityId],
           data: {
-            requestId: request.id,
+            licencePlate: request.licencePlate,
           },
         },
       });

--- a/app/services/api-test/public-cloud/helpers.ts
+++ b/app/services/api-test/public-cloud/helpers.ts
@@ -7,12 +7,10 @@ import {
   createPublicCloudProject,
   editPublicCloudProject,
   deletePublicCloudProject,
-} from '@/services/api-test/public-cloud/products';
-import {
-  makePublicCloudRequestDecision,
   signPublicCloudMou,
   reviewPublicCloudMou,
-} from '@/services/api-test/public-cloud/requests';
+} from '@/services/api-test/public-cloud/products';
+import { makePublicCloudRequestDecision } from '@/services/api-test/public-cloud/requests';
 
 async function runEmouWorkflows(reqData: any) {
   const decisionData = reqData.decisionData;

--- a/app/services/api-test/public-cloud/products.ts
+++ b/app/services/api-test/public-cloud/products.ts
@@ -1,9 +1,11 @@
 import { GET as _listPublicCloudProductRequests } from '@/app/api/public-cloud/products/[licencePlate]/requests/route';
+import { POST as _reviewPublicCloudMou } from '@/app/api/public-cloud/products/[licencePlate]/review-mou/route';
 import {
   GET as _getPublicCloudProject,
   PUT as _editPublicCloudProject,
   DELETE as _deletePublicCloudProject,
 } from '@/app/api/public-cloud/products/[licencePlate]/route';
+import { POST as _signPublicCloudMou } from '@/app/api/public-cloud/products/[licencePlate]/sign-mou/route';
 import { POST as _downloadPublicCloudProjects } from '@/app/api/public-cloud/products/download/route';
 import {
   GET as _listPublicCloudProject,
@@ -70,5 +72,19 @@ export async function listPublicCloudProductRequests(licencePlate: string, activ
     },
   );
 
+  return result;
+}
+
+export async function signPublicCloudMou(id: string, data: { taskId: string; confirmed: boolean }) {
+  const result = await productCollectionRoute.post(_signPublicCloudMou, '/{{licencePlate}}/sign-mou', data, {
+    pathParams: { id },
+  });
+  return result;
+}
+
+export async function reviewPublicCloudMou(id: string, data: { taskId: string; decision: string }) {
+  const result = await productCollectionRoute.post(_reviewPublicCloudMou, '/{{licencePlate}}/review-mou', data, {
+    pathParams: { id },
+  });
   return result;
 }

--- a/app/services/api-test/public-cloud/products.ts
+++ b/app/services/api-test/public-cloud/products.ts
@@ -75,16 +75,16 @@ export async function listPublicCloudProductRequests(licencePlate: string, activ
   return result;
 }
 
-export async function signPublicCloudMou(id: string, data: { taskId: string; confirmed: boolean }) {
+export async function signPublicCloudMou(licencePlate: string, data: { taskId: string; confirmed: boolean }) {
   const result = await productCollectionRoute.post(_signPublicCloudMou, '/{{licencePlate}}/sign-mou', data, {
-    pathParams: { id },
+    pathParams: { licencePlate },
   });
   return result;
 }
 
-export async function reviewPublicCloudMou(id: string, data: { taskId: string; decision: string }) {
+export async function reviewPublicCloudMou(licencePlate: string, data: { taskId: string; decision: string }) {
   const result = await productCollectionRoute.post(_reviewPublicCloudMou, '/{{licencePlate}}/review-mou', data, {
-    pathParams: { id },
+    pathParams: { licencePlate },
   });
   return result;
 }

--- a/app/services/api-test/public-cloud/requests.ts
+++ b/app/services/api-test/public-cloud/requests.ts
@@ -1,6 +1,4 @@
 import { POST as _makePublicCloudRequestDecision } from '@/app/api/public-cloud/requests/[id]/decision/route';
-import { POST as _reviewPublicCloudMou } from '@/app/api/public-cloud/requests/[id]/review-mou/route';
-import { POST as _signPublicCloudMou } from '@/app/api/public-cloud/requests/[id]/sign-mou/route';
 import { POST as _searchPublicCloudRequests } from '@/app/api/public-cloud/requests/search/route';
 import { PublicCloudRequestSearchBody } from '@/validation-schemas/public-cloud';
 import { createRoute } from '../core';
@@ -14,20 +12,6 @@ export async function searchPublicCloudRequests(data: Partial<PublicCloudRequest
 
 export async function makePublicCloudRequestDecision(id: string, data: any) {
   const result = await requestCollectionRoute.post(_makePublicCloudRequestDecision, '/{{id}}/decision', data, {
-    pathParams: { id },
-  });
-  return result;
-}
-
-export async function signPublicCloudMou(id: string, data: { taskId: string; confirmed: boolean }) {
-  const result = await requestCollectionRoute.post(_signPublicCloudMou, '/{{id}}/sign-mou', data, {
-    pathParams: { id },
-  });
-  return result;
-}
-
-export async function reviewPublicCloudMou(id: string, data: { taskId: string; decision: string }) {
-  const result = await requestCollectionRoute.post(_reviewPublicCloudMou, '/{{id}}/review-mou', data, {
     pathParams: { id },
   });
   return result;

--- a/app/services/backend/public-cloud/products.ts
+++ b/app/services/backend/public-cloud/products.ts
@@ -82,3 +82,13 @@ export async function getPublicCloudProductRequests(licencePlate: string, active
 
   return result as PublicCloudRequestSimpleDecorated[];
 }
+
+export async function signPublicCloudMou(licencePlate: string, data: { taskId: string; confirmed: boolean }) {
+  const result = await instance.post(`/${licencePlate}/sign-mou`, data).then((res) => res.data);
+  return result as true;
+}
+
+export async function reviewPublicCloudMou(licencePlate: string, data: { taskId: string; decision: string }) {
+  const result = await instance.post(`/${licencePlate}/review-mou`, data).then((res) => res.data);
+  return result as true;
+}

--- a/app/services/backend/public-cloud/requests.ts
+++ b/app/services/backend/public-cloud/requests.ts
@@ -45,13 +45,3 @@ export async function makePublicCloudRequestDecision(id: string, data: any) {
   const result = await instance.post(`/${id}/decision`, data).then((res) => res.data);
   return result as PublicCloudRequestDetail;
 }
-
-export async function signPublicCloudMou(id: string, data: { taskId: string; confirmed: boolean }) {
-  const result = await instance.post(`/${id}/sign-mou`, data).then((res) => res.data);
-  return result as true;
-}
-
-export async function reviewPublicCloudMou(id: string, data: { taskId: string; decision: string }) {
-  const result = await instance.post(`/${id}/review-mou`, data).then((res) => res.data);
-  return result as true;
-}

--- a/app/services/ches/public-cloud/email-handler.ts
+++ b/app/services/ches/public-cloud/email-handler.ts
@@ -15,6 +15,7 @@ import ExpenseAuthorityMou from '@/emails/_templates/public-cloud/ExpenseAuthori
 import ProvisionedTemplate from '@/emails/_templates/public-cloud/Provisioned';
 import RequestApprovalTemplate from '@/emails/_templates/public-cloud/RequestApproval';
 import RequestRejectionTemplate from '@/emails/_templates/public-cloud/RequestRejection';
+import { getEmouFileName } from '@/helpers/emou';
 import { generateEmouPdf, Billing } from '@/helpers/pdfs/emou';
 import { adminPublicEmails } from '@/services/ches/email-constant';
 import { sendEmail } from '@/services/ches/helpers';
@@ -35,7 +36,7 @@ export async function sendEmouServiceAgreementEmail(request: PublicCloudRequestD
       {
         content: emouPdfBuff.toString('base64'),
         encoding: 'base64',
-        filename: `OCIO and ${request.decisionData.provider === Provider.AWS ? 'AWS' : 'Microsoft Azure'} MOU.pdf`,
+        filename: getEmouFileName(request.decisionData.name, request.decisionData.provider),
         contentType: 'application/pdf',
       },
     ],

--- a/app/types/doc-decorate.ts
+++ b/app/types/doc-decorate.ts
@@ -22,7 +22,15 @@ export interface PrivateCloudRequestDecorate {
 }
 
 export interface PublicCloudProjectDecorate {
-  _permissions: { view: boolean; viewHistory: boolean; edit: boolean; delete: boolean; reprovision: boolean };
+  _permissions: {
+    view: boolean;
+    viewHistory: boolean;
+    edit: boolean;
+    delete: boolean;
+    reprovision: boolean;
+    signMou: boolean;
+    reviewMou: boolean;
+  };
 }
 
 export interface PublicCloudRequestDecorate {

--- a/data-migrations/migrations/20240906172589-populate_account_coding_to_billing4.js
+++ b/data-migrations/migrations/20240906172589-populate_account_coding_to_billing4.js
@@ -1,0 +1,51 @@
+export const up = async (db, client) => {
+  const requests = await db
+    .collection('PublicCloudRequest')
+    .find(
+      { type: 'CREATE' },
+      {
+        projection: { decisionDataId: 1 },
+        sort: { createdAt: 1 },
+      },
+    )
+    .toArray();
+
+  for (let x = 0; x < requests.length; x++) {
+    const request = requests[x];
+    if (!request.decisionDataId) continue;
+
+    const decisionData = await db
+      .collection('PublicCloudRequestedProject')
+      .findOne({ _id: { $eq: request.decisionDataId } });
+    if (!decisionData) continue;
+
+    if (!decisionData.accountCoding) continue;
+
+    let billingId = null;
+    const code = `${decisionData.accountCoding}_${decisionData.provider}`;
+
+    const billingDoc = await db.collection('Billing').findOne({ code: { $eq: code } });
+    if (billingDoc) {
+      billingId = billingDoc._id;
+    } else {
+      const billingData = {
+        code,
+        accountCoding: decisionData.accountCoding,
+        expenseAuthorityId: decisionData.expenseAuthorityId,
+        licencePlate: decisionData.licencePlate,
+        signed: false,
+        approved: false,
+        createdAt: decisionData.createdAt,
+        updatedAt: decisionData.createdAt,
+      };
+      const insertMeta = await db.collection('Billing').insertOne(billingData, {});
+      billingId = insertMeta.insertedId;
+    }
+
+    await db
+      .collection('PublicCloudRequestedProject')
+      .updateMany({ licencePlate: { $eq: decisionData.licencePlate } }, { $set: { billingId } });
+  }
+};
+
+export const down = async (db, client) => {};

--- a/data-migrations/migrations/20240910214355-assign_emou_ea.js
+++ b/data-migrations/migrations/20240910214355-assign_emou_ea.js
@@ -1,0 +1,28 @@
+export const up = async (db, client) => {
+  const billings = await db
+    .collection('Billing')
+    .find(
+      { signed: false, $and: [{ expenseAuthorityId: { $exists: true } }, { expenseAuthorityId: { $ne: null } }] },
+      {
+        projection: { expenseAuthorityId: 1, licencePlate: 1 },
+        sort: { createdAt: 1 },
+      },
+    )
+    .toArray();
+
+  const taskData = billings.map((billing) => {
+    return {
+      type: 'SIGN_MOU',
+      status: 'ASSIGNED',
+      userIds: [String(billing.expenseAuthorityId)],
+      data: {
+        licencePlate: billing.licencePlate,
+      },
+      createdAt: new Date(),
+    };
+  });
+
+  await db.collection('Task').insertMany(taskData, {});
+};
+
+export const down = async (db, client) => {};


### PR DESCRIPTION
- when creating tasks for eMOU workflows, associate them with licence plates.
- add migration script to create tasks for the previously created public cloud products.