### PR TITLE
fix(0000): type forecast MonthlyValue currency as CAD

### DIFF
--- a/app/app/api/public-cloud/products/[licencePlate]/forecasts/route.ts
+++ b/app/app/api/public-cloud/products/[licencePlate]/forecasts/route.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { type MonthlyValue } from '@/components/public-cloud/forecast/forecast-grid-utils';
 import { GlobalRole } from '@/constants';
 import createApiHandler from '@/core/api-handler';
 import { BadRequestResponse, OkResponse, UnauthorizedResponse } from '@/core/responses';
@@ -48,8 +49,7 @@ export const POST = createApiHandler({
     return UnauthorizedResponse();
   }
 
-  let monthlyValues: { year: number; month: number; amount: number; currency: string }[] | undefined =
-    body?.monthlyValues;
+  let monthlyValues: MonthlyValue[] | undefined = body?.monthlyValues;
   const horizonMonths = body?.horizonMonths ?? 24;
 
   if (!monthlyValues?.length) {

--- a/app/app/api/v1/public-cloud/products/[idOrLicencePlate]/provision/route.ts
+++ b/app/app/api/v1/public-cloud/products/[idOrLicencePlate]/provision/route.ts
@@ -126,7 +126,16 @@ export const POST = apiHandler(async ({ pathParams, session, body }) => {
   ) {
     const existingForecast = await prisma.cloudCostForecast.findUnique({ where: { licencePlate } });
     if (!existingForecast) {
-      await createProductForecast(licencePlate, pendingForecast.monthlyValues, pendingForecast.horizonMonths ?? 24);
+      await createProductForecast(
+        licencePlate,
+        pendingForecast.monthlyValues.map((value) => ({
+          year: value.year,
+          month: value.month,
+          amount: value.amount,
+          currency: 'CAD' as const,
+        })),
+        pendingForecast.horizonMonths ?? 24,
+      );
     }
   }
 

--- a/app/components/public-cloud/forecast/forecast-grid-utils.test.ts
+++ b/app/components/public-cloud/forecast/forecast-grid-utils.test.ts
@@ -194,7 +194,7 @@ describe('preserveLockedPastMonthlyValues', () => {
 
   it('keeps baseline months that are omitted from a partial proposed update', () => {
     const baseline = buildFiscalForecastMonths(2, 1000, 'CAD', june2026);
-    const proposed = [{ year: 2026, month: 7, amount: 2500, currency: 'CAD' }];
+    const proposed: MonthlyValue[] = [{ year: 2026, month: 7, amount: 2500, currency: 'CAD' }];
 
     const result = preserveLockedPastMonthlyValues(baseline, proposed, june2026);
 

--- a/app/components/public-cloud/forecast/forecast-grid-utils.ts
+++ b/app/components/public-cloud/forecast/forecast-grid-utils.ts
@@ -2,7 +2,7 @@ export type MonthlyValue = {
   year: number;
   month: number;
   amount: number;
-  currency: string;
+  currency: 'CAD';
 };
 
 export type ForecastCellStatus = 'confirmed' | 'needsReview' | 'suggested' | 'past';
@@ -61,7 +61,7 @@ export function sumMonthlyValues(values: MonthlyValue[]) {
 export function buildFiscalForecastMonths(
   horizonFiscalYears: number,
   monthlyAmount: number,
-  currency: string,
+  currency: 'CAD' = 'CAD',
   now = new Date(),
 ): MonthlyValue[] {
   const fiscalStartYear = getFiscalYearStartYear(now);
@@ -91,7 +91,7 @@ export function buildFiscalForecastMonths(
  */
 export function buildRollingFiscalForecastMonths(
   monthlyAmount: number,
-  currency: string,
+  currency: 'CAD' = 'CAD',
   now = new Date(),
   horizonMonths = FISCAL_FORECAST_HORIZON_MONTHS,
 ): MonthlyValue[] {
@@ -117,7 +117,7 @@ export function buildRollingFiscalForecastMonths(
 
 export function mergeMonthlyValuesOntoFiscalHorizon(
   existing: MonthlyValue[],
-  currency = 'CAD',
+  currency: 'CAD' = 'CAD',
   now = new Date(),
 ): MonthlyValue[] {
   const template = buildRollingFiscalForecastMonths(0, currency, now);
@@ -126,7 +126,7 @@ export function mergeMonthlyValuesOntoFiscalHorizon(
   return template.map((slot) => {
     const found = byKey.get(monthKey(slot.year, slot.month));
     if (found) {
-      return { ...found, currency: found.currency || currency };
+      return { ...found, currency };
     }
     return slot;
   });
@@ -429,7 +429,7 @@ export function formatForecastProviderList(providers: string[]) {
 /** Roll up product monthly totals onto the fiscal horizon (optionally only products with a forecast). */
 export function aggregateMonthlyTotalsFromProducts(
   products: { monthlyTotals: MonthlyValue[]; hasForecast?: boolean }[],
-  currency: string,
+  currency: 'CAD' = 'CAD',
   onlyWithForecast = false,
 ): MonthlyValue[] {
   const totalsByMonth = new Map<string, MonthlyValue>();

--- a/app/components/public-cloud/sections/PublicCloudPendingForecastSection.tsx
+++ b/app/components/public-cloud/sections/PublicCloudPendingForecastSection.tsx
@@ -16,7 +16,19 @@ type PendingForecastPayload = {
 
 function parsePendingForecast(value: unknown): PendingForecastPayload | null {
   if (!value || typeof value !== 'object') return null;
-  return value as PendingForecastPayload;
+  const payload = value as {
+    monthlyValues?: { year: number; month: number; amount: number; currency?: string }[];
+    horizonMonths?: number;
+  };
+  return {
+    horizonMonths: payload.horizonMonths,
+    monthlyValues: (payload.monthlyValues ?? []).map((month) => ({
+      year: month.year,
+      month: month.month,
+      amount: month.amount,
+      currency: 'CAD' as const,
+    })),
+  };
 }
 
 export default function PublicCloudPendingForecastSection() {

--- a/app/helpers/mock-resources/public-cloud-request.ts
+++ b/app/helpers/mock-resources/public-cloud-request.ts
@@ -138,6 +138,7 @@ export function createSamplePublicCloudRequest(args?: {
     originalDataId: productData.id,
     originalData: deepClone(productData),
     changes: null,
+    pendingForecast: null,
     ...data,
   };
 

--- a/app/helpers/platform-forecast-export.ts
+++ b/app/helpers/platform-forecast-export.ts
@@ -51,7 +51,7 @@ function sanitizeSheetName(name: string) {
   return name.replace(/[\\/*?[\]:]/g, '-').slice(0, 31) || 'Sheet';
 }
 
-function buildFilteredGroupTotals(products: PlatformForecastProduct[], currency: string): MonthlyValue[] {
+function buildFilteredGroupTotals(products: PlatformForecastProduct[], currency: 'CAD'): MonthlyValue[] {
   return aggregateMonthlyTotalsFromProducts(products, currency);
 }
 

--- a/app/services/db/public-cloud-forecast.ts
+++ b/app/services/db/public-cloud-forecast.ts
@@ -190,7 +190,7 @@ async function getForecastForProduct(licencePlate: string, forecastId: string) {
 
 export async function createProductForecast(
   licencePlate: string,
-  monthlyValues: { year: number; month: number; amount: number; currency: 'CAD' | string }[],
+  monthlyValues: MonthlyValue[],
   horizonMonths: number,
 ) {
   const existing = await getProductForecast(licencePlate);
@@ -202,7 +202,12 @@ export async function createProductForecast(
     data: {
       licencePlate,
       horizonMonths,
-      monthlyValues: monthlyValues.map((value) => ({ ...value, currency: 'CAD' as const })),
+      monthlyValues: monthlyValues.map((value) => ({
+        year: value.year,
+        month: value.month,
+        amount: value.amount,
+        currency: 'CAD' as const,
+      })),
     },
   });
 }
@@ -210,7 +215,7 @@ export async function createProductForecast(
 export async function updateProductForecast(
   licencePlate: string,
   forecastId: string,
-  monthlyValues: { year: number; month: number; amount: number; currency: 'CAD' | string }[],
+  monthlyValues: MonthlyValue[],
   horizonMonths: number,
 ) {
   const forecast = await getForecastForProduct(licencePlate, forecastId);

--- a/app/services/db/public-cloud-forecast.ts
+++ b/app/services/db/public-cloud-forecast.ts
@@ -190,7 +190,7 @@ async function getForecastForProduct(licencePlate: string, forecastId: string) {
 
 export async function createProductForecast(
   licencePlate: string,
-  monthlyValues: { year: number; month: number; amount: number; currency: string }[],
+  monthlyValues: { year: number; month: number; amount: number; currency: 'CAD' | string }[],
   horizonMonths: number,
 ) {
   const existing = await getProductForecast(licencePlate);
@@ -202,7 +202,7 @@ export async function createProductForecast(
     data: {
       licencePlate,
       horizonMonths,
-      monthlyValues: monthlyValues.map((value) => ({ ...value, currency: 'CAD' })),
+      monthlyValues: monthlyValues.map((value) => ({ ...value, currency: 'CAD' as const })),
     },
   });
 }
@@ -210,22 +210,30 @@ export async function createProductForecast(
 export async function updateProductForecast(
   licencePlate: string,
   forecastId: string,
-  monthlyValues: { year: number; month: number; amount: number; currency: string }[],
+  monthlyValues: { year: number; month: number; amount: number; currency: 'CAD' | string }[],
   horizonMonths: number,
 ) {
   const forecast = await getForecastForProduct(licencePlate, forecastId);
 
-  const existingValues =
-    (forecast.monthlyValues as {
-      year: number;
-      month: number;
-      amount: number;
-      currency: string;
-    }[]) ?? [];
+  const existingValues: MonthlyValue[] = (
+    (forecast.monthlyValues as { year: number; month: number; amount: number; currency?: string }[]) ?? []
+  ).map((value) => ({
+    year: value.year,
+    month: value.month,
+    amount: value.amount,
+    currency: 'CAD' as const,
+  }));
 
-  const lockedValues = preserveLockedPastMonthlyValues(existingValues, monthlyValues).map((value) => ({
+  const proposedValues: MonthlyValue[] = monthlyValues.map((value) => ({
+    year: value.year,
+    month: value.month,
+    amount: value.amount,
+    currency: 'CAD' as const,
+  }));
+
+  const lockedValues = preserveLockedPastMonthlyValues(existingValues, proposedValues).map((value) => ({
     ...value,
-    currency: 'CAD',
+    currency: 'CAD' as const,
   }));
 
   return prisma.cloudCostForecast.update({
@@ -266,7 +274,15 @@ export async function seedForecastValues(product: {
   const existing = await getProductForecast(product.licencePlate);
   if (existing) {
     const currency = PROVIDER_FORECAST_CURRENCY[product.provider];
-    return mergeMonthlyValuesOntoFiscalHorizon(existing.monthlyValues as MonthlyValue[], currency);
+    const existingValues = (
+      (existing.monthlyValues as { year: number; month: number; amount: number; currency?: string }[]) ?? []
+    ).map((value) => ({
+      year: value.year,
+      month: value.month,
+      amount: value.amount,
+      currency: 'CAD' as const,
+    }));
+    return mergeMonthlyValuesOntoFiscalHorizon(existingValues, currency);
   }
   return seedForecastFromProductBudget(product.provider, product.budget, product.environmentsEnabled);
 }


### PR DESCRIPTION
## Summary
- Fixes the post-merge `build-push-app` failure after #7694
- Narrows `MonthlyValue.currency` to `'CAD'` so `forecastMonthlyValues` assignment on create typechecks
- Normalizes related builders/DB helpers to the same literal type

## Test plan
- [ ] Confirm CI `build-push-app` / app image build passes
- [ ] Create product with spend forecast still submits successfully in non-prod