### PR TITLE
feat(forecast): enable public cloud forecast in all environments

### DIFF
--- a/app/core/auth-options.ts
+++ b/app/core/auth-options.ts
@@ -228,7 +228,7 @@ export async function generateSession({
     security: !IS_PROD,
     apiAccount: !IS_PROD,
     costRecovery: !IS_PROD,
-    publicCloudForecast: !IS_PROD,
+    publicCloudForecast: true,
   };
 
   session.permissions = {


### PR DESCRIPTION
## Summary
- Set `session.previews.publicCloudForecast` to `true` (was `!IS_PROD`) so the spend forecast feature is available in production, not only non-prod

## Test plan
- [ ] Non-prod: spend forecast accordion and admin rollup still work as before
- [ ] Prod (or prod-like `APP_ENV`): after login/session refresh, product edit/create show Spend forecast; APIs accept forecast requests for permitted users
- [ ] Admin/public admin can open Public Cloud Forecast rollup when permission allows