### PR TITLE
fix(6058): add hardcoded LP and cluster for local getQuotaChangeStatus

### DIFF
--- a/app/app/api/private-cloud/products/[licencePlate]/quota-change-status/route.ts
+++ b/app/app/api/private-cloud/products/[licencePlate]/quota-change-status/route.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { IS_PROD, IS_TEST } from '@/config';
 import { GlobalRole } from '@/constants';
 import createApiHandler from '@/core/api-handler';
 import { OkResponse, UnauthorizedResponse } from '@/core/responses';
@@ -22,6 +23,7 @@ const apiHandler = createApiHandler({
 export const POST = apiHandler(async ({ session, pathParams, body }) => {
   const { licencePlate } = pathParams;
   const { resourceRequests } = body;
+  const isLocal = !(IS_PROD || IS_TEST);
 
   const { data: currentProduct } = await models.privateCloudProduct.get(
     {
@@ -39,8 +41,8 @@ export const POST = apiHandler(async ({ session, pathParams, body }) => {
   }
 
   const quotaChangeStatus = await getQuotaChangeStatus({
-    licencePlate,
-    cluster: currentProduct.cluster,
+    licencePlate: isLocal ? 'e3913e' : licencePlate,
+    cluster: isLocal ? 'KLAB' : currentProduct.cluster,
     currentResourceRequests: currentProduct.resourceRequests,
     requestedResourceRequests: resourceRequests,
   });


### PR DESCRIPTION
need to add `KLAB_METRICS_READER_TOKEN`. to `.env.local` 