### PR TITLE
chore(4189): update e2e github action workflow to use hash instead of version

### DIFF
--- a/.github/workflows/cypress-e2e-test.yaml
+++ b/.github/workflows/cypress-e2e-test.yaml
@@ -57,7 +57,7 @@ jobs:
       run: npm run cypress-headless
 
     - name: Upload Cypress Screenshots and Videos
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       with:
         name: cypress-artifacts
         path: |-


### PR DESCRIPTION
Update E2E GitHub Action workflow upload-artifacts to use hash instead of version:
Before:
<img width="649" alt="image" src="https://github.com/user-attachments/assets/7b71fc42-3216-4593-9bf2-af35bd2325d6">

After:
<img width="654" alt="image" src="https://github.com/user-attachments/assets/d0475b63-c93b-4003-a2cc-d207bcb58ad8">
