### PR TITLE
feat(aws-lza): add console login links

### DIFF
--- a/app/app/api/public-cloud/products/_operations/delete.ts
+++ b/app/app/api/public-cloud/products/_operations/delete.ts
@@ -33,7 +33,9 @@ export default async function deleteOp({
     return UnauthorizedResponse();
   }
 
-  const { id, requests, updatedAt, _permissions, archivedAt, ...rest } = product;
+  // awsAccounts is callback metadata stored only on the product. It is not
+  // part of PublicCloudRequestData, so do not copy it into a delete request.
+  const { id, requests, updatedAt, _permissions, archivedAt, awsAccounts, ...rest } = product;
 
   // Retrieve the latest request data to acquire the decision data ID that can be assigned to the incoming request's original data.
   const previousRequest = await getLastEffectivePublicCloudRequest(rest.licencePlate);

--- a/app/app/api/v1/public-cloud/products/[idOrLicencePlate]/provision/route.ts
+++ b/app/app/api/v1/public-cloud/products/[idOrLicencePlate]/provision/route.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod';
+import { getAwsLzaAccountName, publicCloudEnvironmentKeys } from '@/constants/public-cloud';
 import createApiHandler from '@/core/api-handler';
 import { logger } from '@/core/logging';
 import prisma from '@/core/prisma';
 import { NotFoundResponse, OkResponse } from '@/core/responses';
-import { DecisionStatus, Prisma, ProjectStatus, RequestType } from '@/prisma/client';
+import { DecisionStatus, Prisma, ProjectStatus, Provider, RequestType } from '@/prisma/client';
+import { mergeAwsLzaAccounts } from '@/services/aws-lza/accounts';
 import { sendRequestCompletionEmails } from '@/services/ches/public-cloud';
 import { models, publicCloudRequestDetailInclude } from '@/services/db';
 import { upsertPublicCloudBillings } from '@/services/db/public-cloud-billing';
@@ -12,12 +14,35 @@ const pathParamSchema = z.object({
   idOrLicencePlate: z.string().max(7),
 });
 
+const bodySchema = z.object({
+  awsAccounts: z
+    .array(
+      z.object({
+        environment: z.enum(publicCloudEnvironmentKeys),
+        name: z.string().min(1).optional(),
+        accountId: z.string().min(1),
+      }),
+    )
+    .optional()
+    .default([]),
+});
+
 const apiHandler = createApiHandler({
   roles: ['service-account public-admin'],
   useServiceAccount: true,
-  validations: { pathParams: pathParamSchema },
+  validations: { pathParams: pathParamSchema, body: bodySchema },
 });
-export const POST = apiHandler(async ({ pathParams, session }) => {
+
+async function getExistingAwsAccounts(licencePlate: string) {
+  const product = await prisma.publicCloudProduct.findUnique({
+    where: { licencePlate },
+    select: { awsAccounts: true },
+  });
+
+  return product?.awsAccounts;
+}
+
+export const POST = apiHandler(async ({ pathParams, session, body }) => {
   const { idOrLicencePlate: licencePlate } = pathParams;
 
   const request = await prisma.publicCloudRequest.findFirst({
@@ -49,8 +74,26 @@ export const POST = apiHandler(async ({ pathParams, session }) => {
 
   const { id, ...decisionData } = request.decisionData;
 
-  // Upsert the project with the requested project data. If admin requested project data exists, use that instead.
   const filter = { licencePlate };
+  let awsAccountData = {};
+
+  if (request.type !== RequestType.DELETE && decisionData.provider === Provider.AWS_LZA) {
+    const callbackAwsAccounts = body.awsAccounts.map((account) => ({
+      ...account,
+      name: account.name ?? getAwsLzaAccountName(licencePlate, account.environment),
+    }));
+
+    awsAccountData = {
+      awsAccounts: mergeAwsLzaAccounts(
+        await getExistingAwsAccounts(licencePlate),
+        callbackAwsAccounts,
+      ) as unknown as Prisma.InputJsonValue,
+    };
+  }
+
+  const productData = { ...decisionData, ...awsAccountData };
+
+  // Upsert the project with the requested project data. If admin requested project data exists, use that instead.
   const upsertProject =
     request.type === RequestType.DELETE
       ? prisma.publicCloudProduct.update({
@@ -59,8 +102,8 @@ export const POST = apiHandler(async ({ pathParams, session }) => {
         })
       : prisma.publicCloudProduct.upsert({
           where: filter,
-          update: decisionData,
-          create: decisionData,
+          update: productData,
+          create: productData,
         });
 
   const [updatedRequest] = await Promise.all([updateRequest, upsertProject]);

--- a/app/app/public-cloud/products/(product)/[licencePlate]/edit/page.tsx
+++ b/app/app/public-cloud/products/(product)/[licencePlate]/edit/page.tsx
@@ -16,6 +16,7 @@ import { openPublicCloudProductEditSubmitModal } from '@/components/modal/public
 import TeamContacts from '@/components/public-cloud/sections/TeamContacts';
 import { GlobalRole } from '@/constants';
 import createClientPage from '@/core/client-page';
+import { normalizeStoredAwsLzaAccounts } from '@/services/aws-lza/accounts';
 import { usePublicProductState } from '@/states/global';
 import { publicCloudEditRequestBodySchema } from '@/validation-schemas/public-cloud';
 
@@ -82,7 +83,12 @@ export default publicCloudProductEdit(() => {
       label: 'Accounts to create',
       description: '',
       Component: AccountEnvironmentsPublic,
-      componentArgs: { selected: currentProduct.environmentsEnabled, mode: 'edit', disabled: isDisabled },
+      componentArgs: {
+        selected: currentProduct.environmentsEnabled,
+        mode: 'edit',
+        disabled: isDisabled,
+        awsAccounts: normalizeStoredAwsLzaAccounts(currentProduct.awsAccounts),
+      },
     },
     {
       LeftIcon: IconUsersGroup,

--- a/app/components/form/AccountEnvironmentsPublic.tsx
+++ b/app/components/form/AccountEnvironmentsPublic.tsx
@@ -1,8 +1,9 @@
 import { Alert, Button } from '@mantine/core';
-import { IconInfoCircle } from '@tabler/icons-react';
+import { IconExternalLink, IconInfoCircle } from '@tabler/icons-react';
 import { useFormContext } from 'react-hook-form';
+import ExternalLink from '@/components/generic/button/ExternalLink';
 import FormCheckbox from '@/components/generic/checkbox/FormCheckbox';
-import { publicCloudEnvironments, PublicCloudEnvironmentKey } from '@/constants/public-cloud';
+import { getAwsLzaConsoleUrl, publicCloudEnvironments, PublicCloudEnvironmentKey } from '@/constants/public-cloud';
 import { Provider } from '@/prisma/client';
 interface EnvironmentsEnabled {
   production: boolean;
@@ -18,14 +19,21 @@ interface EnvironmentsEnabled {
 type EnvironmentKey = PublicCloudEnvironmentKey;
 const environments = publicCloudEnvironments;
 
+interface AwsAccount {
+  environment: PublicCloudEnvironmentKey;
+  accountId: string;
+}
+
 export default function AccountEnvironmentsPublic({
   mode,
   disabled,
   selected,
+  awsAccounts,
 }: {
   mode: string;
   disabled?: boolean;
   selected?: EnvironmentsEnabled;
+  awsAccounts?: AwsAccount[];
 }) {
   const {
     register,
@@ -35,6 +43,7 @@ export default function AccountEnvironmentsPublic({
   } = useFormContext();
 
   const isAzure = watch('provider') === Provider.AZURE;
+  const showAwsConsoleLinks = watch('provider') === Provider.AWS_LZA && Array.isArray(awsAccounts);
   const requiresNetworking = watch('requiresNetworking');
 
   const renderNetworkingCheckbox = (key: EnvironmentKey) => {
@@ -54,6 +63,53 @@ export default function AccountEnvironmentsPublic({
       </div>
     );
   };
+
+  const renderAwsConsoleLink = (key: EnvironmentKey) => {
+    if (!showAwsConsoleLinks) return null;
+
+    const environmentEnabled = watch(`environmentsEnabled.${key}`);
+    const account = awsAccounts?.find((awsAccount) => awsAccount.environment === key);
+
+    return (
+      <div className="ml-7 mt-1 min-w-40 text-sm sm:ml-4">
+        {environmentEnabled && account?.accountId ? (
+          <ExternalLink href={getAwsLzaConsoleUrl(account.accountId)} className="font-medium">
+            Sign in to console
+          </ExternalLink>
+        ) : (
+          <span className="inline-flex items-center gap-1 text-gray-400" aria-disabled="true">
+            Sign in to console
+            <IconExternalLink size={14} />
+          </span>
+        )}
+      </div>
+    );
+  };
+
+  const renderEnvironmentControls = (key: EnvironmentKey, label: string) => (
+    <>
+      <FormCheckbox
+        id={key}
+        inputProps={{
+          ...register(`environmentsEnabled.${key}`, {
+            onChange: (e) => {
+              if (!e.target.checked) {
+                setValue(`environmentsEnabled.${key}RequiresNetworking`, false, {
+                  shouldDirty: true,
+                  shouldValidate: true,
+                });
+              }
+            },
+          }),
+        }}
+        disabled={disabled || selected?.[key]}
+      >
+        {label}
+      </FormCheckbox>
+
+      {renderNetworkingCheckbox(key)}
+    </>
+  );
 
   return (
     <div className="">
@@ -90,28 +146,19 @@ export default function AccountEnvironmentsPublic({
         )}
 
         {environments.map(({ key, label }) => {
-          return (
-            <div className="mt-1" key={key}>
-              <FormCheckbox
-                id={key}
-                inputProps={{
-                  ...register(`environmentsEnabled.${key}`, {
-                    onChange: (e) => {
-                      if (!e.target.checked) {
-                        setValue(`environmentsEnabled.${key}RequiresNetworking`, false, {
-                          shouldDirty: true,
-                          shouldValidate: true,
-                        });
-                      }
-                    },
-                  }),
-                }}
-                disabled={disabled || selected?.[key]}
-              >
-                {label}
-              </FormCheckbox>
+          if (!showAwsConsoleLinks) {
+            return (
+              <div className="mt-1" key={key}>
+                {renderEnvironmentControls(key, label)}
+              </div>
+            );
+          }
 
-              {renderNetworkingCheckbox(key)}
+          return (
+            <div className="mt-1 flex flex-col sm:flex-row sm:items-start sm:justify-between sm:gap-4" key={key}>
+              <div>{renderEnvironmentControls(key, label)}</div>
+
+              {renderAwsConsoleLink(key)}
             </div>
           );
         })}

--- a/app/constants/common.ts
+++ b/app/constants/common.ts
@@ -7,6 +7,16 @@ export type BcgovGuidExtensionKey = typeof BCGOV_GUID_EXTENSION;
 
 export const TEAM_SA_PREFIX = 'z_pltsvc-tsa-';
 
+export const environmentShortNames = {
+  development: 'dev',
+  test: 'test',
+  production: 'prod',
+  tools: 'tools',
+} as const;
+
+export type EnvironmentShortName = keyof typeof environmentShortNames;
+export const environmentLongKeys = Object.keys(environmentShortNames) as Array<EnvironmentShortName>;
+
 export const productSorts = [
   {
     label: 'Product update date (new to old)',

--- a/app/constants/private-cloud.ts
+++ b/app/constants/private-cloud.ts
@@ -64,16 +64,6 @@ export const privateCloudProductSorts = productSorts.concat([
   },
 ]);
 
-export const environmentShortNames = {
-  development: 'dev',
-  test: 'test',
-  production: 'prod',
-  tools: 'tools',
-} as const;
-
-export type EnvironmentShortName = keyof typeof environmentShortNames;
-export const environmentLongKeys = Object.keys(environmentShortNames) as Array<EnvironmentShortName>;
-
 export const environmentLongNames = {
   dev: 'development',
   test: 'test',

--- a/app/constants/public-cloud.ts
+++ b/app/constants/public-cloud.ts
@@ -66,9 +66,24 @@ export const publicCloudEnvironmentKeys = ['production', 'development', 'test', 
 
 export type PublicCloudEnvironmentKey = (typeof publicCloudEnvironmentKeys)[number];
 
+export const publicCloudEnvironmentAccountSuffixes: Record<PublicCloudEnvironmentKey, string> = {
+  production: 'prod',
+  development: 'dev',
+  test: 'test',
+  tools: 'tools',
+};
+
 export const publicCloudEnvironments: { key: PublicCloudEnvironmentKey; label: string }[] = [
   { key: 'production', label: 'Production account' },
   { key: 'development', label: 'Development account' },
   { key: 'test', label: 'Test account' },
   { key: 'tools', label: 'Tools account' },
 ];
+
+export function getAwsLzaAccountName(licencePlate: string, environment: PublicCloudEnvironmentKey) {
+  return `${licencePlate}-${publicCloudEnvironmentAccountSuffixes[environment]}`;
+}
+
+export function getAwsLzaConsoleUrl(accountId: string) {
+  return `https://bcgov.awsapps.com/start/#/console?account_id=${accountId}`;
+}

--- a/app/constants/public-cloud.ts
+++ b/app/constants/public-cloud.ts
@@ -1,5 +1,5 @@
 import { Provider, PublicCloudProductMemberRole, Prisma } from '@/prisma/client';
-import { productSorts } from './common';
+import { environmentShortNames, productSorts } from './common';
 
 export const providers = Object.values(Provider);
 export const publicCloudProductMemberRoles = Object.values(PublicCloudProductMemberRole);
@@ -66,13 +66,6 @@ export const publicCloudEnvironmentKeys = ['production', 'development', 'test', 
 
 export type PublicCloudEnvironmentKey = (typeof publicCloudEnvironmentKeys)[number];
 
-export const publicCloudEnvironmentAccountSuffixes: Record<PublicCloudEnvironmentKey, string> = {
-  production: 'prod',
-  development: 'dev',
-  test: 'test',
-  tools: 'tools',
-};
-
 export const publicCloudEnvironments: { key: PublicCloudEnvironmentKey; label: string }[] = [
   { key: 'production', label: 'Production account' },
   { key: 'development', label: 'Development account' },
@@ -81,7 +74,7 @@ export const publicCloudEnvironments: { key: PublicCloudEnvironmentKey; label: s
 ];
 
 export function getAwsLzaAccountName(licencePlate: string, environment: PublicCloudEnvironmentKey) {
-  return `${licencePlate}-${publicCloudEnvironmentAccountSuffixes[environment]}`;
+  return `${licencePlate}-${environmentShortNames[environment]}`;
 }
 
 export function getAwsLzaConsoleUrl(accountId: string) {

--- a/app/helpers/mock-resources/public-cloud-product.ts
+++ b/app/helpers/mock-resources/public-cloud-product.ts
@@ -62,6 +62,7 @@ export function createSamplePublicCloudProduct(args?: {
       tools: true,
       toolsRequiresNetworking: false,
     },
+    awsAccounts: [],
     createdAt: new Date(),
     updatedAt: new Date(),
     archivedAt: new Date(),

--- a/app/helpers/mock-resources/public-cloud-request.ts
+++ b/app/helpers/mock-resources/public-cloud-request.ts
@@ -93,6 +93,7 @@ export function createSamplePublicCloudRequest(args?: {
 
   const product = {
     ...baseData,
+    awsAccounts: [],
     id: generateShortId(),
   };
 

--- a/app/helpers/pdfs/emou/types.ts
+++ b/app/helpers/pdfs/emou/types.ts
@@ -1,3 +1,3 @@
 import { Prisma } from '@/prisma/client';
 
-export type Product = Omit<Prisma.PublicCloudProductGetPayload<null>, 'updatedAt' | 'archivedAt'>;
+export type Product = Omit<Prisma.PublicCloudProductGetPayload<null>, 'updatedAt' | 'archivedAt' | 'awsAccounts'>;

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -339,6 +339,8 @@ model PublicCloudProduct {
   providerSelectionReasons     String[]
   providerSelectionReasonsNote String
   environmentsEnabled          EnvironmentsEnabled
+  /// Optional so existing MongoDB products load without a data migration.
+  awsAccounts                  Json?
   members                      PublicCloudProductMember[]
   requests                     PublicCloudRequest[]       @relation("project")
 }

--- a/app/services/aws-lza/accounts.ts
+++ b/app/services/aws-lza/accounts.ts
@@ -1,0 +1,51 @@
+import { publicCloudEnvironmentKeys, PublicCloudEnvironmentKey } from '@/constants/public-cloud';
+
+export interface AwsLzaAccount {
+  environment: PublicCloudEnvironmentKey;
+  name: string;
+  accountId: string;
+}
+
+function isPublicCloudEnvironmentKey(environment: string): environment is PublicCloudEnvironmentKey {
+  return publicCloudEnvironmentKeys.includes(environment as PublicCloudEnvironmentKey);
+}
+
+export function mergeAwsLzaAccounts(existingAccounts: unknown = [], resolvedAccounts: AwsLzaAccount[] = []) {
+  const accountsByEnvironment = new Map<PublicCloudEnvironmentKey, AwsLzaAccount>();
+
+  normalizeStoredAwsLzaAccounts(existingAccounts).forEach((account) => {
+    if (!isPublicCloudEnvironmentKey(account.environment)) return;
+
+    accountsByEnvironment.set(account.environment, {
+      environment: account.environment,
+      name: account.name,
+      accountId: account.accountId,
+    });
+  });
+
+  resolvedAccounts.forEach((account) => {
+    accountsByEnvironment.set(account.environment, account);
+  });
+
+  return publicCloudEnvironmentKeys
+    .map((environment) => accountsByEnvironment.get(environment))
+    .filter((account): account is AwsLzaAccount => Boolean(account));
+}
+
+export function normalizeStoredAwsLzaAccounts(accounts: unknown): AwsLzaAccount[] {
+  if (!Array.isArray(accounts)) return [];
+
+  return accounts.filter((account): account is AwsLzaAccount => {
+    if (!account || typeof account !== 'object' || Array.isArray(account)) return false;
+
+    const candidate = account as Record<string, unknown>;
+    return (
+      typeof candidate.environment === 'string' &&
+      isPublicCloudEnvironmentKey(candidate.environment) &&
+      typeof candidate.name === 'string' &&
+      candidate.name.length > 0 &&
+      typeof candidate.accountId === 'string' &&
+      candidate.accountId.length > 0
+    );
+  });
+}

--- a/sandbox/nats-provision/main.ts
+++ b/sandbox/nats-provision/main.ts
@@ -15,6 +15,31 @@ import {
 import { KcAdmin } from '../_packages/keycloak-admin/src/main.js';
 
 const natsServer = `${NATS_HOST}:${NATS_PORT}`;
+const mockAwsAccountId = '123456789012';
+
+const awsLzaEnvironmentMap = {
+  dev: { environment: 'development', suffix: 'dev' },
+  test: { environment: 'test', suffix: 'test' },
+  prod: { environment: 'production', suffix: 'prod' },
+  tools: { environment: 'tools', suffix: 'tools' },
+} as const;
+
+function getPublicCloudProvisionPayload(provider: string, data: any) {
+  if (provider !== 'aws_lza') return {};
+
+  const licencePlate = data.project_set_info.licence_plate;
+  const requestedEnvironments = data.project_set_info.requested_environments ?? {};
+
+  return {
+    awsAccounts: Object.entries(awsLzaEnvironmentMap)
+      .filter(([environmentKey]) => requestedEnvironments[environmentKey])
+      .map(([, account]) => ({
+        environment: account.environment,
+        name: `${licencePlate}-${account.suffix}`,
+        accountId: mockAwsAccountId,
+      })),
+  };
+}
 
 async function getkeyCloakAccessToken() {
   const tokenResponse = await fetch(`${KEYCLOAK_URL}/realms/${AUTH_REALM_NAME}/protocol/openid-connect/token`, {
@@ -118,13 +143,16 @@ async function main() {
         const accessToken = await getkeyCloakAccessToken();
 
         try {
+          const body = getPublicCloudProvisionPayload(provider, data);
+          console.log(`Callback payload for ${provider}: ${JSON.stringify(body)}`);
+
           const res = await fetch(`${APP_URL}/api/v1/public-cloud/products/${licencePlate}/provision`, {
             method: 'POST',
             headers: {
               Authorization: 'Bearer ' + accessToken,
               'Content-Type': 'application/json',
             },
-            body: JSON.stringify({}),
+            body: JSON.stringify(body),
           });
           console.log('Response status', res.status);
         } catch (error) {


### PR DESCRIPTION
- `app/app/api/public-cloud/products/_operations/delete.ts` — Excludes stored AWS account metadata when creating public-cloud deletion requests.

- `app/app/api/v1/public-cloud/products/[idOrLicencePlate]/provision/route.ts` — Accepts AWS LZA account details from provisioning callbacks and stores them on the product.

- `app/app/public-cloud/products/(product)/[licencePlate]/edit/page.tsx` — Passes stored AWS LZA accounts to the environment form on the product edit page.

- `app/components/form/AccountEnvironmentsPublic.tsx` — Displays an AWS console sign-in link beside each provisioned AWS LZA environment.

- `app/constants/public-cloud.ts` — Adds AWS LZA account naming rules and the AWS console login URL helper.

- `app/helpers/mock-resources/public-cloud-product.ts` — Adds default AWS account metadata to mocked public-cloud products.

- `app/helpers/mock-resources/public-cloud-request.ts` — Adds default AWS account metadata to mocked request products.

- `app/helpers/pdfs/emou/types.ts` — Excludes AWS account metadata from the product type used for EMOU PDFs.

- `app/prisma/schema.prisma` — Adds optional AWS LZA account metadata storage to public-cloud products.

- `app/services/aws-lza/accounts.ts` — Adds validation, normalization, and merging helpers for stored AWS LZA accounts.

- `sandbox/nats-provision/main.ts` — Sends mock AWS LZA account details in sandbox provisioning callbacks.