### PR TITLE
docs(devxt-2909): updated developer docs and associated dev scripts

### DIFF
--- a/.bin/copy-db.sh
+++ b/.bin/copy-db.sh
@@ -16,8 +16,8 @@ mkdir -p "$tmp_dir"
 
 pod_name=$(oc get pods | grep pltsvc-db-backup- | awk '{print $1}')
 
-if [ -z "$pod_name" ]; then
-    echo "No pod found matching 'pltsvc-db-backup-'"
+if [[ -z $pod_name ]]; then
+    echo "No pod found matching 'pltsvc-db-backup-'" >&2
     exit 1
 fi
 
@@ -26,8 +26,8 @@ echo "Pod name: $pod_name"
 # Get the most recent file from the backup directory in the pod
 recent_file=$(oc exec "$pod_name" -- sh -c 'ls -t backup | head -n 1')
 
-if [ -z "$recent_file" ]; then
-    echo "No files found in /backup directory of the pod"
+if [[ -z $recent_file ]]; then
+    echo "No files found in /backup directory of the pod" >&2
     exit 1
 fi
 
@@ -41,17 +41,17 @@ echo "Source file size: $pod_file_size bytes"
 oc cp "$pod_name:backup/$recent_file" "$tmp_dir/$recent_file"
 
 # Verify the copy was successful
-if [ ! -f "$tmp_dir/$recent_file" ]; then
-    echo "Error: Failed to copy file from pod"
+if [[ ! -f "$tmp_dir/$recent_file" ]]; then
+    echo "Error: Failed to copy file from pod" >&2
     exit 1
 fi
 
 local_file_size=$(stat -f%z "$tmp_dir/$recent_file" 2>/dev/null || stat -c %s "$tmp_dir/$recent_file" 2>/dev/null)
 echo "Local file size: $local_file_size bytes"
 
-if [ "$pod_file_size" != "$local_file_size" ]; then
-    echo "Error: File sizes don't match. Copy may be incomplete."
-    echo "Expected: $pod_file_size bytes, Got: $local_file_size bytes"
+if [[ $pod_file_size != "$local_file_size" ]]; then
+    echo "Error: File sizes don't match. Copy may be incomplete." >&2
+    echo "Expected: $pod_file_size bytes, Got: $local_file_size bytes" >&2
     rm -f "$tmp_dir/$recent_file"
     exit 1
 fi

--- a/.bin/copy-db.sh
+++ b/.bin/copy-db.sh
@@ -35,7 +35,11 @@ echo "Most recent file: $recent_file"
 
 # Copy the most recent back file to unarchive into the sandbox database
 # Verify file size before and after copy to detect incomplete transfers
-pod_file_size=$(oc exec "$pod_name" -- sh -c "stat -c %s backup/$recent_file 2>/dev/null")
+pod_file_size=$(oc exec "$pod_name" -- sh -c "stat -c %s 'backup/$recent_file' 2>/dev/null || stat -f%z 'backup/$recent_file' 2>/dev/null" || true)
+if [[ ! $pod_file_size =~ ^[0-9]+$ ]]; then
+    echo "Error: Unable to determine source file size for backup/$recent_file" >&2
+    exit 1
+fi
 echo "Source file size: $pod_file_size bytes"
 
 oc cp "$pod_name:backup/$recent_file" "$tmp_dir/$recent_file"
@@ -46,10 +50,15 @@ if [[ ! -f "$tmp_dir/$recent_file" ]]; then
     exit 1
 fi
 
-local_file_size=$(stat -f%z "$tmp_dir/$recent_file" 2>/dev/null || stat -c %s "$tmp_dir/$recent_file" 2>/dev/null)
+local_file_size=$(stat -f%z "$tmp_dir/$recent_file" 2>/dev/null || stat -c %s "$tmp_dir/$recent_file" 2>/dev/null || true)
+if [[ ! $local_file_size =~ ^[0-9]+$ ]]; then
+    echo "Error: Unable to determine local file size for $tmp_dir/$recent_file" >&2
+    rm -f "$tmp_dir/$recent_file"
+    exit 1
+fi
 echo "Local file size: $local_file_size bytes"
 
-if [[ $pod_file_size != "$local_file_size" ]]; then
+if [[ $pod_file_size -ne $local_file_size ]]; then
     echo "Error: File sizes don't match. Copy may be incomplete." >&2
     echo "Expected: $pod_file_size bytes, Got: $local_file_size bytes" >&2
     rm -f "$tmp_dir/$recent_file"

--- a/.bin/copy-db.sh
+++ b/.bin/copy-db.sh
@@ -10,9 +10,6 @@ base_url_with_db="${DATABASE_URL%%\?*}"
 url="${base_url_with_db%/*}"
 database="${base_url_with_db##*/}"
 
-asdf plugin add database-tools https://github.com/egose/asdf-database-tools.git
-asdf install database-tools
-
 tmp_dir="tmp/backup"
 
 mkdir -p "$tmp_dir"
@@ -37,5 +34,27 @@ fi
 echo "Most recent file: $recent_file"
 
 # Copy the most recent back file to unarchive into the sandbox database
+# Verify file size before and after copy to detect incomplete transfers
+pod_file_size=$(oc exec "$pod_name" -- sh -c "stat -c %s backup/$recent_file 2>/dev/null")
+echo "Source file size: $pod_file_size bytes"
+
 oc cp "$pod_name:backup/$recent_file" "$tmp_dir/$recent_file"
+
+# Verify the copy was successful
+if [ ! -f "$tmp_dir/$recent_file" ]; then
+    echo "Error: Failed to copy file from pod"
+    exit 1
+fi
+
+local_file_size=$(stat -f%z "$tmp_dir/$recent_file" 2>/dev/null || stat -c %s "$tmp_dir/$recent_file" 2>/dev/null)
+echo "Local file size: $local_file_size bytes"
+
+if [ "$pod_file_size" != "$local_file_size" ]; then
+    echo "Error: File sizes don't match. Copy may be incomplete."
+    echo "Expected: $pod_file_size bytes, Got: $local_file_size bytes"
+    rm -f "$tmp_dir/$recent_file"
+    exit 1
+fi
+
+echo "File copy verified. Starting mongo-unarchive..."
 mongo-unarchive --uri="$url/?authSource=admin" --db="$database" --local-path="$tmp_dir"

--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -5,10 +5,11 @@ runs:
   using: composite
   steps:
   - name: Setup Tools
-    uses: egose/actions/asdf-tools@9a09f2377dc8c8b8f8cfacc5f695448999670434
+    uses: egose/actions/asdf-tools@68448c0027aeafe0a824f6c9b33fd875e77b844c # v0.9.0
     with:
       plugins: |
         sonarscanner=https://github.com/virtualstaticvoid/asdf-sonarscanner.git
+        database-tools=https://github.com/egose/asdf-database-tools.git
 
   - name: Install python tools
     run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -9,5 +9,6 @@ shfmt 3.13.1
 act 0.2.89
 jq 1.7.1
 mongodb-database-tools 0.11.1
+database-tools 0.12.3
 kube-linter 0.7.4
 shellcheck 0.11.0

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,18 @@
 SHELL := /usr/bin/env bash
 
+# Sandbox detach flag, set to true to run docker-compose in detached mode
+SBD ?= false
+DETACH_FLAG := $(if $(filter true 1 yes,$(SBD)),-d,)
+
 .PHONY: sandbox
 sandbox:
 	export MACHINE_HOST_IP=$$(hostname -I | awk '{print $$1}'); \
-	docker-compose -f ./sandbox/docker-compose.yml up --build --remove-orphans
+	docker-compose -f ./sandbox/docker-compose.yml up $(DETACH_FLAG) --build --remove-orphans
 
 .PHONY: localmac
 localmac:
 	export MACHINE_HOST_IP=$$(ipconfig getifaddr en0); \
-	docker-compose -f ./sandbox/docker-compose.yml -f ./sandbox/docker-compose-arm64.yml up --build --remove-orphans
+	docker-compose -f ./sandbox/docker-compose.yml -f ./sandbox/docker-compose-arm64.yml up $(DETACH_FLAG) --build --remove-orphans
 
 .PHONY: dev
 dev:

--- a/docs/development-setup/local-development-environment.md
+++ b/docs/development-setup/local-development-environment.md
@@ -71,9 +71,9 @@ git config gpg.program gpg
         ```
 1. Install `asdf` packages defined in `.tool-versions`.
     ```sh
-    cat .tool-versions | cut -f 1 -d ' ' | xargs -n 1 asdf plugin-add || true
-    asdf plugin-add docker-compose https://github.com/virtualstaticvoid/asdf-docker-compose.git || true
-    asdf plugin-update --all
+    cat .tool-versions | cut -f 1 -d ' ' | xargs -n 1 asdf plugin add || true
+    asdf plugin add docker-compose https://github.com/virtualstaticvoid/asdf-docker-compose.git || true
+    asdf plugin update --all
     asdf install
     asdf reshim
     ```

--- a/docs/development-setup/running-locally.md
+++ b/docs/development-setup/running-locally.md
@@ -11,6 +11,10 @@ How to run the app locally:
 1. `make copy-db`
 1. `make dev`
 
+## Login
+
+Login using one of the users found in the [mock-users.json](https://github.com/bcgov/platform-services-registry/blob/main/sandbox/mock-users.json) file. The password is the email address.
+
 ## Troubleshooting
 
 ### Canvas error

--- a/docs/development-setup/sandbox.md
+++ b/docs/development-setup/sandbox.md
@@ -61,7 +61,7 @@ make sandbox
 To run in detached mode:
 
 ```bash
-make sandbox SDB=true
+make sandbox SBD=true
 ```
 
 For Mac M1/M2

--- a/docs/development-setup/sandbox.md
+++ b/docs/development-setup/sandbox.md
@@ -36,53 +36,45 @@ Due to BC Government procurement restrictions, Docker Desktop is not permitted. 
 
 ## Getting Started
 
-1. Switch to sandbox folder
+1. Create three directories to mount volumns for `mongodb`,`postgres` and `mailpit`.
+
+In the root of the project directory:
 
 ```bash
-cd sandbox
-```
-
-2. Create three directories to mount volumns for `mongodb`,`postgres` and `mailpit`.
-
-```bash
-mkdir -p ./mnt/mongodb
-mkdir -p ./mnt/postgres
-mkdir -p ./mnt/mailpit
+mkdir -p sandbox/mnt/mongodb
+mkdir -p sandbox/mnt/postgres
+mkdir -p sandbox/mnt/mailpit
 ```
 
 If you have data version conflict errors due to existing mount volumes, please delete the directories and recreate them.
 
-3. Set environment variable MACHINE_HOST_IP to your ip address using the command
+2. Run the sandbox environment
+
+The Makefile uses docker-compose.
 
 For WSL/Linux:
 
 ```bash
-export MACHINE_HOST_IP=$(hostname -I | awk '{print $1}')
+make sandbox
 ```
 
-or
-For Mac M1/M2:
+To run in detached mode:
 
 ```bash
-export MACHINE_HOST_IP=$(ipconfig getifaddr en0)
+make sandbox SDB=true
 ```
 
-4. To create the sandbox environment, utilize local Docker container instances with `docker-compose`:
-
-For WSL/Linux:
+For Mac M1/M2
 
 ```bash
-docker-compose up --build [-d]
+make localmac
 ```
 
-or
-For Mac M1/M2:
+To run in detached mode:
 
 ```bash
-docker-compose -f docker-compose.yml -f docker-compose-arm64.yml up --build [-d]
+make localmac SBD=true
 ```
-
-You can add the `-d` flag to run the containers in daemon mode.
 
 Ensure that neither `MongoDB` nor `Mongosh` is installed on your local machine, as they may interfere with the database schema managed by Prisma, which connects to the `MongoDB Docker container`. If you have either installed, you can remove them by following the instruction provided in this link: [uninstall mongodb and mongosh](https://www.mongodb.com/resources/products/fundamentals/uninstall-mongodb#:~:text=How%20to%20uninstall%20MongoDB%20from%20Mac%201%20If,the%20below%20command%3A%20brew%20uninstall%20mongodb-community%20%20){target="\_blank" rel="noopener noreferrer"}
 

--- a/docs/development-setup/sandbox.md
+++ b/docs/development-setup/sandbox.md
@@ -36,7 +36,7 @@ Due to BC Government procurement restrictions, Docker Desktop is not permitted. 
 
 ## Getting Started
 
-1. Create three directories to mount volumns for `mongodb`,`postgres` and `mailpit`.
+1. Create three directories to mount volumes for `mongodb`, `postgres` and `mailpit`.
 
 In the root of the project directory:
 


### PR DESCRIPTION
This PR does the following:

* Update the developer docs where commands were failing
* Added instructions on how to get test username/passwords for development
* Updated docs to use the Makefile `sandbox` or `localmac` targets rather than manually setting up docker compose
* Modified Makefile `sandbox` and `localmac` to take a `SBD` flag to optionally run in detached mode
* Updated copy-db script
  * removed asdf tool install to the top level .tool-versions file
  * added error checking of file download
    * Note: The error checking added a bit of code to the copy-db script and I'm totally fine reverting it back to what is was originally
