### PR TITLE
fix: clear pendingForecast with null on provision

### DIFF
--- a/app/app/api/v1/public-cloud/products/[idOrLicencePlate]/provision/route.ts
+++ b/app/app/api/v1/public-cloud/products/[idOrLicencePlate]/provision/route.ts
@@ -77,7 +77,7 @@ export const POST = apiHandler(async ({ pathParams, session, body }) => {
       decisionStatus: DecisionStatus.PROVISIONED,
       provisionedDate: new Date(),
       active: false,
-      ...(pendingForecast ? { pendingForecast: Prisma.DbNull } : {}),
+      ...(pendingForecast ? { pendingForecast: null } : {}),
     },
     include: publicCloudRequestDetailInclude,
   });


### PR DESCRIPTION
## Summary
- Fixes the post-merge `build-push-app` failure on main after #7687
- Replaces `Prisma.DbNull` with `null` when clearing `pendingForecast` during public cloud provision, matching Prisma's Json update typing

## Test plan
- [ ] Confirm CI `build-push-app` / app image build passes
- [x] Locally provision a CREATE request that has `pendingForecast` and confirm it is cleared after promotion to `CloudCostForecast`