### PR TITLE
fix(4602): revert the nodejs upgrade 22.12 to 22.10

### DIFF
--- a/.github/actions/setup-npm/action.yml
+++ b/.github/actions/setup-npm/action.yml
@@ -17,10 +17,10 @@ runs:
         ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
 
   - name: Install Root NPM packages
-    run: pnpm install
+    run: pnpm install --no-frozen-lockfile
     shell: bash
 
   - name: Install App NPM packages
-    run: pnpm install
+    run: pnpm install --no-frozen-lockfile
     shell: bash
     working-directory: app

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-nodejs 22.12.0
+nodejs 22.10.0
 python 3.13.1
 pnpm 9.15.1
 oc 4.13.3

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ dev:
 
 .PHONY: install
 install:
-	pnpm install
+	pnpm install --no-frozen-lockfile
 	npm install --prefix app
 	npm install --prefix data-migrations
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,7 +1,7 @@
 ARG deployment_tag
 
 # 1st stage to build the image
-FROM node:22.12.0-alpine3.19 as build
+FROM node:22.10.0-alpine3.19 as build
 
 WORKDIR /app
 
@@ -21,7 +21,7 @@ RUN pnpm build
 
 # 2nd stage to copy image and create a smaller final image
 # FROM gcr.io/distroless/nodejs18-debian12
-FROM node:22.12.0-alpine3.19
+FROM node:22.10.0-alpine3.19
 
 WORKDIR /app
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -15,7 +15,7 @@ ENV SECURE_HEADERS=true \
   DEPLOYMENT_TAG=${deployment_tag}
 
 RUN npm install -g turbo pnpm
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --no-frozen-lockfile --frozen-lockfile
 RUN npx ts-node scripts/render-react-email-tailwind-style.ts
 RUN pnpm build
 

--- a/app/Dockerfile.db
+++ b/app/Dockerfile.db
@@ -1,4 +1,4 @@
-FROM node:22.12.0-alpine3.19
+FROM node:22.10.0-alpine3.19
 
 WORKDIR /app
 

--- a/app/Dockerfile.email
+++ b/app/Dockerfile.email
@@ -1,5 +1,5 @@
 # 1st stage to build the image
-FROM node:22.12.0-alpine3.19 AS build
+FROM node:22.10.0-alpine3.19 AS build
 
 WORKDIR /app
 
@@ -17,7 +17,7 @@ RUN pnpm email-build
 RUN mkdir -p .react-email/public
 
 # 2nd stage to copy image and create a smaller final image
-FROM node:22.12.0-alpine3.19
+FROM node:22.10.0-alpine3.19
 
 WORKDIR /app
 

--- a/app/Dockerfile.email
+++ b/app/Dockerfile.email
@@ -12,7 +12,7 @@ COPY .prettierrc .
 ENV BASE_URL=https://dev-pltsvc.apps.silver.devops.gov.bc.ca
 
 RUN npm install -g turbo pnpm
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --no-frozen-lockfile --frozen-lockfile
 RUN pnpm email-build
 RUN mkdir -p .react-email/public
 

--- a/app/package.json
+++ b/app/package.json
@@ -104,7 +104,7 @@
     "@types/jwk-to-pem": "^2.0.3",
     "@types/jws": "^3.2.9",
     "@types/lodash-es": "^4.17.12",
-    "@types/node": "^22.0.0",
+    "@types/node": "^20.11.24",
     "@types/sanitize-html": "^2.13.0",
     "@typescript-eslint/eslint-plugin": "^7.2.0",
     "@typescript-eslint/parser": "^7.2.0",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -238,8 +238,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: ^22.0.0
-        version: 22.10.2
+        specifier: ^20.14.1
+        version: 20.17.10
       '@types/sanitize-html':
         specifier: ^2.13.0
         version: 2.13.0
@@ -1728,8 +1728,8 @@ packages:
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
-  '@types/node@22.10.2':
-    resolution: {integrity: sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==}
+  '@types/node@20.17.10':
+    resolution: {integrity: sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -5027,8 +5027,8 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@6.20.0:
-    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   update-browserslist-db@1.1.1:
     resolution: {integrity: sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==}
@@ -6874,9 +6874,9 @@ snapshots:
 
   '@types/mdurl@2.0.0': {}
 
-  '@types/node@22.10.2':
+  '@types/node@20.17.10':
     dependencies:
-      undici-types: 6.20.0
+      undici-types: 6.19.8
 
   '@types/parse-json@4.0.2': {}
 
@@ -10952,7 +10952,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@6.20.0: {}
+  undici-types@6.19.8: {}
 
   update-browserslist-db@1.1.1(browserslist@4.24.2):
     dependencies:

--- a/data-migrations/Dockerfile
+++ b/data-migrations/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12.0-alpine3.19
+FROM node:22.10.0-alpine3.19
 
 WORKDIR /app
 

--- a/data-migrations/Dockerfile
+++ b/data-migrations/Dockerfile
@@ -6,7 +6,7 @@ COPY ["package.json", "pnpm-lock.yaml", "migrate-mongo-config.js", "./"]
 COPY migrations migrations
 
 RUN npm install -g turbo pnpm
-RUN pnpm install --ignore-scripts
+RUN pnpm install --no-frozen-lockfile --ignore-scripts
 
 USER node
 

--- a/localdev/_packages/keycloak-admin/package.json
+++ b/localdev/_packages/keycloak-admin/package.json
@@ -13,7 +13,7 @@
     "@keycloak/keycloak-admin-client": "^26.0.0"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
+    "@types/node": "^20.14.1",
     "rimraf": "^6.0.0",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",

--- a/localdev/_packages/keycloak-admin/pnpm-lock.yaml
+++ b/localdev/_packages/keycloak-admin/pnpm-lock.yaml
@@ -13,14 +13,14 @@ importers:
         version: 26.0.7
     devDependencies:
       '@types/node':
-        specifier: ^22.0.0
-        version: 22.10.2
+        specifier: ^20.14.1
+        version: 20.17.10
       rimraf:
         specifier: ^6.0.0
         version: 6.0.1
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.10.2)(typescript@5.7.2)
+        version: 10.9.2(@types/node@20.17.10)(typescript@5.7.2)
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
@@ -64,8 +64,8 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
-  '@types/node@22.10.2':
-    resolution: {integrity: sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==}
+  '@types/node@20.17.10':
+    resolution: {integrity: sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==}
 
   acorn-walk@8.3.4:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
@@ -246,8 +246,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.20.0:
-    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   url-join@5.0.0:
     resolution: {integrity: sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==}
@@ -315,9 +315,9 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@types/node@22.10.2':
+  '@types/node@20.17.10':
     dependencies:
-      undici-types: 6.20.0
+      undici-types: 6.19.8
 
   acorn-walk@8.3.4:
     dependencies:
@@ -447,14 +447,14 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
-  ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2):
+  ts-node@10.9.2(@types/node@20.17.10)(typescript@5.7.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.10.2
+      '@types/node': 20.17.10
       acorn: 8.14.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -473,7 +473,7 @@ snapshots:
 
   typescript@5.7.2: {}
 
-  undici-types@6.20.0: {}
+  undici-types@6.19.8: {}
 
   url-join@5.0.0: {}
 

--- a/localdev/ches-mock/Dockerfile
+++ b/localdev/ches-mock/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12.0-alpine3.19 AS build
+FROM node:22.10.0-alpine3.19 AS build
 WORKDIR /opt
 
 COPY ches-mock ./context
@@ -6,7 +6,7 @@ COPY ches-mock ./context
 RUN npm install -g turbo pnpm
 RUN cd context && pnpm install --ignore-scripts && pnpm build
 
-FROM node:22.12.0-alpine3.19
+FROM node:22.10.0-alpine3.19
 WORKDIR /opt
 
 COPY --from=build /opt/context/build ./

--- a/localdev/ches-mock/Dockerfile
+++ b/localdev/ches-mock/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /opt
 COPY ches-mock ./context
 
 RUN npm install -g turbo pnpm
-RUN cd context && pnpm install --ignore-scripts && pnpm build
+RUN cd context && pnpm install --no-frozen-lockfile --ignore-scripts && pnpm build
 
 FROM node:22.10.0-alpine3.19
 WORKDIR /opt

--- a/localdev/ches-mock/package.json
+++ b/localdev/ches-mock/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@types/express": "^5.0.0",
-    "@types/node": "^22.0.0",
+    "@types/node": "^20.14.1",
     "@types/nodemailer": "^6.4.17",
     "@types/sanitize-html": "^2.13.0",
     "rimraf": "^6.0.0",

--- a/localdev/ches-mock/pnpm-lock.yaml
+++ b/localdev/ches-mock/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       '@types/node':
-        specifier: ^22.0.0
-        version: 22.10.2
+        specifier: ^20.14.1
+        version: 20.17.10
       '@types/nodemailer':
         specifier: ^6.4.17
         version: 6.4.17
@@ -211,8 +211,8 @@ packages:
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
-  '@types/node@22.10.2':
-    resolution: {integrity: sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==}
+  '@types/node@20.17.10':
+    resolution: {integrity: sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==}
 
   '@types/nodemailer@6.4.17':
     resolution: {integrity: sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==}
@@ -738,8 +738,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.20.0:
-    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -858,15 +858,15 @@ snapshots:
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.10.2
+      '@types/node': 20.17.10
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 20.17.10
 
   '@types/express-serve-static-core@5.0.2':
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 20.17.10
       '@types/qs': 6.9.17
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -882,9 +882,9 @@ snapshots:
 
   '@types/mime@1.3.5': {}
 
-  '@types/node@22.10.2':
+  '@types/node@20.17.10':
     dependencies:
-      undici-types: 6.20.0
+      undici-types: 6.19.8
 
   '@types/nodemailer@6.4.17':
     dependencies:
@@ -901,12 +901,12 @@ snapshots:
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.10.2
+      '@types/node': 20.17.10
 
   '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 22.10.2
+      '@types/node': 20.17.10
       '@types/send': 0.17.4
 
   accepts@2.0.0:
@@ -1449,7 +1449,7 @@ snapshots:
 
   typescript@5.7.2: {}
 
-  undici-types@6.20.0: {}
+  undici-types@6.19.8: {}
 
   unpipe@1.0.0: {}
 

--- a/localdev/keycloak-provision/Dockerfile
+++ b/localdev/keycloak-provision/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12.0-alpine3.19 AS build
+FROM node:22.10.0-alpine3.19 AS build
 WORKDIR /opt
 
 COPY ["mock-users.json", "types.ts", "./"]
@@ -8,7 +8,7 @@ COPY _packages ./_packages
 RUN npm install -g turbo pnpm
 RUN cd context && pnpm install --ignore-scripts && pnpm build
 
-FROM node:22.12.0-alpine3.19
+FROM node:22.10.0-alpine3.19
 WORKDIR /opt
 
 COPY --from=build /opt/context/build ./

--- a/localdev/keycloak-provision/Dockerfile
+++ b/localdev/keycloak-provision/Dockerfile
@@ -6,7 +6,9 @@ COPY keycloak-provision ./context
 COPY _packages ./_packages
 
 RUN npm install -g turbo pnpm
-RUN cd context && pnpm install --ignore-scripts && pnpm build
+RUN cd context && pnpm install --ignore-scripts
+RUN cd _packages/keycloak-admin && pnpm install --ignore-scripts && pnpm build
+RUN cd context && pnpm build
 
 FROM node:22.10.0-alpine3.19
 WORKDIR /opt

--- a/localdev/keycloak-provision/Dockerfile
+++ b/localdev/keycloak-provision/Dockerfile
@@ -6,8 +6,8 @@ COPY keycloak-provision ./context
 COPY _packages ./_packages
 
 RUN npm install -g turbo pnpm
-RUN cd context && pnpm install --ignore-scripts
-RUN cd _packages/keycloak-admin && pnpm install --ignore-scripts && pnpm build
+RUN cd context && pnpm install --no-frozen-lockfile --ignore-scripts
+RUN cd _packages/keycloak-admin && pnpm install --no-frozen-lockfile --ignore-scripts && pnpm build
 RUN cd context && pnpm build
 
 FROM node:22.10.0-alpine3.19

--- a/localdev/keycloak-provision/package.json
+++ b/localdev/keycloak-provision/package.json
@@ -12,7 +12,7 @@
     "wait-on": "^8.0.0"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
+    "@types/node": "^20.14.1",
     "@types/wait-on": "^5.3.4",
     "rimraf": "^6.0.0",
     "tsx": "^4.11.2",

--- a/localdev/keycloak-provision/pnpm-lock.yaml
+++ b/localdev/keycloak-provision/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         version: 8.0.1
     devDependencies:
       '@types/node':
-        specifier: ^22.0.0
-        version: 22.10.2
+        specifier: ^20.14.1
+        version: 20.17.10
       '@types/wait-on':
         specifier: ^5.3.4
         version: 5.3.4
@@ -200,8 +200,8 @@ packages:
   '@sideway/pinpoint@2.0.0':
     resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
 
-  '@types/node@22.10.2':
-    resolution: {integrity: sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==}
+  '@types/node@20.17.10':
+    resolution: {integrity: sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==}
 
   '@types/wait-on@5.3.4':
     resolution: {integrity: sha512-EBsPjFMrFlMbbUFf9D1Fp+PAB2TwmUn7a3YtHyD9RLuTIk1jDd8SxXVAoez2Ciy+8Jsceo2MYEYZzJ/DvorOKw==}
@@ -407,8 +407,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.20.0:
-    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   url-join@5.0.0:
     resolution: {integrity: sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==}
@@ -539,9 +539,9 @@ snapshots:
 
   '@sideway/pinpoint@2.0.0': {}
 
-  '@types/node@22.10.2':
+  '@types/node@20.17.10':
     dependencies:
-      undici-types: 6.20.0
+      undici-types: 6.19.8
 
   '@types/wait-on@5.3.4':
     dependencies:
@@ -750,7 +750,7 @@ snapshots:
 
   typescript@5.7.2: {}
 
-  undici-types@6.20.0: {}
+  undici-types@6.19.8: {}
 
   url-join@5.0.0: {}
 

--- a/localdev/m365mock/Dockerfile
+++ b/localdev/m365mock/Dockerfile
@@ -5,7 +5,7 @@ COPY ["mock-users.json", "types.ts", "./"]
 COPY m365mock ./context
 
 RUN npm install -g turbo pnpm
-RUN cd context && pnpm install --ignore-scripts && pnpm build
+RUN cd context && pnpm install --no-frozen-lockfile --ignore-scripts && pnpm build
 
 FROM node:22.10.0-alpine3.19
 WORKDIR /opt

--- a/localdev/m365mock/Dockerfile
+++ b/localdev/m365mock/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12.0-alpine3.19 AS build
+FROM node:22.10.0-alpine3.19 AS build
 WORKDIR /opt
 
 COPY ["mock-users.json", "types.ts", "./"]
@@ -7,7 +7,7 @@ COPY m365mock ./context
 RUN npm install -g turbo pnpm
 RUN cd context && pnpm install --ignore-scripts && pnpm build
 
-FROM node:22.12.0-alpine3.19
+FROM node:22.10.0-alpine3.19
 WORKDIR /opt
 
 COPY --from=build /opt/context/build ./

--- a/localdev/m365mock/package.json
+++ b/localdev/m365mock/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.0",
-    "@types/node": "^22.0.0",
+    "@types/node": "^20.14.1",
     "rimraf": "^6.0.0",
     "tsx": "^4.15.4",
     "typescript": "^5.4.5"

--- a/localdev/m365mock/pnpm-lock.yaml
+++ b/localdev/m365mock/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       '@types/node':
-        specifier: ^22.0.0
-        version: 22.10.2
+        specifier: ^20.14.1
+        version: 20.17.10
       rimraf:
         specifier: ^6.0.0
         version: 6.0.1
@@ -196,8 +196,8 @@ packages:
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
-  '@types/node@22.10.2':
-    resolution: {integrity: sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==}
+  '@types/node@20.17.10':
+    resolution: {integrity: sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==}
 
   '@types/qs@6.9.17':
     resolution: {integrity: sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ==}
@@ -646,8 +646,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.20.0:
-    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -787,9 +787,9 @@ snapshots:
 
   '@types/mime@1.3.5': {}
 
-  '@types/node@22.10.2':
+  '@types/node@20.17.10':
     dependencies:
-      undici-types: 6.20.0
+      undici-types: 6.19.8
 
   '@types/qs@6.9.17': {}
 
@@ -1273,7 +1273,7 @@ snapshots:
 
   typescript@5.7.2: {}
 
-  undici-types@6.20.0: {}
+  undici-types@6.19.8: {}
 
   unpipe@1.0.0: {}
 

--- a/localdev/nats-provision/Dockerfile
+++ b/localdev/nats-provision/Dockerfile
@@ -6,8 +6,8 @@ COPY nats-provision ./context
 COPY _packages ./_packages
 
 RUN npm install -g turbo pnpm
-RUN cd context && pnpm install --ignore-scripts
-RUN cd _packages/keycloak-admin && pnpm install --ignore-scripts && pnpm build
+RUN cd context && pnpm install --no-frozen-lockfile --ignore-scripts
+RUN cd _packages/keycloak-admin && pnpm install --no-frozen-lockfile --ignore-scripts && pnpm build
 RUN cd context && pnpm build
 
 FROM node:22.10.0-alpine3.19

--- a/localdev/nats-provision/Dockerfile
+++ b/localdev/nats-provision/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12.0-alpine3.19 AS build
+FROM node:22.10.0-alpine3.19 AS build
 WORKDIR /opt
 
 COPY ["mock-users.json", "types.ts", "./"]
@@ -10,7 +10,7 @@ RUN cd context && pnpm install --ignore-scripts
 RUN cd _packages/keycloak-admin && pnpm install --ignore-scripts && pnpm build
 RUN cd context && pnpm build
 
-FROM node:22.12.0-alpine3.19
+FROM node:22.10.0-alpine3.19
 WORKDIR /opt
 
 COPY --from=build /opt/context/build ./

--- a/localdev/nats-provision/package.json
+++ b/localdev/nats-provision/package.json
@@ -13,7 +13,7 @@
     "wait-on": "^8.0.0"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
+    "@types/node": "^20.14.1",
     "@types/wait-on": "^5.3.4",
     "rimraf": "^6.0.0",
     "tsx": "^4.11.2",

--- a/localdev/nats-provision/pnpm-lock.yaml
+++ b/localdev/nats-provision/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         version: 8.0.1
     devDependencies:
       '@types/node':
-        specifier: ^22.0.0
-        version: 22.10.2
+        specifier: ^20.14.1
+        version: 20.17.10
       '@types/wait-on':
         specifier: ^5.3.4
         version: 5.3.4
@@ -203,8 +203,8 @@ packages:
   '@sideway/pinpoint@2.0.0':
     resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
 
-  '@types/node@22.10.2':
-    resolution: {integrity: sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==}
+  '@types/node@20.17.10':
+    resolution: {integrity: sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==}
 
   '@types/wait-on@5.3.4':
     resolution: {integrity: sha512-EBsPjFMrFlMbbUFf9D1Fp+PAB2TwmUn7a3YtHyD9RLuTIk1jDd8SxXVAoez2Ciy+8Jsceo2MYEYZzJ/DvorOKw==}
@@ -421,8 +421,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.20.0:
-    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   url-join@5.0.0:
     resolution: {integrity: sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==}
@@ -553,9 +553,9 @@ snapshots:
 
   '@sideway/pinpoint@2.0.0': {}
 
-  '@types/node@22.10.2':
+  '@types/node@20.17.10':
     dependencies:
-      undici-types: 6.20.0
+      undici-types: 6.19.8
 
   '@types/wait-on@5.3.4':
     dependencies:
@@ -774,7 +774,7 @@ snapshots:
 
   typescript@5.7.2: {}
 
-  undici-types@6.20.0: {}
+  undici-types@6.19.8: {}
 
   url-join@5.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -680,8 +680,8 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
-  '@types/node@22.10.2':
-    resolution: {integrity: sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==}
+  '@types/node@20.17.10':
+    resolution: {integrity: sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -3825,8 +3825,8 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@6.20.0:
-    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   undici@5.28.4:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
@@ -4769,9 +4769,9 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
-  '@types/node@22.10.2':
+  '@types/node@20.17.10':
     dependencies:
-      undici-types: 6.20.0
+      undici-types: 6.19.8
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -8325,7 +8325,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@6.20.0: {}
+  undici-types@6.19.8: {}
 
   undici@5.28.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 2.2.4(esbuild@0.23.1)
       '@commitlint/cli':
         specifier: ^19.5.0
-        version: 19.6.1(@types/node@22.10.2)(typescript@5.7.2)
+        version: 19.6.1(@types/node@20.17.10)(typescript@5.7.2)
       '@commitlint/config-conventional':
         specifier: ^19.5.0
         version: 19.6.0
@@ -4205,11 +4205,11 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commitlint/cli@19.6.1(@types/node@22.10.2)(typescript@5.7.2)':
+  '@commitlint/cli@19.6.1(@types/node@20.17.10)(typescript@5.7.2)':
     dependencies:
       '@commitlint/format': 19.5.0
       '@commitlint/lint': 19.6.0
-      '@commitlint/load': 19.6.1(@types/node@22.10.2)(typescript@5.7.2)
+      '@commitlint/load': 19.6.1(@types/node@20.17.10)(typescript@5.7.2)
       '@commitlint/read': 19.5.0
       '@commitlint/types': 19.5.0
       tinyexec: 0.3.1
@@ -4256,7 +4256,7 @@ snapshots:
       '@commitlint/rules': 19.6.0
       '@commitlint/types': 19.5.0
 
-  '@commitlint/load@19.6.1(@types/node@22.10.2)(typescript@5.7.2)':
+  '@commitlint/load@19.6.1(@types/node@20.17.10)(typescript@5.7.2)':
     dependencies:
       '@commitlint/config-validator': 19.5.0
       '@commitlint/execute-rule': 19.5.0
@@ -4264,7 +4264,7 @@ snapshots:
       '@commitlint/types': 19.5.0
       chalk: 5.4.1
       cosmiconfig: 9.0.0(typescript@5.7.2)
-      cosmiconfig-typescript-loader: 6.1.0(@types/node@22.10.2)(cosmiconfig@9.0.0(typescript@5.7.2))(typescript@5.7.2)
+      cosmiconfig-typescript-loader: 6.1.0(@types/node@20.17.10)(cosmiconfig@9.0.0(typescript@5.7.2))(typescript@5.7.2)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -4338,7 +4338,7 @@ snapshots:
       '@cucumber/ci-environment': 10.0.1
       '@cucumber/cucumber-expressions': 17.1.0
       '@cucumber/gherkin': 28.0.0
-      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@24.1.0))(@cucumber/messages@24.1.0)
+      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@27.0.2))(@cucumber/messages@24.1.0)
       '@cucumber/gherkin-utils': 9.0.0
       '@cucumber/html-formatter': 21.6.0(@cucumber/messages@24.1.0)
       '@cucumber/junit-xml-formatter': 0.6.0(@cucumber/messages@24.1.0)
@@ -4377,7 +4377,7 @@ snapshots:
       yaml: 2.6.1
       yup: 1.2.0
 
-  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@24.1.0))(@cucumber/messages@24.1.0)':
+  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1(@cucumber/messages@27.0.2))(@cucumber/messages@24.1.0)':
     dependencies:
       '@cucumber/gherkin': 28.0.0
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.1.0)
@@ -4765,7 +4765,7 @@ snapshots:
 
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 20.17.10
 
   '@types/json5@0.0.29': {}
 
@@ -4787,7 +4787,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 20.17.10
     optional: true
 
   '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)':
@@ -5467,9 +5467,9 @@ snapshots:
 
   core-util-is@1.0.2: {}
 
-  cosmiconfig-typescript-loader@6.1.0(@types/node@22.10.2)(cosmiconfig@9.0.0(typescript@5.7.2))(typescript@5.7.2):
+  cosmiconfig-typescript-loader@6.1.0(@types/node@20.17.10)(cosmiconfig@9.0.0(typescript@5.7.2))(typescript@5.7.2):
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 20.17.10
       cosmiconfig: 9.0.0(typescript@5.7.2)
       jiti: 2.4.1
       typescript: 5.7.2


### PR DESCRIPTION
The Dev and Test Deployment started failing somewhere between Dec 19 and Dec 31. We are reverting some of the changes made by renovate bot to fix it.