### PR TITLE
fix(finance): exclude classic AWS and uniquify Silver dev account IDs

### DIFF
--- a/app/app/api/public-cloud/products/[licencePlate]/finance/route.test.ts
+++ b/app/app/api/public-cloud/products/[licencePlate]/finance/route.test.ts
@@ -10,7 +10,7 @@ import { getProductFinance } from '@/services/api-test/public-cloud/finance';
 
 const owner = mockNoRoleUsers[0];
 
-async function createOwnedProduct() {
+async function createOwnedProduct(provider: Provider = Provider.AWS_LZA) {
   const org = DB_DATA.organizations[0] ?? getRandomOrganization();
   const user = await prisma.user.findFirstOrThrow({ where: { idirGuid: owner.idirGuid } });
   return prisma.publicCloudProduct.create({
@@ -24,7 +24,7 @@ async function createOwnedProduct() {
       primaryTechnicalLeadId: user.id,
       expenseAuthorityId: user.id,
       organizationId: org.id,
-      provider: Provider.AWS_LZA,
+      provider,
       requiresNetworking: false,
       networkingReason: '',
       providerSelectionReasons: ['Cost Efficiency'],
@@ -70,6 +70,13 @@ describe('GET /api/public-cloud/products/:licencePlate/finance', () => {
   it('rejects a billing reader who is not on the product', async () => {
     const product = await createOwnedProduct();
     await mockSessionByRole(GlobalRole.Billingreader);
+    const res = await getProductFinance(product.licencePlate);
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects classic AWS products', async () => {
+    const product = await createOwnedProduct(Provider.AWS);
+    await mockSessionByRole(GlobalRole.Admin);
     const res = await getProductFinance(product.licencePlate);
     expect(res.status).toBe(401);
   });

--- a/app/app/api/public-cloud/products/[licencePlate]/finance/route.ts
+++ b/app/app/api/public-cloud/products/[licencePlate]/finance/route.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { GlobalRole } from '@/constants';
+import { GlobalRole, isFinanceProvider } from '@/constants';
 import createApiHandler from '@/core/api-handler';
 import { OkResponse, UnauthorizedResponse } from '@/core/responses';
 import { models } from '@/services/db';
@@ -20,7 +20,7 @@ export const GET = createApiHandler({
     { where: { licencePlate: pathParams.licencePlate } },
     session,
   );
-  if (!product?._permissions.viewFinanceActuals) {
+  if (!product?._permissions.viewFinanceActuals || !isFinanceProvider(product.provider)) {
     return UnauthorizedResponse();
   }
 

--- a/app/app/public-cloud/finance/export/page.tsx
+++ b/app/app/public-cloud/finance/export/page.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { failure, success } from '@/components/notification';
 import FinanceNav from '@/components/public-cloud/finance/FinanceNav';
 import FinancePreviewDisabled from '@/components/public-cloud/finance/FinancePreviewDisabled';
-import { GlobalPermissions, providerFilterOptions } from '@/constants';
+import { GlobalPermissions, financeProviderFilterOptions } from '@/constants';
 import createClientPage from '@/core/client-page';
 import { downloadFinanceExport } from '@/services/backend/public-cloud/finance';
 
@@ -42,7 +42,7 @@ export default publicCloudFinanceExportPage(({ session }) => {
         <SegmentedControl
           value={provider}
           onChange={setProvider}
-          data={[{ label: 'All', value: 'ALL' }, ...providerFilterOptions]}
+          data={[{ label: 'All', value: 'ALL' }, ...financeProviderFilterOptions]}
           aria-label="Provider filter"
         />
         <Select

--- a/app/app/public-cloud/finance/page.tsx
+++ b/app/app/public-cloud/finance/page.tsx
@@ -20,16 +20,13 @@ import FinanceNav from '@/components/public-cloud/finance/FinanceNav';
 import FinancePreviewDisabled from '@/components/public-cloud/finance/FinancePreviewDisabled';
 import FinanceQueryState from '@/components/public-cloud/finance/FinanceQueryState';
 import { formatForecastProviderLabel } from '@/components/public-cloud/forecast/forecast-grid-utils';
-import { GlobalPermissions, providerFilterOptions } from '@/constants';
+import { GlobalPermissions, financeProviderFilterOptions, type FinanceProviderFilter } from '@/constants';
 import createClientPage from '@/core/client-page';
-import { Provider } from '@/prisma/client';
 import {
   getFinanceIngestPlan,
   getFinanceSnapshot,
   triggerFinanceIngestDag,
 } from '@/services/backend/public-cloud/finance';
-
-type ProviderFilter = 'ALL' | Provider;
 
 function SummaryCard({
   label,
@@ -124,7 +121,7 @@ const publicCloudFinancePage = createClientPage({
 });
 
 export default publicCloudFinancePage(({ session }) => {
-  const [provider, setProvider] = useState<ProviderFilter>('ALL');
+  const [provider, setProvider] = useState<FinanceProviderFilter>('ALL');
   const queryClient = useQueryClient();
   const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ['finance-snapshot', provider],
@@ -167,8 +164,8 @@ export default publicCloudFinancePage(({ session }) => {
       <div className="mb-4 flex flex-wrap items-center gap-4">
         <SegmentedControl
           value={provider}
-          onChange={(value) => setProvider(value as ProviderFilter)}
-          data={[{ label: 'All providers', value: 'ALL' }, ...providerFilterOptions]}
+          onChange={(value) => setProvider(value as FinanceProviderFilter)}
+          data={[{ label: 'All providers', value: 'ALL' }, ...financeProviderFilterOptions]}
           aria-label="Provider filter"
         />
       </div>

--- a/app/app/public-cloud/finance/rankings/page.tsx
+++ b/app/app/public-cloud/finance/rankings/page.tsx
@@ -7,7 +7,7 @@ import { formatCadAmount, formatPercent } from '@/components/public-cloud/financ
 import FinanceNav from '@/components/public-cloud/finance/FinanceNav';
 import FinancePreviewDisabled from '@/components/public-cloud/finance/FinancePreviewDisabled';
 import FinanceQueryState from '@/components/public-cloud/finance/FinanceQueryState';
-import { GlobalPermissions, providerFilterOptions } from '@/constants';
+import { GlobalPermissions, financeProviderFilterOptions } from '@/constants';
 import createClientPage from '@/core/client-page';
 import { getFinanceRankings } from '@/services/backend/public-cloud/finance';
 
@@ -38,7 +38,7 @@ export default publicCloudFinanceRankingsPage(({ session }) => {
         <SegmentedControl
           value={provider}
           onChange={setProvider}
-          data={[{ label: 'All', value: 'ALL' }, ...providerFilterOptions]}
+          data={[{ label: 'All', value: 'ALL' }, ...financeProviderFilterOptions]}
           aria-label="Provider filter"
         />
         <Select

--- a/app/app/public-cloud/finance/unmatched/page.tsx
+++ b/app/app/public-cloud/finance/unmatched/page.tsx
@@ -9,7 +9,7 @@ import { currentCalendarMonth, formatCadAmount } from '@/components/public-cloud
 import FinanceNav from '@/components/public-cloud/finance/FinanceNav';
 import FinancePreviewDisabled from '@/components/public-cloud/finance/FinancePreviewDisabled';
 import FinanceQueryState from '@/components/public-cloud/finance/FinanceQueryState';
-import { GlobalPermissions, providerFilterOptions } from '@/constants';
+import { GlobalPermissions, financeProviderFilterOptions } from '@/constants';
 import createClientPage from '@/core/client-page';
 import { getFinanceUnmatched, resolveFinanceUnmatched } from '@/services/backend/public-cloud/finance';
 
@@ -48,7 +48,7 @@ export default publicCloudFinanceUnmatchedPage(({ session }) => {
       <h1 className="text-xl lg:text-2xl font-semibold mb-2">Unmatched billing</h1>
       <p className="text-sm text-gray-600 mb-4">
         Internal. Billing lines that could not be joined to a product. Prefer billingAccountLinks; otherwise AWS_LZA
-        uses awsAccounts and Azure uses azureSubscriptions. Classic AWS has no native account field.
+        uses awsAccounts and Azure uses azureSubscriptions. Classic AWS is not part of finance reporting.
       </p>
       <FinanceNav />
 
@@ -56,7 +56,7 @@ export default publicCloudFinanceUnmatchedPage(({ session }) => {
         <SegmentedControl
           value={provider}
           onChange={setProvider}
-          data={[{ label: 'All', value: 'ALL' }, ...providerFilterOptions]}
+          data={[{ label: 'All', value: 'ALL' }, ...financeProviderFilterOptions]}
           aria-label="Provider filter"
         />
         <NumberInput

--- a/app/constants/public-cloud.ts
+++ b/app/constants/public-cloud.ts
@@ -23,7 +23,21 @@ export const providerOptions = providers.map((value) => ({
   value,
 }));
 
-/** Filter chips used on finance and forecast pages. Order matches those UIs (LZA, MS Azure, classic AWS). */
+/** Providers with finance actuals. Classic AWS is out of scope (no native billing join; ingest is LZA + Azure). */
+export const financeProviders = [Provider.AWS_LZA, Provider.AZURE] as const;
+export type FinanceProvider = (typeof financeProviders)[number];
+export type FinanceProviderFilter = 'ALL' | FinanceProvider;
+
+export function isFinanceProvider(provider: string): provider is FinanceProvider {
+  return (financeProviders as readonly string[]).includes(provider);
+}
+
+export const financeProviderFilterOptions = financeProviders.map((value) => ({
+  label: providerLabels[value],
+  value,
+}));
+
+/** Filter chips used on the forecast page. Includes classic AWS (legacy products still forecast). */
 export const providerFilterOptions = [
   { label: providerLabels[Provider.AWS_LZA], value: Provider.AWS_LZA },
   { label: providerLabels[Provider.AZURE], value: Provider.AZURE },

--- a/app/helpers/finance-export.ts
+++ b/app/helpers/finance-export.ts
@@ -4,6 +4,7 @@ import {
   formatCadAmount,
   monthKey,
 } from '@/components/public-cloud/finance/finance-measure-utils';
+import { isFinanceProvider } from '@/constants/public-cloud';
 import { getFinanceRankings, getFinanceSnapshot, type ProviderFilter } from '@/services/db/public-cloud-finance';
 import { getPlatformForecastSummary } from '@/services/db/public-cloud-forecast';
 
@@ -25,6 +26,7 @@ function formatExportProductName(product: Pick<ForecastProduct, 'name' | 'status
 }
 
 function matchesProviderFilter(productProvider: ForecastProduct['provider'], provider: ProviderFilter) {
+  if (!isFinanceProvider(productProvider)) return false;
   return provider === 'ALL' || productProvider === provider;
 }
 

--- a/app/helpers/finance-export.ts
+++ b/app/helpers/finance-export.ts
@@ -4,7 +4,7 @@ import {
   formatCadAmount,
   monthKey,
 } from '@/components/public-cloud/finance/finance-measure-utils';
-import { isFinanceProvider } from '@/constants/public-cloud';
+import { financeProviders, isFinanceProvider } from '@/constants/public-cloud';
 import { getFinanceRankings, getFinanceSnapshot, type ProviderFilter } from '@/services/db/public-cloud-finance';
 import { getPlatformForecastSummary } from '@/services/db/public-cloud-forecast';
 
@@ -23,6 +23,10 @@ type ForecastProduct = ForecastSummary['groups'][number]['products'][number];
 
 function formatExportProductName(product: Pick<ForecastProduct, 'name' | 'status'>) {
   return product.status === 'INACTIVE' ? `${product.name} (archived)` : product.name;
+}
+
+function financeExportProviders(provider: ProviderFilter) {
+  return provider === 'ALL' ? [...financeProviders] : [provider];
 }
 
 function matchesProviderFilter(productProvider: ForecastProduct['provider'], provider: ProviderFilter) {
@@ -131,7 +135,9 @@ export async function buildFinanceWorkbookBuffer(options: {
     period: options.period,
     limit: 100,
   });
-  const forecastSummary = await getPlatformForecastSummary();
+  const forecastSummary = options.datasets.includes('forecast')
+    ? await getPlatformForecastSummary({ providers: financeExportProviders(options.provider) })
+    : null;
   const periodKeys = monthWindowKeys(options.period);
 
   const meta = workbook.addWorksheet('Export metadata');
@@ -154,7 +160,7 @@ export async function buildFinanceWorkbookBuffer(options: {
     'No forecast entered — excluded from forecast rollups',
   ]);
 
-  if (options.datasets.includes('forecast')) {
+  if (forecastSummary && options.datasets.includes('forecast')) {
     addForecastSheet(workbook, forecastSummary, options.provider, periodKeys);
   }
   if (options.datasets.includes('actuals')) {
@@ -306,7 +312,9 @@ export async function buildFinanceExportCsvRows(options: {
   const rankings = options.datasets.some((dataset) => ['product-rankings', 'service-line-rankings'].includes(dataset))
     ? await getFinanceRankings({ provider: options.provider, period: options.period, limit: 100 })
     : null;
-  const forecastSummary = options.datasets.includes('forecast') ? await getPlatformForecastSummary() : null;
+  const forecastSummary = options.datasets.includes('forecast')
+    ? await getPlatformForecastSummary({ providers: financeExportProviders(options.provider) })
+    : null;
   const periodKeys = monthWindowKeys(options.period);
 
   if (forecastSummary) appendForecastCsvRows(rows, forecastSummary, options.provider, periodKeys);

--- a/app/services/db/models/public-cloud-product.ts
+++ b/app/services/db/models/public-cloud-product.ts
@@ -1,4 +1,5 @@
 import { Session } from 'next-auth';
+import { isFinanceProvider } from '@/constants/public-cloud';
 import prisma from '@/core/prisma';
 import { Prisma, ProjectStatus, TaskType, PublicCloudProductMemberRole } from '@/prisma/client';
 import { PublicCloudProductDecorate } from '@/types/doc-decorate';
@@ -157,7 +158,9 @@ async function decorate<T extends PublicCloudProductSimple & Partial<PublicCloud
     );
 
   const canViewFinanceActuals = Boolean(
-    session.previews.publicCloudFinance && (session.permissions.viewPublicCloudForecast || isProductTeamMember),
+    session.previews.publicCloudFinance &&
+      isFinanceProvider(doc.provider) &&
+      (session.permissions.viewPublicCloudForecast || isProductTeamMember),
   );
 
   const canEditForecast = canEdit;

--- a/app/services/db/public-cloud-finance.snapshot.test.ts
+++ b/app/services/db/public-cloud-finance.snapshot.test.ts
@@ -14,7 +14,7 @@ import { getFinanceSnapshot } from './public-cloud-finance';
 
 const owner = mockNoRoleUsers[0];
 
-async function createSnapshotProduct(createdAt: Date) {
+async function createSnapshotProduct(createdAt: Date, provider: Provider = Provider.AWS_LZA) {
   const org = DB_DATA.organizations[0] ?? getRandomOrganization();
   const user = await prisma.user.findFirstOrThrow({ where: { idirGuid: owner.idirGuid } });
   return prisma.publicCloudProduct.create({
@@ -28,7 +28,7 @@ async function createSnapshotProduct(createdAt: Date) {
       primaryTechnicalLeadId: user.id,
       expenseAuthorityId: user.id,
       organizationId: org.id,
-      provider: Provider.AWS_LZA,
+      provider,
       requiresNetworking: false,
       networkingReason: '',
       providerSelectionReasons: ['Cost Efficiency'],
@@ -93,5 +93,14 @@ describe('getFinanceSnapshot billing-start scope', () => {
     if (priorClosed) {
       expect(priorClosed.forecast).toBe(0);
     }
+  });
+
+  it('excludes classic AWS from the estate snapshot and freshness', async () => {
+    const before = await getFinanceSnapshot('ALL');
+    await createSnapshotProduct(new Date(), Provider.AWS);
+
+    const snapshot = await getFinanceSnapshot('ALL');
+    expect(snapshot.coverage.productCount).toBe(before.coverage.productCount);
+    expect(snapshot.freshness.map((item) => item.provider).sort()).toEqual(['AWS_LZA', 'AZURE']);
   });
 });

--- a/app/services/db/public-cloud-finance.ts
+++ b/app/services/db/public-cloud-finance.ts
@@ -21,6 +21,7 @@ import {
   yearOverYearChange,
 } from '@/components/public-cloud/finance/finance-measure-utils';
 import { type MonthlyValue } from '@/components/public-cloud/forecast/forecast-grid-utils';
+import { financeProviders, type FinanceProviderFilter } from '@/constants/public-cloud';
 import prisma from '@/core/prisma';
 import { FinanceIngestionStatus, Prisma, Provider, ProjectStatus } from '@/prisma/client';
 import {
@@ -34,10 +35,11 @@ import { evaluateSpendFlagsForPeriod } from '@/services/public-cloud-finance/ing
 import { acquireIngestLock, releaseIngestLock } from '@/services/public-cloud-finance/ingest/ingest-lock';
 import { loadProductBillingStartByPlate } from '@/services/public-cloud-finance/product-billing-start';
 
-export type ProviderFilter = 'ALL' | Provider;
+export type ProviderFilter = FinanceProviderFilter;
 
 function providerWhere(provider: ProviderFilter) {
-  return provider === 'ALL' ? {} : { provider };
+  if (provider === 'ALL') return { provider: { in: [...financeProviders] } };
+  return { provider };
 }
 
 type SnapshotProduct = {
@@ -157,7 +159,7 @@ function buildMonthlyChart(options: {
 }
 
 export async function getDataFreshness() {
-  const providers = [Provider.AWS, Provider.AWS_LZA, Provider.AZURE] as const;
+  const providers = financeProviders;
   return Promise.all(
     providers.map(async (provider) => {
       const [latest, lastSuccess] = await Promise.all([
@@ -209,7 +211,7 @@ export async function getFinanceSnapshot(provider: ProviderFilter = 'ALL') {
     where: {
       licencePlate: { in: plates },
       OR: fyMonths.map((m) => ({ year: m.year, month: m.month })),
-      ...(provider === 'ALL' ? {} : { provider }),
+      ...providerWhere(provider),
     },
   });
 
@@ -240,7 +242,7 @@ export async function getFinanceSnapshot(provider: ProviderFilter = 'ALL') {
               activeActualSpendWhere,
               { licencePlate: { in: plates } },
               { OR: ytdMonths.map((m) => ({ year: m.year, month: m.month })) },
-              provider === 'ALL' ? {} : { provider },
+              providerWhere(provider),
             ],
           },
           _sum: { amountCad: true },
@@ -306,14 +308,14 @@ export async function getFinanceSnapshot(provider: ProviderFilter = 'ALL') {
 
   const [anomaliesAwaitingReview, unmatchedThisMonth, productsMissingForecast] = await Promise.all([
     prisma.spendFlag.count({
-      where: { AND: [unreviewedSpendFlagWhere, provider === 'ALL' ? {} : { provider }] },
+      where: { AND: [unreviewedSpendFlagWhere, providerWhere(provider)] },
     }),
     prisma.unmatchedBillingLine.count({
       where: {
         year: through.year,
         month: through.month,
         AND: [unresolvedUnmatchedWhere],
-        ...(provider === 'ALL' ? {} : { provider }),
+        ...providerWhere(provider),
       },
     }),
     Promise.resolve(activeProducts.filter((product) => !forecastByPlate.has(product.licencePlate)).length),
@@ -515,7 +517,7 @@ export async function getFinanceRankings(options: {
 export async function getForecastCoverageChaseList() {
   // Chase list is ACTIVE-only: do not remind owners of archived products.
   const products = await prisma.publicCloudProduct.findMany({
-    where: { status: ProjectStatus.ACTIVE },
+    where: { status: ProjectStatus.ACTIVE, ...providerWhere('ALL') },
     select: {
       licencePlate: true,
       name: true,
@@ -557,7 +559,9 @@ export async function getForecastCoverageChaseList() {
 
 export async function getAnomalyQueue(options?: { includeReviewed?: boolean }) {
   const flags = await prisma.spendFlag.findMany({
-    where: options?.includeReviewed ? {} : unreviewedSpendFlagWhere,
+    where: {
+      AND: [options?.includeReviewed ? {} : unreviewedSpendFlagWhere, providerWhere('ALL')],
+    },
     orderBy: [{ raisedAt: 'desc' }],
   });
   const plates = [...new Set(flags.map((f) => f.licencePlate))];
@@ -618,7 +622,7 @@ export async function getUnmatchedBilling(options?: { provider?: ProviderFilter;
         {
           year,
           month,
-          ...(provider === 'ALL' ? {} : { provider }),
+          ...providerWhere(provider),
         },
       ],
     },
@@ -628,7 +632,7 @@ export async function getUnmatchedBilling(options?: { provider?: ProviderFilter;
   return {
     year,
     month,
-    note: 'Lines that cannot be matched to a product via billingAccountLinks (or AWS_LZA awsAccounts / Azure azureSubscriptions fallback). Classic AWS has no native account field.',
+    note: 'Lines that cannot be matched to a product via billingAccountLinks (or AWS_LZA awsAccounts / Azure azureSubscriptions fallback). Classic AWS is out of scope.',
     lines: lines.map((line) => ({
       id: line.id,
       provider: line.provider,

--- a/app/services/db/public-cloud-forecast.ts
+++ b/app/services/db/public-cloud-forecast.ts
@@ -171,10 +171,15 @@ function appendCurrencyTotalRows(
 }
 
 /** Estate billing actuals stay off unless the caller opts in (finance preview). */
-export async function getPlatformForecastSummary(options?: { includeActuals?: boolean }) {
+export async function getPlatformForecastSummary(options?: {
+  includeActuals?: boolean;
+  /** When set, only these providers are loaded. Forecast UI omits this to include classic AWS. */
+  providers?: Provider[];
+}) {
   const includeActuals = options?.includeActuals === true;
   // Include ACTIVE and INACTIVE so archived products keep historical forecast rollups.
   const products = await prisma.publicCloudProduct.findMany({
+    where: options?.providers?.length ? { provider: { in: options.providers } } : {},
     select: { licencePlate: true, name: true, provider: true, status: true },
     orderBy: [{ provider: 'asc' }, { name: 'asc' }],
   });

--- a/app/services/db/public-cloud-forecast.ts
+++ b/app/services/db/public-cloud-forecast.ts
@@ -177,9 +177,12 @@ export async function getPlatformForecastSummary(options?: {
   providers?: Provider[];
 }) {
   const includeActuals = options?.includeActuals === true;
+  if (options?.providers !== undefined && options.providers.length === 0) {
+    return { totalProducts: 0, productsWithForecast: 0, groups: [] };
+  }
   // Include ACTIVE and INACTIVE so archived products keep historical forecast rollups.
   const products = await prisma.publicCloudProduct.findMany({
-    where: options?.providers?.length ? { provider: { in: options.providers } } : {},
+    where: options?.providers ? { provider: { in: options.providers } } : {},
     select: { licencePlate: true, name: true, provider: true, status: true },
     orderBy: [{ provider: 'asc' }, { name: 'asc' }],
   });

--- a/app/services/db/public-cloud-forecast.ts
+++ b/app/services/db/public-cloud-forecast.ts
@@ -177,7 +177,7 @@ export async function getPlatformForecastSummary(options?: {
   providers?: Provider[];
 }) {
   const includeActuals = options?.includeActuals === true;
-  if (options?.providers !== undefined && options.providers.length === 0) {
+  if (options?.providers?.length === 0) {
     return { totalProducts: 0, productsWithForecast: 0, groups: [] };
   }
   // Include ACTIVE and INACTIVE so archived products keep historical forecast rollups.

--- a/app/services/public-cloud-finance/ingest/missing-periods.ts
+++ b/app/services/public-cloud-finance/ingest/missing-periods.ts
@@ -5,11 +5,12 @@ import {
   lastCompleteMonth,
   monthKey,
 } from '@/components/public-cloud/finance/finance-measure-utils';
+import { financeProviders } from '@/constants/public-cloud';
 import prisma from '@/core/prisma';
 import { FinanceIngestionStatus, Provider } from '@/prisma/client';
 import type { BillingPeriod } from './types';
 
-export const SCHEDULED_INGEST_PROVIDERS = [Provider.AWS_LZA, Provider.AZURE] as const;
+export const SCHEDULED_INGEST_PROVIDERS = financeProviders;
 
 export function elapsedCompleteFyMonths(through: BillingPeriod = lastCompleteMonth()): BillingPeriod[] {
   const fy = currentFiscalYearBounds(new Date(through.year, through.month - 1, 15));

--- a/app/validation-schemas/cloud-cost.ts
+++ b/app/validation-schemas/cloud-cost.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { financeProviders } from '@/constants/public-cloud';
 import { objectId } from '@/validation-schemas/common';
 
 export const forecastMonthlyValueSchema = z.object({
@@ -22,7 +23,10 @@ export const forecastExportQuerySchema = z.object({
 export type ForecastExportQuery = z.infer<typeof forecastExportQuerySchema>;
 
 export const financeProviderQuerySchema = z.object({
-  provider: z.enum(['ALL', 'AWS', 'AWS_LZA', 'AZURE']).optional().default('ALL'),
+  provider: z
+    .enum(['ALL', ...financeProviders])
+    .optional()
+    .default('ALL'),
 });
 
 export const financeRankingsQuerySchema = financeProviderQuerySchema.extend({
@@ -33,7 +37,10 @@ export const financeRankingsQuerySchema = financeProviderQuerySchema.extend({
 
 export const financeExportQuerySchema = z.object({
   format: z.enum(['csv', 'xlsx']).optional().default('xlsx'),
-  provider: z.enum(['ALL', 'AWS', 'AWS_LZA', 'AZURE']).optional().default('ALL'),
+  provider: z
+    .enum(['ALL', ...financeProviders])
+    .optional()
+    .default('ALL'),
   period: z.enum(['ytd', 'full-fy']).optional().default('ytd'),
   datasets: z.string().optional().default('forecast,actuals,variance,product-rankings,service-line-rankings'),
 });
@@ -69,7 +76,7 @@ export const financeIngestLineSchema = z.object({
 });
 
 export const financeIngestLinesBodySchema = z.object({
-  provider: z.enum(['AWS_LZA', 'AZURE']),
+  provider: z.enum(financeProviders),
   year: z.number().int().min(2000).max(2100),
   month: z.number().int().min(1).max(12),
   lines: z.array(financeIngestLineSchema),

--- a/data-migrations/migrations/20260908124800-backfill_dev_public_cloud_account_ids.js
+++ b/data-migrations/migrations/20260908124800-backfill_dev_public_cloud_account_ids.js
@@ -27,15 +27,24 @@ function countIdentifiers(products) {
   };
 
   for (const product of products) {
+    // One identity per environment: account/subscription wins over a matching billing link.
+    const byEnv = new Map();
+    const add = (environment, value) => {
+      if (!environment || byEnv.has(environment)) return;
+      byEnv.set(environment, value);
+    };
+
     for (const account of Array.isArray(product.awsAccounts) ? product.awsAccounts : []) {
-      bump(account?.accountId);
+      add(account?.environment, account?.accountId);
     }
     for (const subscription of Array.isArray(product.azureSubscriptions) ? product.azureSubscriptions : []) {
-      bump(subscription?.subscriptionId);
+      add(subscription?.environment, subscription?.subscriptionId);
     }
     for (const link of Array.isArray(product.billingAccountLinks) ? product.billingAccountLinks : []) {
-      bump(link?.accountIdentifier);
+      add(link?.environment, link?.accountIdentifier);
     }
+
+    for (const value of byEnv.values()) bump(value);
   }
 
   return counts;

--- a/data-migrations/migrations/20260908124800-backfill_dev_public_cloud_account_ids.js
+++ b/data-migrations/migrations/20260908124800-backfill_dev_public_cloud_account_ids.js
@@ -1,4 +1,4 @@
-import { createHash, randomBytes, randomUUID } from 'node:crypto';
+import { createHash, randomInt, randomUUID } from 'node:crypto';
 
 const AWS_ACCOUNT_ID = /^\d{12}$/;
 const AZURE_SUBSCRIPTION_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -56,7 +56,7 @@ function inventAwsAccountId(licencePlate, environment, used) {
     }
   }
 
-  const fallback = String(randomBytes(6).readUIntBE(0, 6) % 10 ** 12).padStart(12, '0');
+  const fallback = String(randomInt(10 ** 12)).padStart(12, '0');
   used.add(fallback);
   return fallback;
 }
@@ -91,29 +91,40 @@ function existingByEnvironment(items, key) {
   );
 }
 
+function reserveItemIds(product, items, idKey, valid, counts, used, normalize) {
+  const byEnv = existingByEnvironment(items);
+  for (const environment of enabledEnvironments(product)) {
+    const value = byEnv.get(environment)?.[idKey];
+    if (!needsReplacement(value, valid, counts)) {
+      used.add(normalize(value));
+    }
+  }
+}
+
 function reserveKeptIds(products, counts, used) {
   for (const product of products) {
     if (product.provider === 'AWS_LZA') {
-      const byEnv = existingByEnvironment(product.awsAccounts);
-      for (const environment of enabledEnvironments(product)) {
-        const existing = byEnv.get(environment);
-        if (existing && !needsReplacement(existing.accountId, (value) => AWS_ACCOUNT_ID.test(value), counts)) {
-          used.add(existing.accountId);
-        }
-      }
+      reserveItemIds(
+        product,
+        product.awsAccounts,
+        'accountId',
+        (value) => AWS_ACCOUNT_ID.test(value),
+        counts,
+        used,
+        (id) => id,
+      );
       continue;
     }
 
-    const byEnv = existingByEnvironment(product.azureSubscriptions);
-    for (const environment of enabledEnvironments(product)) {
-      const existing = byEnv.get(environment);
-      if (
-        existing &&
-        !needsReplacement(existing.subscriptionId, (value) => AZURE_SUBSCRIPTION_ID.test(value), counts)
-      ) {
-        used.add(existing.subscriptionId.toLowerCase());
-      }
-    }
+    reserveItemIds(
+      product,
+      product.azureSubscriptions,
+      'subscriptionId',
+      (value) => AZURE_SUBSCRIPTION_ID.test(value),
+      counts,
+      used,
+      (id) => id.toLowerCase(),
+    );
   }
 }
 

--- a/data-migrations/migrations/20260908124800-backfill_dev_public_cloud_account_ids.js
+++ b/data-migrations/migrations/20260908124800-backfill_dev_public_cloud_account_ids.js
@@ -1,0 +1,244 @@
+import { createHash, randomBytes, randomUUID } from 'node:crypto';
+
+const AWS_ACCOUNT_ID = /^\d{12}$/;
+const AZURE_SUBSCRIPTION_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const ENV_KEYS = ['production', 'development', 'test', 'tools'];
+const ENV_SHORT = { production: 'prod', development: 'dev', test: 'test', tools: 'tools' };
+
+function isDevOnly() {
+  return process.env.APP_ENV === 'dev';
+}
+
+function enabledEnvironments(product) {
+  const enabled = ENV_KEYS.filter((key) => product.environmentsEnabled?.[key] === true);
+  return enabled.length > 0 ? enabled : ['production'];
+}
+
+function accountName(licencePlate, environment) {
+  return `${licencePlate}-${ENV_SHORT[environment]}`;
+}
+
+function countIdentifiers(products) {
+  const counts = new Map();
+  const bump = (value) => {
+    if (typeof value !== 'string' || value.length === 0) return;
+    const key = value.trim().toLowerCase();
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  };
+
+  for (const product of products) {
+    for (const account of Array.isArray(product.awsAccounts) ? product.awsAccounts : []) {
+      bump(account?.accountId);
+    }
+    for (const subscription of Array.isArray(product.azureSubscriptions) ? product.azureSubscriptions : []) {
+      bump(subscription?.subscriptionId);
+    }
+    for (const link of Array.isArray(product.billingAccountLinks) ? product.billingAccountLinks : []) {
+      bump(link?.accountIdentifier);
+    }
+  }
+
+  return counts;
+}
+
+function needsReplacement(value, valid, counts) {
+  if (typeof value !== 'string' || value.length === 0 || !valid(value)) return true;
+  return (counts.get(value.trim().toLowerCase()) ?? 0) > 1;
+}
+
+function inventAwsAccountId(licencePlate, environment, used) {
+  for (let attempt = 0; attempt < 32; attempt += 1) {
+    const hex = createHash('sha256').update(`dev-aws:${licencePlate}:${environment}:${attempt}`).digest('hex');
+    const id = (BigInt(`0x${hex.slice(0, 16)}`) % 10n ** 12n).toString().padStart(12, '0');
+    if (!used.has(id)) {
+      used.add(id);
+      return id;
+    }
+  }
+
+  const fallback = String(randomBytes(6).readUIntBE(0, 6) % 10 ** 12).padStart(12, '0');
+  used.add(fallback);
+  return fallback;
+}
+
+function inventAzureSubscriptionId(licencePlate, environment, used) {
+  for (let attempt = 0; attempt < 32; attempt += 1) {
+    const hex = createHash('sha256').update(`dev-azure:${licencePlate}:${environment}:${attempt}`).digest('hex');
+    const id = [
+      hex.slice(0, 8),
+      hex.slice(8, 12),
+      `4${hex.slice(13, 16)}`,
+      `${((Number.parseInt(hex[16], 16) & 0x3) | 0x8).toString(16)}${hex.slice(17, 20)}`,
+      hex.slice(20, 32),
+    ].join('-');
+    const key = id.toLowerCase();
+    if (!used.has(key)) {
+      used.add(key);
+      return id;
+    }
+  }
+
+  const fallback = randomUUID();
+  used.add(fallback.toLowerCase());
+  return fallback;
+}
+
+function existingByEnvironment(items, key) {
+  return new Map(
+    (Array.isArray(items) ? items : [])
+      .filter((item) => item && ENV_KEYS.includes(item.environment))
+      .map((item) => [item.environment, item]),
+  );
+}
+
+function reserveKeptIds(products, counts, used) {
+  for (const product of products) {
+    if (product.provider === 'AWS_LZA') {
+      const byEnv = existingByEnvironment(product.awsAccounts);
+      for (const environment of enabledEnvironments(product)) {
+        const existing = byEnv.get(environment);
+        if (existing && !needsReplacement(existing.accountId, (value) => AWS_ACCOUNT_ID.test(value), counts)) {
+          used.add(existing.accountId);
+        }
+      }
+      continue;
+    }
+
+    const byEnv = existingByEnvironment(product.azureSubscriptions);
+    for (const environment of enabledEnvironments(product)) {
+      const existing = byEnv.get(environment);
+      if (
+        existing &&
+        !needsReplacement(existing.subscriptionId, (value) => AZURE_SUBSCRIPTION_ID.test(value), counts)
+      ) {
+        used.add(existing.subscriptionId.toLowerCase());
+      }
+    }
+  }
+}
+
+function buildAwsLzaAccounts(product, counts, used) {
+  const byEnv = existingByEnvironment(product.awsAccounts);
+
+  return enabledEnvironments(product).map((environment) => {
+    const existing = byEnv.get(environment);
+    const keep =
+      existing && !needsReplacement(existing.accountId, (value) => AWS_ACCOUNT_ID.test(value), counts)
+        ? existing.accountId
+        : inventAwsAccountId(product.licencePlate, environment, used);
+    return {
+      environment,
+      name: existing?.name || accountName(product.licencePlate, environment),
+      accountId: keep,
+    };
+  });
+}
+
+function buildAzureSubscriptions(product, counts, used) {
+  const byEnv = existingByEnvironment(product.azureSubscriptions);
+
+  return enabledEnvironments(product).map((environment) => {
+    const existing = byEnv.get(environment);
+    const keep =
+      existing && !needsReplacement(existing.subscriptionId, (value) => AZURE_SUBSCRIPTION_ID.test(value), counts)
+        ? existing.subscriptionId
+        : inventAzureSubscriptionId(product.licencePlate, environment, used);
+    return {
+      environment,
+      name: existing?.name || accountName(product.licencePlate, environment),
+      subscriptionId: keep,
+    };
+  });
+}
+
+export const up = async (db, client) => {
+  if (!isDevOnly()) {
+    console.log(`backfill_dev_public_cloud_account_ids: skip (APP_ENV=${process.env.APP_ENV || 'unset'})`);
+    return;
+  }
+
+  const session = client.startSession();
+
+  try {
+    await session.withTransaction(async () => {
+      const PublicCloudProduct = db.collection('PublicCloudProduct');
+      const products = await PublicCloudProduct.find(
+        { provider: { $in: ['AWS_LZA', 'AZURE'] } },
+        {
+          projection: {
+            licencePlate: 1,
+            provider: 1,
+            environmentsEnabled: 1,
+            awsAccounts: 1,
+            azureSubscriptions: 1,
+            billingAccountLinks: 1,
+          },
+          session,
+        },
+      ).toArray();
+
+      const counts = countIdentifiers(products);
+      const used = new Set();
+      reserveKeptIds(products, counts, used);
+      const writes = [];
+
+      for (const product of products) {
+        if (product.provider === 'AWS_LZA') {
+          const awsAccounts = buildAwsLzaAccounts(product, counts, used);
+          writes.push({
+            updateOne: {
+              filter: { _id: product._id },
+              update: {
+                $set: {
+                  awsAccounts,
+                  billingAccountLinks: awsAccounts.map((account) => ({
+                    provider: 'AWS_LZA',
+                    accountIdentifier: account.accountId,
+                    environment: account.environment,
+                  })),
+                },
+              },
+            },
+          });
+          continue;
+        }
+
+        const azureSubscriptions = buildAzureSubscriptions(product, counts, used);
+        writes.push({
+          updateOne: {
+            filter: { _id: product._id },
+            update: {
+              $set: {
+                azureSubscriptions,
+                billingAccountLinks: azureSubscriptions.map((subscription) => ({
+                  provider: 'AZURE',
+                  accountIdentifier: subscription.subscriptionId,
+                  environment: subscription.environment,
+                })),
+              },
+            },
+          },
+        });
+      }
+
+      if (writes.length === 0) {
+        console.log('backfill_dev_public_cloud_account_ids: no AWS_LZA / AZURE products.');
+        return;
+      }
+
+      const result = await PublicCloudProduct.bulkWrite(writes, { ordered: false, session });
+      console.log(
+        `backfill_dev_public_cloud_account_ids: updated ${result.modifiedCount} of ${writes.length} public-cloud products.`,
+      );
+    });
+  } catch (error) {
+    console.error('backfill_dev_public_cloud_account_ids failed:', error);
+    throw error;
+  } finally {
+    await session.endSession();
+  }
+};
+
+export const down = async () => {
+  console.log('backfill_dev_public_cloud_account_ids: down is a no-op (generated IDs are not restored).');
+};

--- a/docs/business-logic/public-cloud/finance-reporting.md
+++ b/docs/business-logic/public-cloud/finance-reporting.md
@@ -1,5 +1,7 @@
 # Public Cloud financial reporting (prototype)
 
+Finance reporting covers **AWS LZA** and **MS Azure** only. Classic AWS products stay in the registry and on the forecast page, but they are not ingested, filtered, or rolled into finance snapshot / rankings / coverage / unmatched / export.
+
 ## Account / subscription join keys
 
 Ingestion joins provider billing lines to registry products via account or subscription identifiers.

--- a/helm/_app/templates/job-pre-data-migrations.yaml
+++ b/helm/_app/templates/job-pre-data-migrations.yaml
@@ -37,6 +37,9 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             ['. /vault/secrets/secrets.env && node_modules/.bin/migrate-mongo up']
+          env:
+            - name: APP_ENV
+              value: {{ index (.Values.env | default dict) "APP_ENV" | default "" | quote }}
           resources:
             limits:
               cpu: 0.5

--- a/sandbox/nats-provision/main.ts
+++ b/sandbox/nats-provision/main.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import waitOn from 'wait-on';
 import { connect, JSONCodec } from 'nats';
 import {
@@ -15,9 +16,6 @@ import {
 import { KcAdmin } from '../_packages/keycloak-admin/src/main.js';
 
 const natsServer = `${NATS_HOST}:${NATS_PORT}`;
-const mockAwsAccountId = '123456789012';
-const mockAzureSubscriptionId = '00000000-0000-4000-8000-000000000001';
-
 const awsLzaEnvironmentMap = {
   dev: { environment: 'development', suffix: 'dev' },
   test: { environment: 'test', suffix: 'test' },
@@ -26,6 +24,22 @@ const awsLzaEnvironmentMap = {
 } as const;
 
 const azureEnvironmentMap = awsLzaEnvironmentMap;
+
+function inventAwsAccountId(licencePlate: string, environment: string) {
+  const hex = createHash('sha256').update(`dev-aws:${licencePlate}:${environment}:0`).digest('hex');
+  return (BigInt(`0x${hex.slice(0, 16)}`) % 10n ** 12n).toString().padStart(12, '0');
+}
+
+function inventAzureSubscriptionId(licencePlate: string, environment: string) {
+  const hex = createHash('sha256').update(`dev-azure:${licencePlate}:${environment}:0`).digest('hex');
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    `4${hex.slice(13, 16)}`,
+    `${((Number.parseInt(hex[16], 16) & 0x3) | 0x8).toString(16)}${hex.slice(17, 20)}`,
+    hex.slice(20, 32),
+  ].join('-');
+}
 
 function getPublicCloudProvisionPayload(provider: string, data: any) {
   const licencePlate = data.project_set_info.licence_plate;
@@ -38,7 +52,7 @@ function getPublicCloudProvisionPayload(provider: string, data: any) {
         .map(([, account]) => ({
           environment: account.environment,
           name: `${licencePlate}-${account.suffix}`,
-          accountId: mockAwsAccountId,
+          accountId: inventAwsAccountId(licencePlate, account.environment),
         })),
     };
   }
@@ -50,7 +64,7 @@ function getPublicCloudProvisionPayload(provider: string, data: any) {
         .map(([, account]) => ({
           environment: account.environment,
           name: `${licencePlate}-${account.suffix}`,
-          subscriptionId: mockAzureSubscriptionId,
+          subscriptionId: inventAzureSubscriptionId(licencePlate, account.environment),
         })),
     };
   }


### PR DESCRIPTION
## Summary
- Scope public-cloud finance (snapshot, rankings, coverage, unmatched, export, freshness, product actuals) to **AWS LZA** and **MS Azure**. Classic AWS stays on forecast only.
- `ALL` no longer loads every public-cloud product, which 500'd in **dev** because of the large legacy AWS estate. Finance export queries the same LZA + Azure set instead of filtering classic AWS in memory.
- `getPlatformForecastSummary({ providers: [] })` returns no rows (does not fail open and reload the estate).
- Silver **dev** nats-provision reused one mock AWS account ID / Azure subscription, so finance joins collided. A fail-closed migration (`APP_ENV=dev` only) replaces missing, invalid, or duplicate IDs and keeps unique valid ones. Matching account + billing-link pairs count as one identity so well-formed products are not rewritten.
- The pre-data-migrations Helm job now receives `APP_ENV`. Local nats-provision invents unique IDs per licence plate and environment so new products do not reuse one mock ID.

## Test plan
- [ ] Open `/public-cloud/finance` in **dev** (or locally against a DB with classic AWS products): snapshot `ALL` returns 200 and freshness shows only AWS LZA and MS Azure
- [ ] Confirm there is no classic AWS filter chip on finance pages
- [ ] `?provider=AWS` on finance APIs is rejected
- [ ] Classic AWS product pages still show forecast, not finance actuals
- [ ] Forecast page still lists classic AWS products
- [ ] Finance CSV/xlsx export for `ALL` or a single LZA/Azure provider does not include classic AWS
- [ ] In Silver **dev** only, after the pre-data-migrations job: LZA/Azure products have unique valid account/subscription IDs and matching billing links; test/prod are unchanged
- [ ] New LZA/Azure provisions in local/dev get distinct account IDs (not `123456789012` for every product)