### PR TITLE
feat(forecast): improve spend forecast grid and rollup UX

### DIFF
--- a/app/app/public-cloud/forecast/page.tsx
+++ b/app/app/public-cloud/forecast/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button, Checkbox, SegmentedControl, Select, TextInput } from '@mantine/core';
+import { Button, SegmentedControl, Select, TextInput } from '@mantine/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
@@ -9,14 +9,21 @@ import ExportButton from '@/components/buttons/ExportButton';
 import LoadingBox from '@/components/generic/LoadingBox';
 import {
   aggregateMonthlyTotalsFromProducts,
+  FISCAL_FORECAST_HORIZON_MONTHS,
+  fiscalYearChunkHasOptionalMonths,
   formatForecastAmount,
   formatForecastProviderLabel,
   getFiscalYearChunks,
+  getFiscalYearTotalSummary,
   getProviderSpendLabel,
+  getRequiredHorizonMonths,
+  isBeyondRequiredHorizon,
+  isForecastHorizonComplete,
   isPastMonth,
   monthKey,
   shortMonthLabel,
   sumMonthlyValues,
+  sumRequiredHorizonMonths,
   yearRangeLabel,
   type FiscalYearChunk,
   type MonthlyValue,
@@ -31,6 +38,7 @@ const DEFAULT_PRODUCT_LIMIT = 10;
 const PRODUCT_LIMIT_INCREMENT = 10;
 
 type ProductSort = 'forecast-desc' | 'name-asc';
+type ProductListFilter = 'all' | 'with-forecast' | 'missing-forecast' | 'incomplete-required';
 type ProviderFilter = 'ALL' | 'AWS_LZA' | 'AZURE' | 'AWS';
 
 const PROVIDER_FILTER_OPTIONS: { value: Exclude<ProviderFilter, 'ALL'>; label: string }[] = [
@@ -57,6 +65,31 @@ function productChunkForecasts(product: PlatformForecastProduct, fyChunk: Fiscal
   return fyChunk.months.map((_, i) =>
     product.hasForecast ? product.monthlyTotals[fyChunk.startIndex + i]?.amount ?? 0 : null,
   );
+}
+
+/** True when some, but not all, products with a forecast have a value for this month. */
+function isMonthCoveragePartial(products: PlatformForecastProduct[], monthIndex: number) {
+  const withForecast = products.filter((product) => product.hasForecast);
+  if (withForecast.length <= 1) return false;
+
+  let withValue = 0;
+  for (const product of withForecast) {
+    if ((product.monthlyTotals[monthIndex]?.amount ?? 0) > 0) withValue += 1;
+  }
+
+  return withValue > 0 && withValue < withForecast.length;
+}
+
+/** Has a forecast but is missing at least one required 24-month horizon value. */
+function productHasIncompleteRequiredMonths(product: PlatformForecastProduct) {
+  return product.hasForecast && !isForecastHorizonComplete(product.monthlyTotals);
+}
+
+function matchesProductListFilter(product: PlatformForecastProduct, filter: ProductListFilter) {
+  if (filter === 'all') return true;
+  if (filter === 'missing-forecast') return !product.hasForecast;
+  if (filter === 'incomplete-required') return productHasIncompleteRequiredMonths(product);
+  return product.hasForecast;
 }
 
 function matchesProductSearch(product: PlatformForecastProduct, search: string) {
@@ -86,7 +119,7 @@ function PlatformForecastGrid({ group }: Readonly<{ group: PlatformForecastSumma
   const [showProducts, setShowProducts] = useState(false);
   const [productSearch, setProductSearch] = useState('');
   const [productSort, setProductSort] = useState<ProductSort>('forecast-desc');
-  const [missingOnly, setMissingOnly] = useState(false);
+  const [productListFilter, setProductListFilter] = useState<ProductListFilter>('all');
   const [productLimit, setProductLimit] = useState(DEFAULT_PRODUCT_LIMIT);
   const [providerFilter, setProviderFilter] = useState<ProviderFilter>('ALL');
 
@@ -104,12 +137,14 @@ function PlatformForecastGrid({ group }: Readonly<{ group: PlatformForecastSumma
 
   const values = filteredTotals.monthlyTotals;
   const fiscalYearChunks = getFiscalYearChunks(values);
-  const grandTotal = sumMonthlyValues(values);
+  const requiredMonths = getRequiredHorizonMonths(values);
+  const grandTotal = sumRequiredHorizonMonths(values);
   const spendLabel = activeProviders.length === 1 ? getProviderSpendLabel(activeProviders[0]) : 'Cloud Spend';
   const filteredProductCount = providerFilteredProducts.length;
   const filteredForecastCount = providerFilteredProducts.filter((product) => product.hasForecast).length;
+  const incompleteRequiredCount = providerFilteredProducts.filter(productHasIncompleteRequiredMonths).length;
   const lineItemProducts = providerFilteredProducts.filter((product) =>
-    missingOnly ? !product.hasForecast : product.hasForecast,
+    matchesProductListFilter(product, productListFilter),
   );
   const searchedProducts = sortProducts(
     lineItemProducts.filter((product) => matchesProductSearch(product, productSearch)),
@@ -127,7 +162,7 @@ function PlatformForecastGrid({ group }: Readonly<{ group: PlatformForecastSumma
 
   useEffect(() => {
     setProductLimit(DEFAULT_PRODUCT_LIMIT);
-  }, [productSearch, productSort, missingOnly, providerFilter]);
+  }, [productSearch, productSort, productListFilter, providerFilter]);
 
   useEffect(() => {
     if (providerFilter !== 'ALL' && !availableProviders.includes(providerFilter)) {
@@ -169,7 +204,7 @@ function PlatformForecastGrid({ group }: Readonly<{ group: PlatformForecastSumma
 
       {showProducts && (
         <div className="rounded-lg border border-gray-200 bg-white p-3 space-y-3">
-          <div className="grid gap-3 lg:grid-cols-[minmax(220px,1fr)_220px_auto] lg:items-end">
+          <div className="grid gap-3 lg:grid-cols-[minmax(220px,1fr)_200px_minmax(220px,1fr)] lg:items-end">
             <TextInput
               label="Find product"
               placeholder="Search name or licence plate"
@@ -186,11 +221,23 @@ function PlatformForecastGrid({ group }: Readonly<{ group: PlatformForecastSumma
               ]}
               allowDeselect={false}
             />
-            <Checkbox
-              label="Missing forecast only"
-              checked={missingOnly}
-              onChange={(event) => setMissingOnly(event.currentTarget.checked)}
-              className="pb-2"
+            <Select
+              label="Show products"
+              value={productListFilter}
+              onChange={(value) => setProductListFilter((value as ProductListFilter) ?? 'all')}
+              data={[
+                { value: 'all', label: `All (${filteredProductCount})` },
+                { value: 'with-forecast', label: `With forecast (${filteredForecastCount})` },
+                {
+                  value: 'incomplete-required',
+                  label: `Incomplete required months (${incompleteRequiredCount})`,
+                },
+                {
+                  value: 'missing-forecast',
+                  label: `Missing forecast (${filteredProductCount - filteredForecastCount})`,
+                },
+              ]}
+              allowDeselect={false}
             />
           </div>
           <div className="flex flex-wrap items-center justify-between gap-3">
@@ -242,11 +289,18 @@ function PlatformForecastGrid({ group }: Readonly<{ group: PlatformForecastSumma
       <div className="space-y-6">
         {fiscalYearChunks.map((fyChunk) => {
           const yearTotal = sumMonthlyValues(fyChunk.months);
+          const fySummary = getFiscalYearTotalSummary(fyChunk);
+          const hasOptional = fiscalYearChunkHasOptionalMonths(fyChunk);
 
           return (
             <div key={fyChunk.label} className="border border-gray-200 rounded-lg overflow-hidden bg-white">
               <div className="px-4 py-2 bg-gray-50 border-b border-gray-200 text-sm font-semibold text-gray-700">
                 {fyChunk.label} <span className="font-normal text-gray-500">({yearRangeLabel(fyChunk.months)})</span>
+                {hasOptional && (
+                  <span className="ml-2 font-normal text-xs text-gray-500">
+                    months beyond the required {FISCAL_FORECAST_HORIZON_MONTHS}-month window are optional
+                  </span>
+                )}
               </div>
               <div className="overflow-x-auto">
                 <table className="w-full min-w-[720px] text-sm">
@@ -255,12 +309,31 @@ function PlatformForecastGrid({ group }: Readonly<{ group: PlatformForecastSumma
                       <th className="px-3 py-2 text-left text-gray-500 min-w-48 sticky left-0 bg-white">
                         {spendLabel}
                       </th>
-                      {fyChunk.months.map((v) => (
-                        <th key={monthKey(v.year, v.month)} className="px-2 py-2 text-center text-gray-500 font-medium">
-                          {shortMonthLabel(v.year, v.month)}
-                        </th>
-                      ))}
-                      <th className="px-3 py-2 text-center font-semibold bg-amber-50 text-gray-800">TOTAL</th>
+                      {fyChunk.months.map((v, i) => {
+                        const optional = isBeyondRequiredHorizon(v.year, v.month);
+                        const coveragePartial = isMonthCoveragePartial(
+                          providerFilteredProducts,
+                          fyChunk.startIndex + i,
+                        );
+                        return (
+                          <th
+                            key={monthKey(v.year, v.month)}
+                            className={`px-2 py-2 text-center font-medium ${
+                              optional || coveragePartial ? 'text-gray-400' : 'text-gray-500'
+                            }`}
+                          >
+                            {shortMonthLabel(v.year, v.month)}
+                            {optional && <div className="text-[10px] font-normal normal-case">optional</div>}
+                            {coveragePartial && <div className="text-[10px] font-normal normal-case">partial</div>}
+                          </th>
+                        );
+                      })}
+                      <th className="px-3 py-2 text-center font-semibold bg-amber-50 text-gray-800">
+                        TOTAL
+                        {fySummary.isPartial && (
+                          <div className="text-[10px] font-normal normal-case text-gray-500">partial</div>
+                        )}
+                      </th>
                     </tr>
                   </thead>
                   <tbody>
@@ -290,20 +363,34 @@ function PlatformForecastGrid({ group }: Readonly<{ group: PlatformForecastSumma
                                 <div className="pl-3 text-xs text-gray-400">{product.licencePlate}</div>
                               </Link>
                             </td>
-                            {fyChunk.months.map((v, i) => (
-                              <td
-                                key={monthKey(v.year, v.month)}
-                                className={`px-2 py-2 text-center ${
-                                  isPastMonth(v.year, v.month) ? 'bg-gray-50 text-gray-500' : 'text-gray-700'
-                                }`}
-                              >
-                                {forecasts[i] != null && hasAnyForecast
-                                  ? formatForecastAmount(forecasts[i]!, group.currency)
-                                  : '—'}
-                              </td>
-                            ))}
+                            {fyChunk.months.map((v, i) => {
+                              const past = isPastMonth(v.year, v.month);
+                              const cellClass = past ? 'bg-gray-50 text-gray-400' : 'text-gray-700';
+                              return (
+                                <td key={monthKey(v.year, v.month)} className={`px-2 py-2 text-center ${cellClass}`}>
+                                  {past
+                                    ? '—'
+                                    : forecasts[i] != null && hasAnyForecast && forecasts[i]! > 0
+                                      ? formatForecastAmount(forecasts[i]!, group.currency)
+                                      : '—'}
+                                </td>
+                              );
+                            })}
                             <td className="px-3 py-2 text-center bg-amber-50/60 text-gray-800">
-                              {hasAnyForecast ? formatForecastAmount(productYearTotal, group.currency) : '—'}
+                              {hasAnyForecast
+                                ? formatForecastAmount(
+                                    fySummary.requiredOnly
+                                      ? fyChunk.months.reduce(
+                                          (sum, month, i) =>
+                                            isBeyondRequiredHorizon(month.year, month.month)
+                                              ? sum
+                                              : sum + (forecasts[i] ?? 0),
+                                          0,
+                                        )
+                                      : productYearTotal,
+                                    group.currency,
+                                  )
+                                : '—'}
                             </td>
                           </tr>
                         );
@@ -348,18 +435,17 @@ function PlatformForecastGrid({ group }: Readonly<{ group: PlatformForecastSumma
                       <td className="px-3 py-2 text-gray-700 sticky left-0 bg-inherit border-r border-gray-100">
                         {showProducts ? 'Forecast total' : 'Forecast'}
                       </td>
-                      {fyChunk.months.map((v) => (
-                        <td
-                          key={monthKey(v.year, v.month)}
-                          className={`px-2 py-2 text-center ${
-                            isPastMonth(v.year, v.month) ? 'bg-gray-100 text-gray-500' : 'bg-inherit text-gray-900'
-                          }`}
-                        >
-                          {formatForecastAmount(v.amount, group.currency)}
-                        </td>
-                      ))}
+                      {fyChunk.months.map((v) => {
+                        const past = isPastMonth(v.year, v.month);
+                        const cellClass = past ? 'bg-gray-100 text-gray-400' : 'bg-inherit text-gray-900';
+                        return (
+                          <td key={monthKey(v.year, v.month)} className={`px-2 py-2 text-center ${cellClass}`}>
+                            {past || v.amount <= 0 ? '—' : formatForecastAmount(v.amount, group.currency)}
+                          </td>
+                        );
+                      })}
                       <td className="px-3 py-2 text-center font-bold bg-amber-50 text-gray-900">
-                        {formatForecastAmount(yearTotal, group.currency)}
+                        {formatForecastAmount(fySummary.total, group.currency)}
                       </td>
                     </tr>
                   </tbody>
@@ -373,12 +459,12 @@ function PlatformForecastGrid({ group }: Readonly<{ group: PlatformForecastSumma
       <div className="flex flex-wrap gap-4">
         <div className="rounded-lg border-2 border-amber-300 bg-amber-50 p-4">
           <div className="text-xs font-semibold text-gray-600 uppercase tracking-wide">
-            {values.length}-month forecast total ({group.currency})
+            {FISCAL_FORECAST_HORIZON_MONTHS}-month forecast total ({group.currency})
           </div>
           <div className="text-2xl font-bold text-gray-900 mt-1">
             {formatForecastAmount(grandTotal, group.currency)}
           </div>
-          <div className="text-xs text-gray-600 mt-1">{yearRangeLabel(values)}</div>
+          <div className="text-xs text-gray-600 mt-1">{yearRangeLabel(requiredMonths)}</div>
         </div>
       </div>
     </div>

--- a/app/app/public-cloud/forecast/page.tsx
+++ b/app/app/public-cloud/forecast/page.tsx
@@ -67,8 +67,9 @@ function productChunkForecasts(product: PlatformForecastProduct, fyChunk: Fiscal
   );
 }
 
-function formatProductMonthAmount(amount: number | null, hasAnyForecast: boolean, past: boolean, currency: string) {
-  if (past || amount == null || !hasAnyForecast || amount <= 0) return '—';
+function formatProductMonthAmount(amount: number | null, hasAnyForecast: boolean, currency: string) {
+  if (amount == null || !hasAnyForecast || amount <= 0) return '—';
+  // Past months can still show previously entered forecast values (read-only).
   return formatForecastAmount(amount, currency);
 }
 
@@ -92,8 +93,17 @@ function formatProductYearTotal(
   return formatForecastAmount(total, currency);
 }
 
-/** True when some, but not all, products with a forecast have a value for this month. */
-function isMonthCoveragePartial(products: PlatformForecastProduct[], monthIndex: number) {
+/**
+ * True when some, but not all, products with a forecast have a value for this month.
+ * Past months are never "partial" — blank past is expected for products created later.
+ */
+function isMonthCoveragePartial(
+  products: PlatformForecastProduct[],
+  month: { year: number; month: number },
+  monthIndex: number,
+) {
+  if (isPastMonth(month.year, month.month)) return false;
+
   const withForecast = products.filter((product) => product.hasForecast);
   if (withForecast.length <= 1) return false;
 
@@ -344,6 +354,7 @@ function PlatformForecastGrid({ group }: Readonly<{ group: PlatformForecastSumma
                         const optional = isBeyondRequiredHorizon(v.year, v.month);
                         const coveragePartial = isMonthCoveragePartial(
                           providerFilteredProducts,
+                          v,
                           fyChunk.startIndex + i,
                         );
                         return (
@@ -399,7 +410,7 @@ function PlatformForecastGrid({ group }: Readonly<{ group: PlatformForecastSumma
                               const cellClass = past ? 'bg-gray-50 text-gray-400' : 'text-gray-700';
                               return (
                                 <td key={monthKey(v.year, v.month)} className={`px-2 py-2 text-center ${cellClass}`}>
-                                  {formatProductMonthAmount(forecasts[i], hasAnyForecast, past, group.currency)}
+                                  {formatProductMonthAmount(forecasts[i], hasAnyForecast, group.currency)}
                                 </td>
                               );
                             })}
@@ -461,7 +472,7 @@ function PlatformForecastGrid({ group }: Readonly<{ group: PlatformForecastSumma
                         const cellClass = past ? 'bg-gray-100 text-gray-400' : 'bg-inherit text-gray-900';
                         return (
                           <td key={monthKey(v.year, v.month)} className={`px-2 py-2 text-center ${cellClass}`}>
-                            {past || v.amount <= 0 ? '—' : formatForecastAmount(v.amount, group.currency)}
+                            {v.amount <= 0 ? '—' : formatForecastAmount(v.amount, group.currency)}
                           </td>
                         );
                       })}

--- a/app/app/public-cloud/forecast/page.tsx
+++ b/app/app/public-cloud/forecast/page.tsx
@@ -67,6 +67,31 @@ function productChunkForecasts(product: PlatformForecastProduct, fyChunk: Fiscal
   );
 }
 
+function formatProductMonthAmount(amount: number | null, hasAnyForecast: boolean, past: boolean, currency: string) {
+  if (past || amount == null || !hasAnyForecast || amount <= 0) return '—';
+  return formatForecastAmount(amount, currency);
+}
+
+function sumProductRequiredMonthsInChunk(forecasts: (number | null)[], fyChunk: FiscalYearChunk) {
+  return fyChunk.months.reduce((sum, month, i) => {
+    if (isBeyondRequiredHorizon(month.year, month.month)) return sum;
+    return sum + (forecasts[i] ?? 0);
+  }, 0);
+}
+
+function formatProductYearTotal(
+  hasAnyForecast: boolean,
+  requiredOnly: boolean,
+  forecasts: (number | null)[],
+  fyChunk: FiscalYearChunk,
+  productYearTotal: number,
+  currency: string,
+) {
+  if (!hasAnyForecast) return '—';
+  const total = requiredOnly ? sumProductRequiredMonthsInChunk(forecasts, fyChunk) : productYearTotal;
+  return formatForecastAmount(total, currency);
+}
+
 /** True when some, but not all, products with a forecast have a value for this month. */
 function isMonthCoveragePartial(products: PlatformForecastProduct[], monthIndex: number) {
   const withForecast = products.filter((product) => product.hasForecast);
@@ -374,29 +399,19 @@ function PlatformForecastGrid({ group }: Readonly<{ group: PlatformForecastSumma
                               const cellClass = past ? 'bg-gray-50 text-gray-400' : 'text-gray-700';
                               return (
                                 <td key={monthKey(v.year, v.month)} className={`px-2 py-2 text-center ${cellClass}`}>
-                                  {past
-                                    ? '—'
-                                    : forecasts[i] != null && hasAnyForecast && forecasts[i]! > 0
-                                      ? formatForecastAmount(forecasts[i]!, group.currency)
-                                      : '—'}
+                                  {formatProductMonthAmount(forecasts[i], hasAnyForecast, past, group.currency)}
                                 </td>
                               );
                             })}
                             <td className="px-3 py-2 text-center bg-amber-50/60 text-gray-800">
-                              {hasAnyForecast
-                                ? formatForecastAmount(
-                                    fySummary.requiredOnly
-                                      ? fyChunk.months.reduce(
-                                          (sum, month, i) =>
-                                            isBeyondRequiredHorizon(month.year, month.month)
-                                              ? sum
-                                              : sum + (forecasts[i] ?? 0),
-                                          0,
-                                        )
-                                      : productYearTotal,
-                                    group.currency,
-                                  )
-                                : '—'}
+                              {formatProductYearTotal(
+                                hasAnyForecast,
+                                fySummary.requiredOnly,
+                                forecasts,
+                                fyChunk,
+                                productYearTotal,
+                                group.currency,
+                              )}
                             </td>
                           </tr>
                         );

--- a/app/app/public-cloud/forecast/page.tsx
+++ b/app/app/public-cloud/forecast/page.tsx
@@ -151,10 +151,16 @@ function PlatformForecastGrid({ group }: Readonly<{ group: PlatformForecastSumma
     productSort,
   );
   const visibleProducts = searchedProducts.slice(0, productLimit);
-  const otherProductCount = Math.max(providerFilteredProducts.length - visibleProducts.length, 0);
+  // Other-row residuals only make sense when the list is the forecast universe, not a chase filter.
+  const otherRowEnabled = productListFilter === 'all' || productListFilter === 'with-forecast';
+  const otherBasisProducts =
+    productListFilter === 'with-forecast'
+      ? providerFilteredProducts.filter((product) => product.hasForecast)
+      : providerFilteredProducts;
+  const otherProductCount = otherRowEnabled ? Math.max(otherBasisProducts.length - visibleProducts.length, 0) : 0;
   const hiddenMatchingProductCount = Math.max(searchedProducts.length - visibleProducts.length, 0);
   const canShowMoreProducts = hiddenMatchingProductCount > 0;
-  const showOtherRow = showProducts && otherProductCount > 0;
+  const showOtherRow = showProducts && otherRowEnabled && otherProductCount > 0;
   const providerControlData = [
     { value: 'ALL', label: 'All providers' },
     ...PROVIDER_FILTER_OPTIONS.filter((option) => availableProviders.includes(option.value)),

--- a/app/components/public-cloud/forecast/ProjectBudgetForecastPanel.tsx
+++ b/app/components/public-cloud/forecast/ProjectBudgetForecastPanel.tsx
@@ -60,7 +60,9 @@ function CellEditor({ value, currency, status, editable, onChange, onFocusCell, 
   if (status === 'past') {
     return (
       <div className="flex flex-col items-center justify-center min-h-9">
-        <span className="font-medium text-sm text-gray-400">—</span>
+        <span className="font-medium text-sm text-gray-400">
+          {value > 0 ? formatForecastAmount(value, currency) : '—'}
+        </span>
       </div>
     );
   }

--- a/app/components/public-cloud/forecast/ProjectBudgetForecastPanel.tsx
+++ b/app/components/public-cloud/forecast/ProjectBudgetForecastPanel.tsx
@@ -7,19 +7,21 @@ import { createPublicCloudForecast, updatePublicCloudForecast } from '@/services
 import {
   applyAmountToFutureMonths,
   FISCAL_FORECAST_HORIZON_MONTHS,
+  fiscalYearChunkHasOptionalMonths,
   formatForecastAmount,
   getCellStatuses,
   getFiscalYearChunks,
+  getFiscalYearTotalSummary,
   getProviderBudgetCurrency,
   getProviderSpendLabel,
-  isInProgressFiscalYear,
-  isPartialFiscalYearChunk,
+  getRequiredHorizonMonths,
   isPastMonth,
+  isRequiredForecastMonth,
   mergeMonthlyValuesOntoFiscalHorizon,
   monthKey,
   preserveLockedPastMonthlyValues,
   shortMonthLabel,
-  sumMonthlyValues,
+  sumRequiredHorizonMonths,
   yearRangeLabel,
   type BudgetCurrency,
   type ForecastCellStatus,
@@ -44,18 +46,21 @@ type CellEditorProps = Readonly<{
 }>;
 
 function CellEditor({ value, currency, status, editable, onChange, onFocusCell, onApplyToFuture }: CellEditorProps) {
-  const [draftValue, setDraftValue] = useState(value);
+  // Empty string = not entered (stored as 0). Keeps the input blank instead of "$0".
+  const [draftValue, setDraftValue] = useState<number | ''>(value > 0 ? Math.round(value) : '');
+  const [focused, setFocused] = useState(false);
   const [showApplyFuture, setShowApplyFuture] = useState(false);
 
   useEffect(() => {
-    setDraftValue(Math.round(value));
+    if (focused) return;
+    setDraftValue(value > 0 ? Math.round(value) : '');
     setShowApplyFuture(false);
-  }, [value]);
+  }, [value, focused]);
 
   if (status === 'past') {
     return (
       <div className="flex flex-col items-center justify-center min-h-9">
-        <span className="font-medium text-sm text-gray-400">{formatForecastAmount(value, currency)}</span>
+        <span className="font-medium text-sm text-gray-400">—</span>
       </div>
     );
   }
@@ -64,15 +69,26 @@ function CellEditor({ value, currency, status, editable, onChange, onFocusCell, 
     return (
       <div className="space-y-1">
         <NumberInput
-          value={Math.round(draftValue)}
+          value={draftValue}
           min={0}
           hideControls
           decimalScale={0}
           allowDecimal={false}
           thousandSeparator=","
-          prefix="$"
-          onFocus={() => onFocusCell?.()}
+          prefix={draftValue === '' ? undefined : '$'}
+          allowNegative={false}
+          onFocus={() => {
+            setFocused(true);
+            onFocusCell?.();
+          }}
+          onBlur={() => setFocused(false)}
           onChange={(val) => {
+            if (val === '' || val === undefined || val === null) {
+              setDraftValue('');
+              onChange(0);
+              setShowApplyFuture(Math.round(value) !== 0);
+              return;
+            }
             const next = typeof val === 'number' ? Math.round(val) : 0;
             setDraftValue(next);
             onChange(next);
@@ -97,9 +113,19 @@ function CellEditor({ value, currency, status, editable, onChange, onFocusCell, 
     );
   }
 
+  if (value <= 0) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-9">
+        <span className="font-medium text-sm text-gray-400">—</span>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col items-center justify-center min-h-9">
-      <span className="font-medium text-sm text-gray-900">{formatForecastAmount(value, currency)}</span>
+      <span className={`font-medium text-sm ${status === 'optional' ? 'text-gray-500' : 'text-gray-900'}`}>
+        {formatForecastAmount(value, currency)}
+      </span>
     </div>
   );
 }
@@ -196,7 +222,9 @@ export default function ProjectBudgetForecastPanel({
   const canSave = isUnsavedDraft || isDirty;
   const canCopyAcrossRange = lastActiveIndex != null;
   const fiscalYearChunks = getFiscalYearChunks(values);
-  const grandTotal = sumMonthlyValues(values);
+  const requiredMonths = useMemo(() => getRequiredHorizonMonths(values), [values]);
+  const requiredTotal = useMemo(() => sumRequiredHorizonMonths(values), [values]);
+  const hasOptionalMonths = fiscalYearChunks.some((chunk) => fiscalYearChunkHasOptionalMonths(chunk));
 
   const saveForecast = useMutation({
     mutationFn: () => {
@@ -258,7 +286,7 @@ export default function ProjectBudgetForecastPanel({
     if (budgetMonthlyTotalCad == null) return;
     const amount = budgetMonthlyTotalCad;
     setValues((prev) =>
-      prev.map((value) => (isPastMonth(value.year, value.month) ? value : { ...value, amount, currency })),
+      prev.map((value) => (isRequiredForecastMonth(value.year, value.month) ? { ...value, amount, currency } : value)),
     );
   };
 
@@ -276,8 +304,9 @@ export default function ProjectBudgetForecastPanel({
           run April–March.
         </p>
         <p>
-          Rolling {FISCAL_FORECAST_HORIZON_MONTHS}-month forecast ({yearRangeLabel(values)}). Past months are locked and
-          shown for reference.
+          Required rolling {FISCAL_FORECAST_HORIZON_MONTHS}-month forecast ({yearRangeLabel(requiredMonths)}). Past
+          months are locked and left blank. Months beyond that window are optional and can be filled for a full fiscal
+          year view.
         </p>
         {budgetMonthlyTotal != null && (
           <p>
@@ -324,6 +353,12 @@ export default function ProjectBudgetForecastPanel({
             )}
           </p>
         )}
+        {hasOptionalMonths && editable && (
+          <p className="text-gray-600">
+            Months labeled optional are beyond the required window — only the {FISCAL_FORECAST_HORIZON_MONTHS}-month
+            forecast is required.
+          </p>
+        )}
       </div>
 
       <div className="sticky top-0 z-20 -mx-1 px-1 py-2 bg-gray-50/95 backdrop-blur border-b border-gray-200 space-y-2">
@@ -358,29 +393,44 @@ export default function ProjectBudgetForecastPanel({
 
       <div className="space-y-6">
         {fiscalYearChunks.map((fyChunk) => {
-          const yearTotal = sumMonthlyValues(fyChunk.months);
+          const fySummary = getFiscalYearTotalSummary(fyChunk);
+          const hasOptional = fiscalYearChunkHasOptionalMonths(fyChunk);
 
           return (
             <div key={fyChunk.label} className="border border-gray-200 rounded-lg overflow-hidden bg-white">
               <div className="px-4 py-2 bg-gray-50 border-b border-gray-200 text-sm font-semibold text-gray-700">
                 {fyChunk.label} <span className="font-normal text-gray-500">({yearRangeLabel(fyChunk.months)})</span>
-                {isPartialFiscalYearChunk(fyChunk) && (
+                {hasOptional && (
                   <span className="ml-2 font-normal text-xs text-gray-500">
-                    partial year — end of the rolling {FISCAL_FORECAST_HORIZON_MONTHS}-month window
+                    months beyond the required {FISCAL_FORECAST_HORIZON_MONTHS}-month window are optional
                   </span>
                 )}
               </div>
               <div className="overflow-x-auto">
-                <table className="w-full min-w-[720px] text-sm">
+                <table className="w-full min-w-[720px] text-sm table-fixed">
                   <thead>
                     <tr className="border-b border-gray-200">
                       <th className="px-3 py-2 text-left text-gray-500 w-28 sticky left-0 bg-white">{spendLabel}</th>
-                      {fyChunk.months.map((v) => (
-                        <th key={monthKey(v.year, v.month)} className="px-2 py-2 text-center text-gray-500 font-medium">
-                          {shortMonthLabel(v.year, v.month)}
-                        </th>
-                      ))}
-                      <th className="px-3 py-2 text-center font-semibold bg-amber-50 text-gray-800">TOTAL</th>
+                      {fyChunk.months.map((v, i) => {
+                        const optional = cellStatuses[fyChunk.startIndex + i] === 'optional';
+                        return (
+                          <th
+                            key={monthKey(v.year, v.month)}
+                            className={`px-2 py-2 text-center font-medium ${
+                              optional ? 'text-gray-400' : 'text-gray-500'
+                            }`}
+                          >
+                            {shortMonthLabel(v.year, v.month)}
+                            {optional && <div className="text-[10px] font-normal normal-case">optional</div>}
+                          </th>
+                        );
+                      })}
+                      <th className="px-3 py-2 text-center font-semibold bg-amber-50 text-gray-800 w-28">
+                        TOTAL
+                        {fySummary.isPartial && (
+                          <div className="text-[10px] font-normal normal-case text-gray-500">partial</div>
+                        )}
+                      </th>
                     </tr>
                   </thead>
                   <tbody>
@@ -410,7 +460,7 @@ export default function ProjectBudgetForecastPanel({
                         );
                       })}
                       <td className="px-3 py-2 text-center font-bold bg-amber-50 text-gray-900">
-                        {formatForecastAmount(yearTotal, currency)}
+                        {formatForecastAmount(fySummary.total, currency)}
                       </td>
                     </tr>
                   </tbody>
@@ -423,23 +473,20 @@ export default function ProjectBudgetForecastPanel({
 
       <div className="grid gap-3 sm:grid-cols-3">
         {fiscalYearChunks.map((fyChunk) => {
-          const yearTotal = sumMonthlyValues(fyChunk.months);
-          const isPartial = isPartialFiscalYearChunk(fyChunk);
-          const inProgress = isInProgressFiscalYear(fyChunk);
-          let yearHint = 'First fiscal year in forecast';
-          if (isPartial) {
-            yearHint = `First ${fyChunk.months.length} month${
-              fyChunk.months.length === 1 ? '' : 's'
-            } of the fiscal year`;
-          } else if (inProgress) {
-            yearHint = 'Full-year forecast total (year still in progress)';
-          }
+          const fySummary = getFiscalYearTotalSummary(fyChunk);
 
           return (
-            <div key={fyChunk.label} className="rounded-lg border border-gray-200 p-4 bg-white">
-              <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide">{fyChunk.label} total</div>
-              <div className="text-2xl font-bold text-gray-900 mt-1">{formatForecastAmount(yearTotal, currency)}</div>
-              <div className="text-sm text-gray-500 mt-1">{yearHint}</div>
+            <div
+              key={fyChunk.label}
+              className={`rounded-lg border p-4 bg-white ${
+                fySummary.isPartial ? 'border-amber-200' : 'border-gray-200'
+              }`}
+            >
+              <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide">{fySummary.title}</div>
+              <div className="text-2xl font-bold text-gray-900 mt-1">
+                {formatForecastAmount(fySummary.total, currency)}
+              </div>
+              <div className="text-sm text-gray-500 mt-1">{fySummary.hint}</div>
             </div>
           );
         })}
@@ -447,8 +494,8 @@ export default function ProjectBudgetForecastPanel({
           <div className="text-xs font-semibold text-gray-600 uppercase tracking-wide">
             {FISCAL_FORECAST_HORIZON_MONTHS}-month forecast total
           </div>
-          <div className="text-2xl font-bold text-gray-900 mt-1">{formatForecastAmount(grandTotal, currency)}</div>
-          <div className="text-xs text-gray-600 mt-1">{yearRangeLabel(values)}</div>
+          <div className="text-2xl font-bold text-gray-900 mt-1">{formatForecastAmount(requiredTotal, currency)}</div>
+          <div className="text-xs text-gray-600 mt-1">{yearRangeLabel(requiredMonths)}</div>
         </div>
       </div>
 

--- a/app/components/public-cloud/forecast/ProjectBudgetForecastPanel.tsx
+++ b/app/components/public-cloud/forecast/ProjectBudgetForecastPanel.tsx
@@ -106,7 +106,7 @@ function CellEditor({ value, currency, status, editable, onChange, onFocusCell, 
               setShowApplyFuture(false);
             }}
           >
-            Apply to all future months
+            Apply to required future months
           </button>
         )}
       </div>
@@ -187,7 +187,7 @@ export default function ProjectBudgetForecastPanel({
   );
 
   const [values, setValues] = useState(baselineValues);
-  /** Index of the month last focused or edited — source for "Copy value across range". */
+  /** Index of the month last focused or edited — source for "Copy across required months". */
   const [lastActiveIndex, setLastActiveIndex] = useState<number | null>(null);
 
   useEffect(() => {
@@ -382,7 +382,7 @@ export default function ProjectBudgetForecastPanel({
                 disabled={!canCopyAcrossRange}
                 onClick={handleCopyAcrossRange}
               >
-                Copy value across range
+                Copy across required months
               </Button>
             </>
           ) : (

--- a/app/components/public-cloud/forecast/forecast-grid-utils.test.ts
+++ b/app/components/public-cloud/forecast/forecast-grid-utils.test.ts
@@ -100,8 +100,8 @@ describe('fiscal year helpers', () => {
     ];
     const merged = mergeMonthlyValuesOntoFiscalHorizon(existing, 'CAD', june2026);
     expect(merged).toHaveLength(36);
-    // Past months stay blank even if stored with a budget seed.
-    expect(merged.find((m) => m.year === 2026 && m.month === 5)?.amount).toBe(0);
+    // Existing forecasts keep stored past amounts (projects that existed earlier in the year).
+    expect(merged.find((m) => m.year === 2026 && m.month === 5)?.amount).toBe(9999);
     expect(merged.find((m) => m.year === 2026 && m.month === 6)?.amount).toBe(5000);
     expect(merged.find((m) => m.year === 2026 && m.month === 7)?.amount).toBe(5500);
     expect(merged.at(-1)).toMatchObject({ year: 2029, month: 3, amount: 0 });
@@ -266,7 +266,7 @@ describe('getCellStatuses', () => {
 describe('preserveLockedPastMonthlyValues', () => {
   const june2026 = new Date(2026, 5, 15);
 
-  it('locks past months at zero even if proposed or baseline had amounts', () => {
+  it('keeps baseline past amounts when proposed tries to change them', () => {
     const baseline = buildFiscalForecastMonths(2, 1000, 'CAD', june2026);
     const proposed = baseline.map((v) => ({ ...v, amount: 9999 }));
 
@@ -275,7 +275,7 @@ describe('preserveLockedPastMonthlyValues', () => {
     const april = result.find((v) => v.month === 4 && v.year === 2026);
     const july = result.find((v) => v.month === 7 && v.year === 2026);
 
-    expect(april?.amount).toBe(0);
+    expect(april?.amount).toBe(1000);
     expect(july?.amount).toBe(9999);
   });
 
@@ -287,7 +287,7 @@ describe('preserveLockedPastMonthlyValues', () => {
 
     expect(result).toHaveLength(baseline.length);
     expect(result.find((v) => v.month === 7 && v.year === 2026)?.amount).toBe(2500);
-    expect(result.find((v) => v.month === 4 && v.year === 2026)?.amount).toBe(0);
+    expect(result.find((v) => v.month === 4 && v.year === 2026)?.amount).toBe(1000);
     expect(result.find((v) => v.month === 8 && v.year === 2026)?.amount).toBe(1000);
   });
 });

--- a/app/components/public-cloud/forecast/forecast-grid-utils.test.ts
+++ b/app/components/public-cloud/forecast/forecast-grid-utils.test.ts
@@ -149,6 +149,16 @@ describe('fiscal year helpers', () => {
     expect(full.total).toBe(12_000);
     expect(full.hint).toBe('Full fiscal year');
   });
+
+  it('labels an in-progress fiscal year by the remaining month range', () => {
+    const months = buildRollingFiscalForecastMonths(1000, 'CAD', june2026);
+    const chunks = getFiscalYearChunks(months);
+    const currentFy = getFiscalYearTotalSummary(chunks[0], june2026);
+
+    expect(currentFy.isPartial).toBe(false);
+    expect(currentFy.title).toBe('FY26/27 total');
+    expect(currentFy.hint).toBe('Jun–Mar forecast (year still in progress)');
+  });
 });
 
 const baseValues: MonthlyValue[] = [
@@ -177,12 +187,12 @@ describe('applyAmountToFutureMonths', () => {
     expect(result.map((v) => v.amount)).toEqual([1000, 1000, 2500, 2500]);
   });
 
-  it('copies amount into optional months beyond the required horizon', () => {
+  it('does not copy amount into optional months beyond the required horizon', () => {
     const statuses: ForecastCellStatus[] = ['suggested', 'optional', 'optional', 'past'];
 
     const result = applyAmountToFutureMonths(baseValues, statuses, 0, 2500);
 
-    expect(result.map((v) => v.amount)).toEqual([1000, 2500, 2500, 1000]);
+    expect(result.map((v) => v.amount)).toEqual([1000, 1000, 1000, 1000]);
   });
 });
 

--- a/app/components/public-cloud/forecast/forecast-grid-utils.test.ts
+++ b/app/components/public-cloud/forecast/forecast-grid-utils.test.ts
@@ -4,17 +4,24 @@ import {
   buildRollingFiscalForecastMonths,
   copyAmountAcrossEditableMonths,
   FISCAL_FORECAST_HORIZON_MONTHS,
+  fiscalYearChunkHasOptionalMonths,
   formatFiscalYearLabel,
   getFiscalYearChunks,
   getFiscalYearStartYear,
+  getFiscalYearTotalSummary,
   getCellStatuses,
   getForecastIncreases,
   getProviderBudgetCurrency,
   getProviderSpendLabel,
+  getRequiredHorizonMonths,
+  isBeyondRequiredHorizon,
   isForecastHorizonComplete,
   isPartialFiscalYearChunk,
+  isRequiredForecastMonth,
   mergeMonthlyValuesOntoFiscalHorizon,
   preserveLockedPastMonthlyValues,
+  shortMonthRangeLabel,
+  sumRequiredHorizonMonths,
   type ForecastCellStatus,
   type MonthlyValue,
 } from './forecast-grid-utils';
@@ -44,44 +51,103 @@ describe('fiscal year helpers', () => {
     expect(months[12]).toMatchObject({ year: 2027, month: 4 });
   });
 
-  it('builds a rolling grid covering 24 months from the current month', () => {
-    // June 2026: Apr '26 – May '28 (2 past months + 24 rolling months = 26 slots).
+  it('builds a rolling grid padded to fiscal year ends', () => {
+    // June 2026: required Jun '26 – May '28; grid Apr '26 – Mar '29 (3 full FYs).
     const months = buildRollingFiscalForecastMonths(1000, 'CAD', june2026);
-    expect(months).toHaveLength(26);
-    expect(months[0]).toMatchObject({ year: 2026, month: 4 });
-    expect(months.at(-1)).toMatchObject({ year: 2028, month: 5 });
+    expect(months).toHaveLength(36);
+    expect(months[0]).toMatchObject({ year: 2026, month: 4, amount: 0 });
+    expect(months[1]).toMatchObject({ year: 2026, month: 5, amount: 0 });
+    expect(months[2]).toMatchObject({ year: 2026, month: 6, amount: 1000 });
+    expect(months.at(-1)).toMatchObject({ year: 2029, month: 3, amount: 0 });
+    expect(months.find((m) => m.year === 2028 && m.month === 5)?.amount).toBe(1000);
+    expect(months.find((m) => m.year === 2028 && m.month === 6)?.amount).toBe(0);
   });
 
   it('rolling grid spans exactly 2 fiscal years when at the start of a fiscal year', () => {
     const april2026 = new Date(2026, 3, 1);
     const months = buildRollingFiscalForecastMonths(1000, 'CAD', april2026);
     expect(months).toHaveLength(24);
-    expect(months[0]).toMatchObject({ year: 2026, month: 4 });
-    expect(months.at(-1)).toMatchObject({ year: 2028, month: 3 });
+    expect(months[0]).toMatchObject({ year: 2026, month: 4, amount: 1000 });
+    expect(months.at(-1)).toMatchObject({ year: 2028, month: 3, amount: 1000 });
   });
 
-  it('chunks the rolling grid into fiscal years with a partial third year', () => {
+  it('chunks the rolling grid into full 12-month fiscal years', () => {
     const months = buildRollingFiscalForecastMonths(1000, 'CAD', june2026);
     const chunks = getFiscalYearChunks(months);
     expect(chunks).toHaveLength(3);
     expect(chunks.map((c) => c.label)).toEqual(['FY26/27', 'FY27/28', 'FY28/29']);
     expect(chunks[0].months).toHaveLength(12);
     expect(chunks[1].months).toHaveLength(12);
-    expect(chunks[2].months).toHaveLength(2);
+    expect(chunks[2].months).toHaveLength(12);
     expect(isPartialFiscalYearChunk(chunks[0])).toBe(false);
-    expect(isPartialFiscalYearChunk(chunks[2])).toBe(true);
+    expect(isPartialFiscalYearChunk(chunks[2])).toBe(false);
+    expect(fiscalYearChunkHasOptionalMonths(chunks[0], june2026)).toBe(false);
+    expect(fiscalYearChunkHasOptionalMonths(chunks[2], june2026)).toBe(true);
+  });
+
+  it('does not seed past months with the budget amount', () => {
+    const months = buildRollingFiscalForecastMonths(1000, 'CAD', june2026);
+    expect(months.filter((m) => m.year === 2026 && m.month < 6).every((m) => m.amount === 0)).toBe(true);
+    expect(getRequiredHorizonMonths(months, june2026)).toHaveLength(24);
+    expect(sumRequiredHorizonMonths(months, june2026)).toBe(24_000);
   });
 
   it('merges existing values onto the rolling fiscal horizon', () => {
     const existing: MonthlyValue[] = [
+      { year: 2026, month: 5, amount: 9999, currency: 'CAD' },
       { year: 2026, month: 6, amount: 5000, currency: 'CAD' },
       { year: 2026, month: 7, amount: 5500, currency: 'CAD' },
     ];
     const merged = mergeMonthlyValuesOntoFiscalHorizon(existing, 'CAD', june2026);
-    expect(merged).toHaveLength(26);
-    expect(merged.find((m) => m.year === 2026 && m.month === 6)?.amount).toBe(5000);
+    expect(merged).toHaveLength(36);
+    // Past months stay blank even if stored with a budget seed.
     expect(merged.find((m) => m.year === 2026 && m.month === 5)?.amount).toBe(0);
-    expect(merged.at(-1)).toMatchObject({ year: 2028, month: 5, amount: 0 });
+    expect(merged.find((m) => m.year === 2026 && m.month === 6)?.amount).toBe(5000);
+    expect(merged.find((m) => m.year === 2026 && m.month === 7)?.amount).toBe(5500);
+    expect(merged.at(-1)).toMatchObject({ year: 2029, month: 3, amount: 0 });
+  });
+
+  it('classifies months beyond the required horizon as optional', () => {
+    expect(isBeyondRequiredHorizon(2028, 5, june2026)).toBe(false);
+    expect(isBeyondRequiredHorizon(2028, 6, june2026)).toBe(true);
+    expect(isRequiredForecastMonth(2026, 5, june2026)).toBe(false);
+    expect(isRequiredForecastMonth(2026, 6, june2026)).toBe(true);
+    expect(isRequiredForecastMonth(2028, 6, june2026)).toBe(false);
+  });
+
+  it('labels a stub fiscal year as partial until every optional month is filled', () => {
+    const months = buildRollingFiscalForecastMonths(1000, 'CAD', june2026);
+    const chunks = getFiscalYearChunks(months);
+    const partial = getFiscalYearTotalSummary(chunks[2], june2026);
+
+    expect(partial.isPartial).toBe(true);
+    expect(partial.title).toBe('FY28/29 partial');
+    expect(partial.total).toBe(2000); // Apr–May 2028 only (required through May)
+    expect(partial.hint).toBe('Apr–May only');
+    expect(partial.partialRangeLabel).toBe('partial');
+    expect(shortMonthRangeLabel(chunks[2].months.slice(0, 2))).toBe('Apr–May');
+
+    // A single optional month must not flip the card to "full fiscal year".
+    const oneOptional = {
+      ...chunks[2],
+      months: chunks[2].months.map((m) => (m.year === 2028 && m.month === 6 ? { ...m, amount: 100 } : m)),
+    };
+    const stillPartial = getFiscalYearTotalSummary(oneOptional, june2026);
+    expect(stillPartial.isPartial).toBe(true);
+    expect(stillPartial.title).toBe('FY28/29 partial');
+    expect(stillPartial.total).toBe(2100);
+    expect(stillPartial.hint).toBe('Apr–May required · 1 of 10 optional months entered');
+    expect(stillPartial.partialRangeLabel).toBe('partial');
+
+    const filled = {
+      ...chunks[2],
+      months: chunks[2].months.map((m) => ({ ...m, amount: 1000 })),
+    };
+    const full = getFiscalYearTotalSummary(filled, june2026);
+    expect(full.isPartial).toBe(false);
+    expect(full.title).toBe('FY28/29 total');
+    expect(full.total).toBe(12_000);
+    expect(full.hint).toBe('Full fiscal year');
   });
 });
 
@@ -110,13 +176,21 @@ describe('applyAmountToFutureMonths', () => {
 
     expect(result.map((v) => v.amount)).toEqual([1000, 1000, 2500, 2500]);
   });
+
+  it('copies amount into optional months beyond the required horizon', () => {
+    const statuses: ForecastCellStatus[] = ['suggested', 'optional', 'optional', 'past'];
+
+    const result = applyAmountToFutureMonths(baseValues, statuses, 0, 2500);
+
+    expect(result.map((v) => v.amount)).toEqual([1000, 2500, 2500, 1000]);
+  });
 });
 
 describe('getCellStatuses', () => {
   const june2026 = new Date(2026, 5, 15);
 
   it('locks past months and requires review for the full current/future horizon', () => {
-    const values = buildFiscalForecastMonths(2, 1000, 'CAD', june2026);
+    const values = buildRollingFiscalForecastMonths(1000, 'CAD', june2026);
     const statuses = getCellStatuses(values, {
       quarterlyReview: { poSignedOff: false, status: 'IN_PROGRESS' },
       activeBaseline: null,
@@ -130,12 +204,14 @@ describe('getCellStatuses', () => {
     const juneIndex = values.findIndex((v) => v.month === 6 && v.year === 2026);
     const julyIndex = values.findIndex((v) => v.month === 7 && v.year === 2026);
     const nextFyIndex = values.findIndex((v) => v.month === 4 && v.year === 2027);
+    const optionalIndex = values.findIndex((v) => v.month === 6 && v.year === 2028);
 
     expect(statuses[aprilIndex]).toBe('past');
     expect(statuses[mayIndex]).toBe('past');
     expect(statuses[juneIndex]).toBe('needsReview');
     expect(statuses[julyIndex]).toBe('needsReview');
     expect(statuses[nextFyIndex]).toBe('needsReview');
+    expect(statuses[optionalIndex]).toBe('optional');
   });
 
   it('stops highlighting the full horizon once the forecast review is saved', () => {
@@ -180,7 +256,7 @@ describe('getCellStatuses', () => {
 describe('preserveLockedPastMonthlyValues', () => {
   const june2026 = new Date(2026, 5, 15);
 
-  it('reverts changes to past months from baseline', () => {
+  it('locks past months at zero even if proposed or baseline had amounts', () => {
     const baseline = buildFiscalForecastMonths(2, 1000, 'CAD', june2026);
     const proposed = baseline.map((v) => ({ ...v, amount: 9999 }));
 
@@ -189,7 +265,7 @@ describe('preserveLockedPastMonthlyValues', () => {
     const april = result.find((v) => v.month === 4 && v.year === 2026);
     const july = result.find((v) => v.month === 7 && v.year === 2026);
 
-    expect(april?.amount).toBe(1000);
+    expect(april?.amount).toBe(0);
     expect(july?.amount).toBe(9999);
   });
 
@@ -201,7 +277,7 @@ describe('preserveLockedPastMonthlyValues', () => {
 
     expect(result).toHaveLength(baseline.length);
     expect(result.find((v) => v.month === 7 && v.year === 2026)?.amount).toBe(2500);
-    expect(result.find((v) => v.month === 4 && v.year === 2026)?.amount).toBe(1000);
+    expect(result.find((v) => v.month === 4 && v.year === 2026)?.amount).toBe(0);
     expect(result.find((v) => v.month === 8 && v.year === 2026)?.amount).toBe(1000);
   });
 });

--- a/app/components/public-cloud/forecast/forecast-grid-utils.ts
+++ b/app/components/public-cloud/forecast/forecast-grid-utils.ts
@@ -162,14 +162,11 @@ export function mergeMonthlyValuesOntoFiscalHorizon(
   const byKey = new Map(existing.map((v) => [monthKey(v.year, v.month), v]));
 
   return template.map((slot) => {
-    // Past months stay blank — they are not actual spend and must not carry budget seed.
-    if (isPastMonth(slot.year, slot.month, now)) {
-      return { ...slot, amount: 0, currency };
-    }
     const found = byKey.get(monthKey(slot.year, slot.month));
     if (found) {
       return { ...found, currency };
     }
+    // Missing past slots stay blank (new products). Existing forecasts keep stored past amounts above.
     return slot;
   });
 }
@@ -313,7 +310,7 @@ export function getInitialConfirmedKeys(
   return keys;
 }
 
-/** Merge proposed months onto baseline. Past months stay locked at 0; omitted months are kept. */
+/** Merge proposed months onto baseline. Past months stay locked from baseline; omitted months are kept. */
 export function preserveLockedPastMonthlyValues(
   baseline: MonthlyValue[],
   proposed: MonthlyValue[],
@@ -327,14 +324,9 @@ export function preserveLockedPastMonthlyValues(
     .map((key) => {
       const existing = baselineByKey.get(key);
       const next = proposedByKey.get(key);
-      if (!next) {
-        if (existing && isPastMonth(existing.year, existing.month, now)) {
-          return { ...existing, amount: 0 };
-        }
-        return existing!;
-      }
+      if (!next) return existing!;
       if (isPastMonth(next.year, next.month, now)) {
-        return { ...(existing ?? next), amount: 0 };
+        return existing ?? next;
       }
       return next;
     })

--- a/app/components/public-cloud/forecast/forecast-grid-utils.ts
+++ b/app/components/public-cloud/forecast/forecast-grid-utils.ts
@@ -15,12 +15,14 @@ export function getProviderBudgetCurrency(provider?: string): BudgetCurrency {
   return provider === 'AZURE' ? 'CAD' : 'USD';
 }
 
-export type ForecastCellStatus = 'confirmed' | 'needsReview' | 'suggested' | 'past';
+export type ForecastCellStatus = 'confirmed' | 'needsReview' | 'suggested' | 'past' | 'optional';
 
 /** Rolling forecast horizon: the current month plus 23 future months. */
 export const FISCAL_FORECAST_HORIZON_MONTHS = 24;
 
 const FISCAL_YEAR_START_MONTH = 4;
+/** Fiscal years end in March (month index 2). */
+const FISCAL_YEAR_END_MONTH = 3;
 
 export function monthKey(year: number, month: number) {
   return `${year}-${month}`;
@@ -92,12 +94,37 @@ export function buildFiscalForecastMonths(
   return monthlyValues;
 }
 
+/** Last calendar month included in the required rolling horizon. */
+export function getRequiredHorizonEndDate(now = new Date(), horizonMonths = FISCAL_FORECAST_HORIZON_MONTHS) {
+  return new Date(now.getFullYear(), now.getMonth() + horizonMonths - 1, 1);
+}
+
+/** True when the month is after the required rolling horizon (optional pad to FY end). */
+export function isBeyondRequiredHorizon(
+  year: number,
+  month: number,
+  now = new Date(),
+  horizonMonths = FISCAL_FORECAST_HORIZON_MONTHS,
+) {
+  const end = getRequiredHorizonEndDate(now, horizonMonths);
+  return year * 12 + month > end.getFullYear() * 12 + (end.getMonth() + 1);
+}
+
+/** Current/future month inside the required rolling horizon. */
+export function isRequiredForecastMonth(
+  year: number,
+  month: number,
+  now = new Date(),
+  horizonMonths = FISCAL_FORECAST_HORIZON_MONTHS,
+) {
+  return !isPastMonth(year, month, now) && !isBeyondRequiredHorizon(year, month, now, horizonMonths);
+}
+
 /**
  * Grid months for the rolling forecast: from the start of the current fiscal
- * year (April) through the current month + (horizonMonths - 1), so the grid
- * always contains exactly `horizonMonths` current/future months. Whenever the
- * window extends past the next fiscal year this produces a partial third
- * fiscal-year chunk.
+ * year (April) through the end of the fiscal year that contains the required
+ * horizon end (always full April–March rows). Past and beyond-horizon months
+ * are seeded as 0; only required-horizon months receive `monthlyAmount`.
  */
 export function buildRollingFiscalForecastMonths(
   monthlyAmount: number,
@@ -107,19 +134,20 @@ export function buildRollingFiscalForecastMonths(
 ): MonthlyValue[] {
   const fiscalStartYear = getFiscalYearStartYear(now);
   const startDate = new Date(fiscalStartYear, FISCAL_YEAR_START_MONTH - 1, 1);
-  const endDate = new Date(now.getFullYear(), now.getMonth() + horizonMonths - 1, 1);
+  const horizonEnd = getRequiredHorizonEndDate(now, horizonMonths);
+  const horizonEndFyStart = getFiscalYearStartForMonth(horizonEnd.getFullYear(), horizonEnd.getMonth() + 1);
+  // Pad through March of the fiscal year that contains the horizon end.
+  const endDate = new Date(horizonEndFyStart + 1, FISCAL_YEAR_END_MONTH - 1, 1);
   const monthCount =
     (endDate.getFullYear() - startDate.getFullYear()) * 12 + (endDate.getMonth() - startDate.getMonth()) + 1;
 
   const monthlyValues: MonthlyValue[] = [];
   for (let i = 0; i < monthCount; i++) {
     const d = new Date(startDate.getFullYear(), startDate.getMonth() + i, 1);
-    monthlyValues.push({
-      year: d.getFullYear(),
-      month: d.getMonth() + 1,
-      amount: monthlyAmount,
-      currency,
-    });
+    const year = d.getFullYear();
+    const month = d.getMonth() + 1;
+    const amount = isRequiredForecastMonth(year, month, now, horizonMonths) ? monthlyAmount : 0;
+    monthlyValues.push({ year, month, amount, currency });
   }
 
   return monthlyValues;
@@ -134,6 +162,10 @@ export function mergeMonthlyValuesOntoFiscalHorizon(
   const byKey = new Map(existing.map((v) => [monthKey(v.year, v.month), v]));
 
   return template.map((slot) => {
+    // Past months stay blank — they are not actual spend and must not carry budget seed.
+    if (isPastMonth(slot.year, slot.month, now)) {
+      return { ...slot, amount: 0, currency };
+    }
     const found = byKey.get(monthKey(slot.year, slot.month));
     if (found) {
       return { ...found, currency };
@@ -250,6 +282,10 @@ export function getCellStatuses(
       return 'past';
     }
 
+    if (isBeyondRequiredHorizon(v.year, v.month, now)) {
+      return 'optional';
+    }
+
     if (confirmedKeys.has(key)) return 'confirmed';
 
     if (reviewDue) return 'needsReview';
@@ -277,7 +313,7 @@ export function getInitialConfirmedKeys(
   return keys;
 }
 
-/** Merge proposed months onto baseline. Past months stay locked; omitted months are kept. */
+/** Merge proposed months onto baseline. Past months stay locked at 0; omitted months are kept. */
 export function preserveLockedPastMonthlyValues(
   baseline: MonthlyValue[],
   proposed: MonthlyValue[],
@@ -291,9 +327,14 @@ export function preserveLockedPastMonthlyValues(
     .map((key) => {
       const existing = baselineByKey.get(key);
       const next = proposedByKey.get(key);
-      if (!next) return existing!;
+      if (!next) {
+        if (existing && isPastMonth(existing.year, existing.month, now)) {
+          return { ...existing, amount: 0 };
+        }
+        return existing!;
+      }
       if (isPastMonth(next.year, next.month, now)) {
-        return existing ?? next;
+        return { ...(existing ?? next), amount: 0 };
       }
       return next;
     })
@@ -322,7 +363,108 @@ export function isForecastHorizonComplete(
 }
 
 function isEditableForecastCell(status: ForecastCellStatus) {
-  return status === 'suggested' || status === 'needsReview';
+  return status === 'suggested' || status === 'needsReview' || status === 'optional';
+}
+
+/** Months inside the required rolling horizon (excludes past and optional pad). */
+export function getRequiredHorizonMonths(
+  values: MonthlyValue[],
+  now = new Date(),
+  horizonMonths = FISCAL_FORECAST_HORIZON_MONTHS,
+) {
+  return values.filter((v) => isRequiredForecastMonth(v.year, v.month, now, horizonMonths));
+}
+
+export function sumRequiredHorizonMonths(
+  values: MonthlyValue[],
+  now = new Date(),
+  horizonMonths = FISCAL_FORECAST_HORIZON_MONTHS,
+) {
+  return sumMonthlyValues(getRequiredHorizonMonths(values, now, horizonMonths));
+}
+
+/** True when this fiscal-year row includes months beyond the required horizon. */
+export function fiscalYearChunkHasOptionalMonths(fyChunk: FiscalYearChunk, now = new Date()) {
+  return fyChunk.months.some((m) => isBeyondRequiredHorizon(m.year, m.month, now));
+}
+
+/** Short range like "Apr–Jun" for partial-year total labels. */
+export function shortMonthRangeLabel(months: MonthlyValue[]) {
+  if (!months.length) return '';
+  const first = months[0];
+  const last = months.at(-1);
+  if (!last) return '';
+  const fmt = (year: number, month: number) =>
+    new Date(year, month - 1, 1).toLocaleDateString('en-US', { month: 'short' });
+  if (first.year === last.year && first.month === last.month) {
+    return fmt(first.year, first.month);
+  }
+  return `${fmt(first.year, first.month)}–${fmt(last.year, last.month)}`;
+}
+
+export type FiscalYearTotalSummary = {
+  isPartial: boolean;
+  total: number;
+  /** e.g. "FY28/29 partial" or "FY28/29 total" */
+  title: string;
+  hint: string;
+  /** Present when partial, e.g. "Apr–Jun" or "4 of 12". */
+  partialRangeLabel?: string;
+  /** True when the displayed total excludes empty optional pad months. */
+  requiredOnly: boolean;
+};
+
+/**
+ * How to present an FY total: partial until every optional pad month has a
+ * value; only then treat it as a full fiscal-year total.
+ */
+export function getFiscalYearTotalSummary(fyChunk: FiscalYearChunk, now = new Date()): FiscalYearTotalSummary {
+  const optionalMonths = fyChunk.months.filter((m) => isBeyondRequiredHorizon(m.year, m.month, now));
+  const requiredInFy = fyChunk.months.filter((m) => isRequiredForecastMonth(m.year, m.month, now));
+  const filledOptionalCount = optionalMonths.filter((m) => m.amount > 0).length;
+  const allOptionalFilled = optionalMonths.length > 0 && filledOptionalCount === optionalMonths.length;
+  const isPartial = optionalMonths.length > 0 && !allOptionalFilled;
+
+  if (isPartial) {
+    const requiredRange = shortMonthRangeLabel(requiredInFy);
+    // No optional amounts yet — show the required slice only.
+    if (filledOptionalCount === 0) {
+      return {
+        isPartial: true,
+        total: sumMonthlyValues(requiredInFy),
+        title: `${fyChunk.label} partial`,
+        hint: `${requiredRange} only`,
+        partialRangeLabel: 'partial',
+        requiredOnly: true,
+      };
+    }
+
+    // Some optional months entered — keep "partial" and include those amounts.
+    return {
+      isPartial: true,
+      total: sumMonthlyValues(fyChunk.months),
+      title: `${fyChunk.label} partial`,
+      hint: `${requiredRange} required · ${filledOptionalCount} of ${optionalMonths.length} optional months entered`,
+      partialRangeLabel: 'partial',
+      requiredOnly: false,
+    };
+  }
+
+  const inProgress = isInProgressFiscalYear(fyChunk, now);
+  let hint = 'Full fiscal-year forecast total';
+  if (optionalMonths.length > 0) {
+    hint = 'Full fiscal year';
+  } else if (inProgress) {
+    hint = 'Full-year forecast total (year still in progress)';
+  }
+
+  return {
+    isPartial: false,
+    total: sumMonthlyValues(fyChunk.months),
+    title: `${fyChunk.label} total`,
+    hint,
+    requiredOnly: false,
+  };
 }
 
 /** Copy a source month's amount to all editable cells. */
@@ -362,7 +504,10 @@ export function isInProgressFiscalYear(fyChunk: FiscalYearChunk, now = new Date(
   return nowIndex >= startIndex && nowIndex <= endIndex;
 }
 
-/** A fiscal-year chunk that only covers part of the year (the tail of the rolling window). */
+/**
+ * A fiscal-year chunk that only covers part of the year.
+ * With FY-end padding this is normally false; kept for callers/tests.
+ */
 export function isPartialFiscalYearChunk(fyChunk: FiscalYearChunk) {
   return fyChunk.months.length < 12;
 }

--- a/app/components/public-cloud/forecast/forecast-grid-utils.ts
+++ b/app/components/public-cloud/forecast/forecast-grid-utils.ts
@@ -362,8 +362,9 @@ export function isForecastHorizonComplete(
   return true;
 }
 
-function isEditableForecastCell(status: ForecastCellStatus) {
-  return status === 'suggested' || status === 'needsReview' || status === 'optional';
+/** Bulk fill/copy targets required-horizon cells only — not optional pad months. */
+function isBulkEditableForecastCell(status: ForecastCellStatus) {
+  return status === 'suggested' || status === 'needsReview';
 }
 
 /** Months inside the required rolling horizon (excludes past and optional pad). */
@@ -455,7 +456,11 @@ export function getFiscalYearTotalSummary(fyChunk: FiscalYearChunk, now = new Da
   if (optionalMonths.length > 0) {
     hint = 'Full fiscal year';
   } else if (inProgress) {
-    hint = 'Full-year forecast total (year still in progress)';
+    const remaining = fyChunk.months.filter((m) => !isPastMonth(m.year, m.month, now));
+    const remainingRange = shortMonthRangeLabel(remaining);
+    hint = remainingRange
+      ? `${remainingRange} forecast (year still in progress)`
+      : 'Forecast total (year still in progress)';
   }
 
   return {
@@ -467,17 +472,17 @@ export function getFiscalYearTotalSummary(fyChunk: FiscalYearChunk, now = new Da
   };
 }
 
-/** Copy a source month's amount to all editable cells. */
+/** Copy a source month's amount to all required-horizon editable cells. */
 export function copyAmountAcrossEditableMonths(
   values: MonthlyValue[],
   statuses: ForecastCellStatus[],
   sourceIndex: number,
 ): MonthlyValue[] {
   const sourceAmount = values[sourceIndex]?.amount ?? 0;
-  return values.map((v, i) => (isEditableForecastCell(statuses[i]) ? { ...v, amount: sourceAmount } : v));
+  return values.map((v, i) => (isBulkEditableForecastCell(statuses[i]) ? { ...v, amount: sourceAmount } : v));
 }
 
-/** Copy a source month's amount to all later editable cells. */
+/** Copy a source month's amount to later required-horizon editable cells (skips optional). */
 export function applyAmountToFutureMonths(
   values: MonthlyValue[],
   statuses: ForecastCellStatus[],
@@ -485,7 +490,7 @@ export function applyAmountToFutureMonths(
   amount: number,
 ): MonthlyValue[] {
   return values.map((v, i) => {
-    if (i <= sourceIndex || !isEditableForecastCell(statuses[i])) {
+    if (i <= sourceIndex || !isBulkEditableForecastCell(statuses[i])) {
       return v;
     }
     return { ...v, amount };

--- a/app/seed/seed-all-local.ts
+++ b/app/seed/seed-all-local.ts
@@ -10,7 +10,7 @@ import {
   expectedMonthlyForecastRollup,
   seedDemoPublicCloudProducts,
 } from './seed-demo-products';
-import { seedForecastForProduct } from './seed-forecast-local';
+import { FORECAST_SEED_PROFILES, seedForecastForProduct } from './seed-forecast-local';
 import { seedFoundation } from './seed-foundation';
 
 async function main() {
@@ -27,6 +27,11 @@ async function main() {
   await seedDemoPublicCloudProducts();
 
   console.log('\n3. Forecast demo data...');
+  console.log('   Non-complete profiles:');
+  for (const [plate, profile] of Object.entries(FORECAST_SEED_PROFILES)) {
+    console.log(`     ${plate} → ${profile}`);
+  }
+
   for (const licencePlate of AZURE_DEMO_PLATES) {
     await seedForecastForProduct(licencePlate, {
       reset,
@@ -49,8 +54,9 @@ async function main() {
     console.log(`  http://localhost:3000/public-cloud/products/${plate}/edit`);
   }
   console.log(`Public Cloud Forecast: http://localhost:3000/public-cloud/forecast`);
+  console.log('  → Show products: "Incomplete required months" / "Missing forecast" to verify filters');
   console.log(
-    `Expected rollups: Azure CA$${expectedMonthlyForecastRollup(
+    `Budget-based monthly totals (if every product were fully forecast): Azure CA$${expectedMonthlyForecastRollup(
       Provider.AZURE,
     ).toLocaleString()}/mo, AWS LZA $${expectedMonthlyForecastRollup(Provider.AWS_LZA).toLocaleString()}/mo`,
   );

--- a/app/seed/seed-forecast-local.ts
+++ b/app/seed/seed-forecast-local.ts
@@ -3,11 +3,18 @@
  * Run: pnpm run seed-forecast-local [licencePlate] [--reset] [--skip-forecast]
  *
  * Default licence plate: e71b0e (Cost Model Test 1)
+ *
+ * Some demo plates use non-complete profiles so the platform rollup can be
+ * exercised (incomplete required months, sparse optional, missing forecast).
  */
 import {
   buildRollingFiscalForecastMonths,
   FISCAL_FORECAST_HORIZON_MONTHS,
+  isBeyondRequiredHorizon,
+  isRequiredForecastMonth,
+  monthKey,
   sumEnabledEnvironmentBudgets,
+  type MonthlyValue,
 } from '../components/public-cloud/forecast/forecast-grid-utils';
 import prisma from '../core/prisma';
 import { Provider } from '../prisma/client';
@@ -21,6 +28,55 @@ const DEFAULT_PLATE = 'e71b0e';
 const ADMIN_EMAIL = 'admin.system@gov.bc.ca';
 const DEFAULT_MONTHLY_FORECAST_AZURE = 5000;
 const DEFAULT_MONTHLY_FORECAST_AWS = 4000;
+
+/** How a demo product’s forecast should be seeded for local testing. */
+export type ForecastSeedProfile = 'complete' | 'incomplete-required' | 'sparse-optional' | 'missing';
+
+/**
+ * Explicit demo plates with non-complete forecasts.
+ * Re-seed with --reset to apply after changing these.
+ */
+export const FORECAST_SEED_PROFILES: Record<string, ForecastSeedProfile> = {
+  // Named demo products
+  a1c2d3: 'incomplete-required', // Cost Model Test 3 (Azure)
+  b4e5f6: 'incomplete-required', // Cost Model Test 4 (AWS LZA)
+  // Scale tests — incomplete required horizon
+  aa0005: 'incomplete-required',
+  aa0010: 'incomplete-required',
+  bb0005: 'incomplete-required',
+  bb0010: 'incomplete-required',
+  // Sparse optional month (e.g. Jul beyond the 24-month window)
+  bb0053: 'sparse-optional',
+  aa0053: 'sparse-optional',
+  // No forecast at all
+  aa0002: 'missing',
+  bb0002: 'missing',
+};
+
+export function getForecastSeedProfile(licencePlate: string): ForecastSeedProfile {
+  return FORECAST_SEED_PROFILES[licencePlate] ?? 'complete';
+}
+
+/** Zero the last few required-horizon months so the product shows as incomplete. */
+export function applyIncompleteRequiredMonths(values: MonthlyValue[], now = new Date()): MonthlyValue[] {
+  const requiredKeys = values
+    .filter((value) => isRequiredForecastMonth(value.year, value.month, now))
+    .slice(-3)
+    .map((value) => monthKey(value.year, value.month));
+  const toClear = new Set(requiredKeys);
+
+  return values.map((value) => (toClear.has(monthKey(value.year, value.month)) ? { ...value, amount: 0 } : value));
+}
+
+/** Keep a full required horizon and set a small amount on the first optional month. */
+export function applySparseOptionalMonth(values: MonthlyValue[], amount = 100, now = new Date()): MonthlyValue[] {
+  const firstOptional = values.find((value) => isBeyondRequiredHorizon(value.year, value.month, now));
+  if (!firstOptional) return values;
+
+  return values.map((value) =>
+    value.year === firstOptional.year && value.month === firstOptional.month ? { ...value, amount } : value,
+  );
+}
 
 function parseArgs() {
   const args = process.argv.slice(2);
@@ -37,6 +93,23 @@ async function clearForecastData(licencePlate: string) {
   await prisma.cloudCostForecast.deleteMany({ where: { licencePlate } });
 }
 
+async function buildSeedMonthlyValues(product: {
+  provider: Provider;
+  budget: { dev: number; test: number; prod: number; tools: number };
+  environmentsEnabled: {
+    development: boolean;
+    test: boolean;
+    production: boolean;
+    tools: boolean;
+  };
+}) {
+  const budgetTotal = sumEnabledEnvironmentBudgets(product.budget, product.environmentsEnabled);
+  if (budgetTotal > 0) {
+    return seedForecastFromProductBudget(product.provider, product.budget, product.environmentsEnabled);
+  }
+  return buildRollingFiscalForecastMonths(resolveDefaultMonthlyAmount(product.provider), 'CAD', new Date());
+}
+
 async function ensureForecast(
   licencePlate: string,
   product: {
@@ -49,22 +122,33 @@ async function ensureForecast(
       tools: boolean;
     };
   },
+  profile: ForecastSeedProfile,
 ) {
+  if (profile === 'missing') {
+    console.log(`  forecast profile "missing" — no forecast created`);
+    return null;
+  }
+
   const existing = await getProductForecast(licencePlate);
   if (existing) {
-    console.log(`  forecast already exists — skipped`);
+    console.log(`  forecast already exists — skipped (use --reset to re-apply profile "${profile}")`);
     return existing;
   }
 
-  const budgetTotal = sumEnabledEnvironmentBudgets(product.budget, product.environmentsEnabled);
-  const monthlyValues =
-    budgetTotal > 0
-      ? await seedForecastFromProductBudget(product.provider, product.budget, product.environmentsEnabled)
-      : buildRollingFiscalForecastMonths(resolveDefaultMonthlyAmount(product.provider), 'CAD', new Date());
+  let monthlyValues = await buildSeedMonthlyValues(product);
+  if (profile === 'incomplete-required') {
+    monthlyValues = applyIncompleteRequiredMonths(monthlyValues);
+  } else if (profile === 'sparse-optional') {
+    monthlyValues = applySparseOptionalMonth(monthlyValues);
+  }
 
   const forecast = await createProductForecast(licencePlate, monthlyValues, FISCAL_FORECAST_HORIZON_MONTHS);
-  const monthlyAmount = monthlyValues[0]?.amount ?? resolveDefaultMonthlyAmount(product.provider);
-  console.log(`  created forecast (${monthlyValues.length} months @ CA$${monthlyAmount}/mo)`);
+  const filledRequired = monthlyValues.filter(
+    (value) => isRequiredForecastMonth(value.year, value.month) && value.amount > 0,
+  ).length;
+  console.log(
+    `  created forecast (${monthlyValues.length} months, profile "${profile}", ${filledRequired} required months filled)`,
+  );
   return forecast;
 }
 
@@ -79,7 +163,12 @@ function printWalkthrough(licencePlate: string) {
   console.log(`   http://localhost:3000/public-cloud/products/${licencePlate}/edit`);
   console.log('2. Admin platform forecast');
   console.log('   http://localhost:3000/public-cloud/forecast\n');
-  console.log('Re-seed: pnpm run seed-forecast-local -- --reset\n');
+  console.log('Incomplete / sparse / missing demo plates:');
+  for (const [plate, profile] of Object.entries(FORECAST_SEED_PROFILES)) {
+    console.log(`   ${plate} → ${profile}`);
+  }
+  console.log('\nRe-seed: pnpm run seed-forecast-local -- --reset');
+  console.log('Full re-seed: pnpm run seed-all-local -- --reset\n');
 }
 
 export async function seedForecastForProduct(
@@ -87,8 +176,9 @@ export async function seedForecastForProduct(
   options: { reset?: boolean; skipForecast?: boolean; showWalkthrough?: boolean } = {},
 ) {
   const { reset = false, skipForecast = false, showWalkthrough = false } = options;
+  const profile = getForecastSeedProfile(licencePlate);
 
-  console.log(`Seeding forecast demo data for ${licencePlate}...`);
+  console.log(`Seeding forecast demo data for ${licencePlate} (profile: ${profile})...`);
 
   const product = await prisma.publicCloudProduct.findFirst({ where: { licencePlate } });
   if (!product) {
@@ -112,7 +202,7 @@ export async function seedForecastForProduct(
 
   if (!skipForecast) {
     console.log('Forecast:');
-    await ensureForecast(licencePlate, product);
+    await ensureForecast(licencePlate, product, profile);
   } else {
     console.log('Forecast: skipped (--skip-forecast)');
   }

--- a/app/seed/seed-forecast-local.ts
+++ b/app/seed/seed-forecast-local.ts
@@ -11,6 +11,7 @@ import {
   buildRollingFiscalForecastMonths,
   FISCAL_FORECAST_HORIZON_MONTHS,
   isBeyondRequiredHorizon,
+  isPastMonth,
   isRequiredForecastMonth,
   monthKey,
   sumEnabledEnvironmentBudgets,
@@ -30,17 +31,26 @@ const DEFAULT_MONTHLY_FORECAST_AZURE = 5000;
 const DEFAULT_MONTHLY_FORECAST_AWS = 4000;
 
 /** How a demo product’s forecast should be seeded for local testing. */
-export type ForecastSeedProfile = 'complete' | 'incomplete-required' | 'sparse-optional' | 'missing';
+export type ForecastSeedProfile = 'complete' | 'with-past' | 'incomplete-required' | 'sparse-optional' | 'missing';
 
 /**
- * Explicit demo plates with non-complete forecasts.
+ * Explicit demo plates with non-default forecasts.
  * Re-seed with --reset to apply after changing these.
+ *
+ * - with-past: existing projects that already had Apr–(current-1) forecasted
+ * - complete (default): new-project style — past months blank
  */
 export const FORECAST_SEED_PROFILES: Record<string, ForecastSeedProfile> = {
-  // Named demo products
+  // Existing-style named demos (past FY months filled)
+  e71b0e: 'with-past', // Cost Model Test 1 (Azure)
+  f82c1a: 'with-past', // Cost Model Test 2 (AWS LZA)
+  aa0001: 'with-past',
+  bb0001: 'with-past',
+  aa0003: 'with-past',
+  bb0003: 'with-past',
+  // Incomplete required horizon
   a1c2d3: 'incomplete-required', // Cost Model Test 3 (Azure)
   b4e5f6: 'incomplete-required', // Cost Model Test 4 (AWS LZA)
-  // Scale tests — incomplete required horizon
   aa0005: 'incomplete-required',
   aa0010: 'incomplete-required',
   bb0005: 'incomplete-required',
@@ -75,6 +85,20 @@ export function applySparseOptionalMonth(values: MonthlyValue[], amount = 100, n
 
   return values.map((value) =>
     value.year === firstOptional.year && value.month === firstOptional.month ? { ...value, amount } : value,
+  );
+}
+
+/**
+ * Fill past months in the current fiscal year from the required-horizon amount.
+ * Simulates products that existed earlier and already forecasted Apr–(current-1).
+ */
+export function applyPastFiscalMonths(values: MonthlyValue[], now = new Date()): MonthlyValue[] {
+  const sampleAmount =
+    values.find((value) => isRequiredForecastMonth(value.year, value.month, now) && value.amount > 0)?.amount ?? 0;
+  if (sampleAmount <= 0) return values;
+
+  return values.map((value) =>
+    isPastMonth(value.year, value.month, now) ? { ...value, amount: sampleAmount } : value,
   );
 }
 
@@ -140,14 +164,17 @@ async function ensureForecast(
     monthlyValues = applyIncompleteRequiredMonths(monthlyValues);
   } else if (profile === 'sparse-optional') {
     monthlyValues = applySparseOptionalMonth(monthlyValues);
+  } else if (profile === 'with-past') {
+    monthlyValues = applyPastFiscalMonths(monthlyValues);
   }
 
   const forecast = await createProductForecast(licencePlate, monthlyValues, FISCAL_FORECAST_HORIZON_MONTHS);
   const filledRequired = monthlyValues.filter(
     (value) => isRequiredForecastMonth(value.year, value.month) && value.amount > 0,
   ).length;
+  const filledPast = monthlyValues.filter((value) => isPastMonth(value.year, value.month) && value.amount > 0).length;
   console.log(
-    `  created forecast (${monthlyValues.length} months, profile "${profile}", ${filledRequired} required months filled)`,
+    `  created forecast (${monthlyValues.length} months, profile "${profile}", ${filledRequired} required + ${filledPast} past months filled)`,
   );
   return forecast;
 }


### PR DESCRIPTION
## Summary
- Pad fiscal-year rows to a full 12 months, with months beyond the required 24-month window editable but labeled optional
- Keep past months blank (no budget seed), show empty inputs for unentered values, and label stub-year / sparse rollup totals as partial
- Add rollup product filters (All / With forecast / Incomplete required months / Missing forecast) and seed incomplete demo forecasts for local testing

## Test plan
- [ ] Create/edit a product: past months show `—`, required months fill from budget, optional months stay blank until entered
- [ ] Confirm FY TOTAL shows `partial` until optional months are fully filled; 24-month total excludes optional amounts
- [ ] On `/public-cloud/forecast`, verify month headers show `optional` / `partial` where expected
- [ ] Use Show products filters for All, Incomplete required months, and Missing forecast
- [ ] Re-seed with `pnpm run seed-all-local -- --reset` and confirm incomplete/sparse/missing demo plates