### PR TITLE
feat(3814): tweak public cloud create test to run in github actions

### DIFF
--- a/.github/workflows/cypress-e2e-test.yaml
+++ b/.github/workflows/cypress-e2e-test.yaml
@@ -43,9 +43,9 @@ jobs:
         mkdir -p ./localdev/mnt/postgres
 
         export MACHINE_HOST_IP=$(hostname -I | awk '{print $1}')
-        ~/.docker/cli-plugins/docker-compose -f localdev/docker-compose.yml -f localdev/docker-compose-ci.yml up -d
+        ~/.docker/cli-plugins/docker-compose -f localdev/docker-compose.yml up -d
         node_modules/.bin/wait-on http://localhost:8080/health/ready --timeout 120000
-        node_modules/.bin/wait-on http://localhost:8080/realms/platform-services/.well-known/openid-configuration --timeout 120000
+        node_modules/.bin/wait-on http://localhost:8080/realms/platform-services/.well-known/openid-configuration --timeout 240000
         cp app/.env.example app/.env.test
 
     - name: Run App
@@ -67,5 +67,5 @@ jobs:
 
     - name: Clean Up Localdev Environment
       run: |
-        ~/.docker/cli-plugins/docker-compose -f localdev/docker-compose.yml -f localdev/docker-compose-ci.yml down
+        ~/.docker/cli-plugins/docker-compose -f localdev/docker-compose.yml down
         sudo rm -rf ./localdev/mnt

--- a/cypress/_tmp/edit-request-private-test.feature
+++ b/cypress/_tmp/edit-request-private-test.feature
@@ -25,6 +25,7 @@ Feature: Edit Request
     And User selects "Finance" in "Ministry"
     And User clicks tab "Team contacts"
     And User types and selects "david.johnson@gov.bc.ca" in "Product Owner Email"
+    And User waits for "2" seconds
     And User types and selects "sarah.williams@gov.bc.ca" in "Technical Lead Email"
     And User clicks button "ADD SECONDARY TECHNICAL LEAD"
     And User types and selects Secondary Tech Lead "michael.brown@gov.bc.ca"

--- a/cypress/integration/create-request-public-test.feature
+++ b/cypress/integration/create-request-public-test.feature
@@ -15,6 +15,7 @@ Feature: New Request
     And User checks checkbox "Tools Account"
     And User clicks tab "Team contacts"
     And User types and selects "james.smith@gov.bc.ca" in "Product Owner Email"
+    And User waits for "2" seconds
     And User types and selects "john.doe@gov.bc.ca" in "Technical Lead Email"
     And User clicks tab "Expense authority"
     And User types and selects "public.admin.system@gov.bc.ca" in "Expense Authority Email"
@@ -28,8 +29,8 @@ Feature: New Request
     And User types "2345" in "Standard Object of Expense (STOB)"
     And User types "6789012" in "Project Code"
     And User clicks button "SUBMIT REQUEST"
-    And User checks checkbox "...has signed a Memorandum of Understanding..."
-    And User checks checkbox "...is liable to pay the base charge..."
+    And User checks checkbox "No eMOU exists for this account coding."
+    And User checks checkbox "...team is liable to pay the base charge..."
     And User clicks modal window button "SUBMIT REQUEST"
     And User waits for "4" seconds
     And User clicks button "Return to Dashboard"


### PR DESCRIPTION
feat(3814): tweak public cloud create test to run in github actions
Adding timeouts in Public Cloud Create Test,
Updating text to find the checkbox in 'All Set' modal window,
Update the timeout and delete call to docker-compose-ci in workflow e2e tests file.