### PR TITLE
fix failing e2e test

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     "target": "es2016",
     "module": "commonjs",
+    "ignoreDeprecations": "6.0",
+    "baseUrl": ".",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "es2016",
     "module": "commonjs",
     "ignoreDeprecations": "6.0",
-    "baseUrl": ".",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,


### PR DESCRIPTION
This PR fixes the failing e2e test, [example](https://github.com/bcgov/platform-services-registry/actions/runs/27431186452/job/81081679450)

```
TSError: ⨯ Unable to compile TypeScript:
error TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
  Visit https://aka.ms/ts6 for migration information. 
```

This fix is to use the `"ignoreDeprecations": "6.0"` option.

A ticket has been created to actually fix it.

But this PR is a quick fix to run the e2e test in the meantime.

