### PR TITLE
fix(4589): add a command to install keycloak-admin to nats-provision docker file

### DIFF
--- a/localdev/nats-provision/Dockerfile
+++ b/localdev/nats-provision/Dockerfile
@@ -6,7 +6,9 @@ COPY nats-provision ./context
 COPY _packages ./_packages
 
 RUN npm install -g turbo pnpm
-RUN cd context && pnpm install --ignore-scripts && pnpm build
+RUN cd context && pnpm install --ignore-scripts
+RUN cd _packages/keycloak-admin && pnpm install --ignore-scripts && pnpm build
+RUN cd context && pnpm build
 
 FROM node:22.12.0-alpine3.19
 WORKDIR /opt


### PR DESCRIPTION
<img width="393" alt="image" src="https://github.com/user-attachments/assets/85641b3c-c467-46ab-9073-5bb2aced7979" />
