### PR TITLE
fix(4589): add a command to install keycloak-admin to nats-provision docker file

### DIFF
--- a/localdev/nats-provision/Dockerfile
+++ b/localdev/nats-provision/Dockerfile
@@ -7,6 +7,7 @@ COPY _packages ./_packages
 
 RUN npm install -g turbo pnpm
 RUN cd context && pnpm install --ignore-scripts && pnpm build
+RUN cd ../keycloak-admin && pnpm install --ignore-scripts && pnpm build
 
 FROM node:22.12.0-alpine3.19
 WORKDIR /opt


### PR DESCRIPTION
<img width="532" alt="image" src="https://github.com/user-attachments/assets/f79c48db-7b0e-4b2b-b256-8abddc6454e8" />
