### PR TITLE
e2e(2924): disable e2e test from running on push

### DIFF
--- a/.github/workflows/cypress-e2e-test.yaml
+++ b/.github/workflows/cypress-e2e-test.yaml
@@ -1,12 +1,12 @@
 name: 32.Run E2E Tests
 
 on:
-  push:
-    paths-ignore:
-    - data-migrations/**
-    - helm/**
-    - terraform/**
-    - tools/**
+  # push:
+  #   paths-ignore:
+  #   - data-migrations/**
+  #   - helm/**
+  #   - terraform/**
+  #   - tools/**
 
   workflow_dispatch:
 


### PR DESCRIPTION
The e2e tests are not working, and have not for a long time.

This PR disables the automatic running of the e2e tests so the failing tests don't show up in the PR checks.

A ticket(2910) has been created to look at fixing or removing the e2e tests
