### PR TITLE
Revert "chore(deps): update nginx docker tag to v1.31.4"

### DIFF
--- a/maintenance/Dockerfile
+++ b/maintenance/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.31.4-alpine
+FROM nginx:1.31.3-alpine
 
 RUN addgroup -S nonroot && adduser -S nonroot -G nonroot
 


### PR DESCRIPTION
Reverts bcgov/platform-services-registry#7913
`nginx:1.31.4-alpine` currently fails to build with no match for platform in manifest. Keeping `1.31.3-alpine `until the required image manifest is available.