### PR TITLE
feat(3647): add saving screenshots, tweak e2e tests, sandbox image pulls

### DIFF
--- a/.github/workflows/cypress-e2e-test.yaml
+++ b/.github/workflows/cypress-e2e-test.yaml
@@ -45,6 +45,7 @@ jobs:
         export MACHINE_HOST_IP=$(hostname -I | awk '{print $1}')
         ~/.docker/cli-plugins/docker-compose -f localdev/docker-compose.yml -f localdev/docker-compose-ci.yml up -d
         node_modules/.bin/wait-on http://localhost:8080/health/ready --timeout 120000
+        node_modules/.bin/wait-on http://localhost:8080/realms/platform-services/.well-known/openid-configuration --timeout 120000
         cp app/.env.example app/.env.test
 
     - name: Run App
@@ -54,6 +55,15 @@ jobs:
 
     - name: Cypress run
       run: npm run cypress-headless
+
+    - name: Upload Cypress Screenshots and Videos
+      uses: actions/upload-artifact@v3
+      with:
+        name: cypress-artifacts
+        path: |-
+          /home/runner/work/platform-services-registry/platform-services-registry/cypress/screenshots
+          /home/runner/work/platform-services-registry/platform-services-registry/cypress/videos
+      if: ${{ failure() }}
 
     - name: Clean Up Localdev Environment
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-.vscode/settings.json
 /node_modules
 /.pnp
 .pnp.js
@@ -9,6 +8,7 @@
 # misc
 .DS_Store
 *.pem
+.vscode
 
 # debug
 npm-debug.log*

--- a/cypress/_tmp/dummy.feature
+++ b/cypress/_tmp/dummy.feature
@@ -1,0 +1,21 @@
+# Feature: Dummy Feature
+#   Scenario: Let pipeline run without reds while adjusting the tests to GHA environment
+#     Given User visits local keycloak and finds james.smith
+#     And User logs in with username "james.smith@gov.bc.ca" and password "james.smith@gov.bc.ca"
+#     When User clicks tab "PRIVATE CLOUD OPENSHIFT"
+#     And User clicks button "REQUEST A NEW PRODUCT"
+#     And User types "Automated Test Product Name" in "Product Name"
+#     And User types "Automated Test Description" in "Description"
+#     And User selects "Citizens Services" in "Ministry"
+#     And User selects "SILVER" in "Hosting Tier"
+#     And User clicks tab "Team contacts"
+#     And User types and selects "james.smith@gov.bc.ca" in "Product Owner Email"
+#     And User types and selects "john.doe@gov.bc.ca" in "Technical Lead Email"
+#     And User clicks tab "Common components"
+#     And User checks checkbox "The app does not use..."
+#     And User clicks button "SUBMIT REQUEST"
+#     And User checks checkbox "By checking this box..."
+#     And User clicks button "Submit"
+#     And User clicks button "Return to Dashboard"
+#     Then User should be redirected to Requests tab
+#     And User should see "Automated Test Product Name"

--- a/cypress/integration/create-request-private-test.feature
+++ b/cypress/integration/create-request-private-test.feature
@@ -10,9 +10,11 @@ Feature: New Request
     And User selects "SILVER" in "Hosting Tier"
     And User clicks tab "Team contacts"
     And User types and selects "james.smith@gov.bc.ca" in "Product Owner Email"
+    And User waits for "2" seconds
     And User types and selects "john.doe@gov.bc.ca" in "Technical Lead Email"
     And User clicks tab "Common components"
     And User checks checkbox "The app does not use..."
+    And User makes a screenshot
     And User clicks button "SUBMIT REQUEST"
     And User checks checkbox "By checking this box..."
     And User clicks button "Submit"

--- a/cypress/integration/dummy.feature
+++ b/cypress/integration/dummy.feature
@@ -1,3 +1,0 @@
-Feature: Dummy Feature
-  Scenario: Let pipeline run without reds while adjusting the tests to GHA environment
-    Given User visits main page

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -53,7 +53,6 @@ export function loginToRegistry(username: string, password: string): void {
   cy.contains('button', 'Login').click();
   cy.wait(5000); // wait until the page loads, otherwise no chances to find clause below
   cy.url().then((val) => {
-    console.log(val);
     if (val.includes('/api/auth/signin?csrf=true')) {
       cy.contains('span', 'Sign in with Keycloak').click();
       cy.wait(2000);

--- a/cypress/support/step_definitions/common.ts
+++ b/cypress/support/step_definitions/common.ts
@@ -16,6 +16,26 @@ Given('User visits main page', () => {
   cy.visit('/login', { failOnStatusCode: false });
 });
 
+// Step for debug
+// Given('User visits local keycloak and finds james.smith', () => {
+//   cy.wait(300);
+//   cy.visit('http://localhost:8080');
+//   cy.contains('a', 'Administration Console').click();
+//   cy.get('input[id="username"]').type('admin');
+//   cy.get('input[id="password"]').type('password');
+//   cy.get('input[type="submit"]').click();
+//   cy.get('button[id="nav-toggle"]').click();
+//   cy.get('button[data-testid="realmSelectorToggle"]').click();
+//   cy.screenshot();
+//   cy.contains('div', 'platform-services').should('be.visible').click();
+//   cy.get('a[id="nav-item-users"]').click();
+//   cy.wait(3);
+//   cy.contains('td', 'james.smith@gov.bc.ca').should('be.visible');
+//   cy.visit('http://localhost:3000/login');
+//   cy.wait(5);
+//   cy.screenshot();
+// });
+
 When(/^User clicks link "(.*)"$/, (buttonText: string) => {
   cy.contains('a, span', buttonText).first().scrollIntoView().click();
 });
@@ -36,8 +56,9 @@ When(/^User types and selects Secondary Tech Lead "(.*)"$/, (contactEmail: strin
     .find('input')
     .first()
     .clear()
-    .type(contactEmail);
-  cy.contains('span', contactEmail).scrollIntoView().click();
+    .type(contactEmail)
+    .screenshot();
+  cy.contains('span', contactEmail).screenshot().click();
 });
 
 When(/^User types justification "(.*)" in "(.*)"$/, (fieldText: string, fieldHeader) => {
@@ -92,6 +113,10 @@ When(/^User clicks button with text (.*)$/, (buttonText: string) => {
 
 When('User logs out', () => {
   cy.logoutFromRegistry();
+});
+
+When('User makes a screenshot', () => {
+  cy.screenshot();
 });
 
 Then('User should be redirected to Requests tab', () => {

--- a/localdev/docker-compose-ci.yml
+++ b/localdev/docker-compose-ci.yml
@@ -1,20 +1,25 @@
 services:
   keycloak:
     image: ghcr.io/bcgov/pltsvc-localdev-keycloak:latest
+    pull_policy: always
     build: {}
 
   keycloak-provision:
     image: ghcr.io/bcgov/pltsvc-localdev-keycloak-provision:latest
+    pull_policy: always
     build: {}
 
   m365proxy:
     image: ghcr.io/bcgov/pltsvc-localdev-m365proxy:latest
+    pull_policy: always
     build: {}
 
   nats-provision:
     image: ghcr.io/bcgov/pltsvc-localdev-nats-provision:latest
+    pull_policy: always
     build: {}
 
   m365mock:
     image: ghcr.io/bcgov/pltsvc-localdev-m365mock:latest
+    pull_policy: always
     build: {}


### PR DESCRIPTION
feat(3647): add saving screenshots, tweak e2e tests, sandbox image pulls
As part of tweaking tests to run in GitHub actions we faced some obstacles.
First, to understand the Cypress side problems, I added the code to GitHub Action to pass the screenshots form Cypress to GitHub actions Artifacts (thanks Junmin with suggesting it and giving references).
After that I found that the tests in most of the times didn't see the realm provisioned in KeyCloak sandbox instance. I added steps to reach KeyCloak, login and watch for the realm.
Then Junmin found the problem with image pull mechanism and fixed it (fix included in this PR). 
And after that I found the problem with adding Tech Lead to the product. Adding timeout fixed the issue.