### PR TITLE
feat(3636): track cloud provider selection reasons

### DIFF
--- a/app/app/public-cloud/products/(product)/[licencePlate]/edit/page.tsx
+++ b/app/app/public-cloud/products/(product)/[licencePlate]/edit/page.tsx
@@ -180,10 +180,17 @@ export default publicCloudProductEdit(({ pathParams, queryParams, session }) => 
   ];
 
   const isSubmitEnabled = formState.isDirty || isSecondaryTechLeadRemoved;
-
   return (
     <div>
-      <PublicCloudBillingInfo product={snap.currentProduct} className="mb-2" />
+      <PublicCloudBillingInfo
+        product={{
+          ...snap.currentProduct,
+          ...(snap.currentProduct.providerSelectionReasons && {
+            providerSelectionReasons: [...snap.currentProduct.providerSelectionReasons],
+          }),
+        }}
+        className="mb-2"
+      />
       <FormProvider {...methods}>
         <FormErrorNotification />
         <form autoComplete="off" onSubmit={methods.handleSubmit(() => setOpenComment(true))}>


### PR DESCRIPTION
<img width="1581" alt="Screenshot 2024-09-25 at 10 45 29 AM" src="https://github.com/user-attachments/assets/a6efc0f5-66ce-4f23-b2b0-fed51fbe3bda">
