### PR TITLE
fix(finance): seed Silver-dev public-cloud forecasts for LZA and Azure

### DIFF
--- a/data-migrations/migrations/20260908214000-backfill_dev_public_cloud_forecasts.js
+++ b/data-migrations/migrations/20260908214000-backfill_dev_public_cloud_forecasts.js
@@ -1,0 +1,280 @@
+/**
+ * Silver dev only. Overwrite CloudCostForecast for every AWS LZA and Azure product
+ * so finance / forecast UIs have demo data that matches local seed amounts
+ * (CA$5k Azure / CA$4k AWS) and shows every coverage state.
+ *
+ * Two incomplete styles exist because the screens disagree:
+ * - omitted required-month keys → coverage chase list "incomplete"
+ * - required months present at $0 → platform "Incomplete required" filter
+ *
+ * Classic AWS is left alone. Test and prod skip (APP_ENV !== 'dev').
+ */
+import { ObjectId } from 'mongodb';
+
+const FINANCE_PROVIDERS = ['AWS_LZA', 'AZURE'];
+const HORIZON_MONTHS = 24;
+const FISCAL_YEAR_START_MONTH = 4;
+const FISCAL_YEAR_END_MONTH = 3;
+const CURRENCY = 'CAD';
+const DEFAULT_MONTHLY_AZURE = 5000;
+const DEFAULT_MONTHLY_AWS = 4000;
+const SPARSE_OPTIONAL_AMOUNT = 100;
+const LOW_LAST_PAST_AMOUNT = 50;
+const INCOMPLETE_REQUIRED_COUNT = 3;
+
+const SPECIAL_PROFILES = [
+  'missing',
+  'incomplete-gaps',
+  'incomplete-required',
+  'sparse-optional',
+  'from-may',
+  'from-jun',
+  'from-jul',
+  'from-aug',
+  'complete',
+  'low-last-past',
+];
+
+const PROFILE_START_MONTH = {
+  'with-past': 4,
+  'incomplete-required': 4,
+  'incomplete-gaps': 4,
+  'sparse-optional': 4,
+  'low-last-past': 4,
+  'from-may': 5,
+  'from-jun': 6,
+  'from-jul': 7,
+  'from-aug': 8,
+};
+
+function monthKey(year, month) {
+  return `${year}-${month}`;
+}
+
+function getFiscalYearStartForMonth(year, month) {
+  return month >= FISCAL_YEAR_START_MONTH ? year : year - 1;
+}
+
+function getFiscalYearStartYear(now) {
+  return getFiscalYearStartForMonth(now.getUTCFullYear(), now.getUTCMonth() + 1);
+}
+
+function getRequiredHorizonEndDate(now, horizonMonths = HORIZON_MONTHS) {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + horizonMonths - 1, 1));
+}
+
+function isPastMonth(year, month, now) {
+  const currentYear = now.getUTCFullYear();
+  const currentMonth = now.getUTCMonth() + 1;
+  return year < currentYear || (year === currentYear && month < currentMonth);
+}
+
+function isBeyondRequiredHorizon(year, month, now, horizonMonths = HORIZON_MONTHS) {
+  const end = getRequiredHorizonEndDate(now, horizonMonths);
+  return year * 12 + month > end.getUTCFullYear() * 12 + (end.getUTCMonth() + 1);
+}
+
+function isRequiredForecastMonth(year, month, now, horizonMonths = HORIZON_MONTHS) {
+  return !isPastMonth(year, month, now) && !isBeyondRequiredHorizon(year, month, now, horizonMonths);
+}
+
+function fiscalMonthOrder(month) {
+  return month >= FISCAL_YEAR_START_MONTH ? month : month + 12;
+}
+
+function monthlyAmountFor(provider) {
+  return provider === 'AZURE' ? DEFAULT_MONTHLY_AZURE : DEFAULT_MONTHLY_AWS;
+}
+
+function buildRollingFiscalForecastMonths(monthlyAmount, now, horizonMonths = HORIZON_MONTHS) {
+  const fiscalStartYear = getFiscalYearStartYear(now);
+  const startDate = new Date(Date.UTC(fiscalStartYear, FISCAL_YEAR_START_MONTH - 1, 1));
+  const horizonEnd = getRequiredHorizonEndDate(now, horizonMonths);
+  const horizonEndFyStart = getFiscalYearStartForMonth(horizonEnd.getUTCFullYear(), horizonEnd.getUTCMonth() + 1);
+  const endDate = new Date(Date.UTC(horizonEndFyStart + 1, FISCAL_YEAR_END_MONTH - 1, 1));
+  const monthCount =
+    (endDate.getUTCFullYear() - startDate.getUTCFullYear()) * 12 +
+    (endDate.getUTCMonth() - startDate.getUTCMonth()) +
+    1;
+
+  const monthlyValues = [];
+  for (let i = 0; i < monthCount; i += 1) {
+    const date = new Date(Date.UTC(startDate.getUTCFullYear(), startDate.getUTCMonth() + i, 1));
+    const year = date.getUTCFullYear();
+    const month = date.getUTCMonth() + 1;
+    monthlyValues.push({
+      year,
+      month,
+      amount: isRequiredForecastMonth(year, month, now, horizonMonths) ? monthlyAmount : 0,
+      currency: CURRENCY,
+    });
+  }
+  return monthlyValues;
+}
+
+function applyPastFiscalMonths(values, now, fromMonth = FISCAL_YEAR_START_MONTH) {
+  const sampleAmount =
+    values.find((value) => isRequiredForecastMonth(value.year, value.month, now) && value.amount > 0)?.amount ?? 0;
+  if (sampleAmount <= 0) return values;
+  const startOrder = fiscalMonthOrder(fromMonth);
+
+  return values.map((value) => {
+    if (!isPastMonth(value.year, value.month, now)) return value;
+    if (fiscalMonthOrder(value.month) < startOrder) return { ...value, amount: 0 };
+    return { ...value, amount: sampleAmount };
+  });
+}
+
+function lastRequiredKeys(values, now, count = INCOMPLETE_REQUIRED_COUNT) {
+  return values
+    .filter((value) => isRequiredForecastMonth(value.year, value.month, now))
+    .slice(-count)
+    .map((value) => monthKey(value.year, value.month));
+}
+
+function applyIncompleteRequiredMonths(values, now) {
+  const toClear = new Set(lastRequiredKeys(values, now));
+  return values.map((value) => (toClear.has(monthKey(value.year, value.month)) ? { ...value, amount: 0 } : value));
+}
+
+function applyIncompleteGaps(values, now) {
+  const toOmit = new Set(lastRequiredKeys(values, now));
+  return values.filter((value) => !toOmit.has(monthKey(value.year, value.month)));
+}
+
+function applySparseOptionalMonth(values, amount = SPARSE_OPTIONAL_AMOUNT, now) {
+  const firstOptional = values.find((value) => isBeyondRequiredHorizon(value.year, value.month, now));
+  if (!firstOptional) return values;
+  return values.map((value) =>
+    value.year === firstOptional.year && value.month === firstOptional.month ? { ...value, amount } : value,
+  );
+}
+
+function applyLastPastMonthLowForecast(values, amount = LOW_LAST_PAST_AMOUNT, now) {
+  const lastPast = [...values].reverse().find((value) => isPastMonth(value.year, value.month, now) && value.amount > 0);
+  if (!lastPast) return values;
+  return values.map((value) =>
+    value.year === lastPast.year && value.month === lastPast.month ? { ...value, amount } : value,
+  );
+}
+
+export function assignProfiles(products) {
+  const assigned = [];
+
+  for (const provider of FINANCE_PROVIDERS) {
+    const group = products
+      .filter((product) => product.provider === provider)
+      .sort((a, b) => String(a.licencePlate).localeCompare(String(b.licencePlate)));
+    const active = group.filter((product) => product.status === 'ACTIVE');
+    const inactive = group.filter((product) => product.status !== 'ACTIVE');
+
+    active.forEach((product, index) => {
+      assigned.push({
+        product,
+        profile: index < SPECIAL_PROFILES.length ? SPECIAL_PROFILES[index] : 'with-past',
+      });
+    });
+    for (const product of inactive) {
+      assigned.push({ product, profile: 'with-past' });
+    }
+  }
+
+  return assigned;
+}
+
+export function buildMonthlyValues(profile, provider, now) {
+  if (profile === 'missing') return null;
+
+  let values = buildRollingFiscalForecastMonths(monthlyAmountFor(provider), now);
+  const startMonth = PROFILE_START_MONTH[profile];
+  if (startMonth) {
+    values = applyPastFiscalMonths(values, now, startMonth);
+  }
+  if (profile === 'incomplete-required') {
+    values = applyIncompleteRequiredMonths(values, now);
+  } else if (profile === 'incomplete-gaps') {
+    values = applyIncompleteGaps(values, now);
+  } else if (profile === 'sparse-optional') {
+    values = applySparseOptionalMonth(values, SPARSE_OPTIONAL_AMOUNT, now);
+  } else if (profile === 'low-last-past') {
+    values = applyLastPastMonthLowForecast(values, LOW_LAST_PAST_AMOUNT, now);
+  }
+  return values;
+}
+
+function emptyProfileCounts() {
+  return Object.fromEntries([...SPECIAL_PROFILES, 'with-past'].map((profile) => [profile, 0]));
+}
+
+function formatCounts(counts) {
+  return Object.entries(counts)
+    .filter(([, count]) => count > 0)
+    .map(([profile, count]) => `${profile}=${count}`)
+    .join(' ');
+}
+
+export const up = async (db) => {
+  const appEnv = process.env.APP_ENV;
+  if (appEnv !== 'dev') {
+    console.log(`backfill_dev_public_cloud_forecasts: not running outside Silver dev (APP_ENV=${appEnv || 'unset'})`);
+    return;
+  }
+
+  const now = new Date();
+  const products = await db
+    .collection('PublicCloudProduct')
+    .find({ provider: { $in: FINANCE_PROVIDERS } }, { projection: { licencePlate: 1, provider: 1, status: 1 } })
+    .toArray();
+
+  if (products.length === 0) {
+    console.log('backfill_dev_public_cloud_forecasts: no AWS_LZA / AZURE products.');
+    return;
+  }
+
+  const forecasts = db.collection('CloudCostForecast');
+  const assigned = assignProfiles(products);
+  const countsByProvider = {
+    AWS_LZA: emptyProfileCounts(),
+    AZURE: emptyProfileCounts(),
+  };
+  let upserted = 0;
+  let deleted = 0;
+
+  for (const { product, profile } of assigned) {
+    countsByProvider[product.provider][profile] += 1;
+    const licencePlate = product.licencePlate;
+    const monthlyValues = buildMonthlyValues(profile, product.provider, now);
+
+    if (monthlyValues == null) {
+      const result = await forecasts.deleteOne({ licencePlate });
+      deleted += result.deletedCount;
+      continue;
+    }
+
+    const result = await forecasts.updateOne(
+      { licencePlate },
+      {
+        $set: {
+          licencePlate,
+          horizonMonths: HORIZON_MONTHS,
+          monthlyValues,
+          updatedAt: now,
+        },
+        $setOnInsert: {
+          _id: new ObjectId(),
+          createdAt: now,
+        },
+      },
+      { upsert: true },
+    );
+    upserted += result.modifiedCount + (result.upsertedCount ?? 0);
+  }
+
+  console.log(
+    `backfill_dev_public_cloud_forecasts: AWS_LZA ${formatCounts(countsByProvider.AWS_LZA)}; AZURE ${formatCounts(
+      countsByProvider.AZURE,
+    )}; upserted ${upserted}, deleted ${deleted}.`,
+  );
+};
+
+export const down = async () => {};

--- a/data-migrations/migrations/20260908214000-backfill_dev_public_cloud_forecasts.js
+++ b/data-migrations/migrations/20260908214000-backfill_dev_public_cloud_forecasts.js
@@ -13,14 +13,11 @@ import { ObjectId } from 'mongodb';
 
 const FINANCE_PROVIDERS = ['AWS_LZA', 'AZURE'];
 const HORIZON_MONTHS = 24;
-const FISCAL_YEAR_START_MONTH = 4;
-const FISCAL_YEAR_END_MONTH = 3;
 const CURRENCY = 'CAD';
-const DEFAULT_MONTHLY_AZURE = 5000;
-const DEFAULT_MONTHLY_AWS = 4000;
+const DEFAULT_MONTHLY = { AZURE: 5000, AWS_LZA: 4000 };
 const SPARSE_OPTIONAL_AMOUNT = 100;
 const LOW_LAST_PAST_AMOUNT = 50;
-const INCOMPLETE_REQUIRED_COUNT = 3;
+const INCOMPLETE_TAIL = 3;
 
 const SPECIAL_PROFILES = [
   'missing',
@@ -47,115 +44,53 @@ const PROFILE_START_MONTH = {
   'from-aug': 8,
 };
 
-function monthKey(year, month) {
-  return `${year}-${month}`;
+function shiftMonth(year, month, delta) {
+  const date = new Date(Date.UTC(year, month - 1 + delta, 1));
+  return { year: date.getUTCFullYear(), month: date.getUTCMonth() + 1 };
 }
 
-function getFiscalYearStartForMonth(year, month) {
-  return month >= FISCAL_YEAR_START_MONTH ? year : year - 1;
+function monthIndex(year, month) {
+  return year * 12 + month;
 }
 
-function getFiscalYearStartYear(now) {
-  return getFiscalYearStartForMonth(now.getUTCFullYear(), now.getUTCMonth() + 1);
+function fiscalOrder(month) {
+  return month >= 4 ? month : month + 12;
 }
 
-function getRequiredHorizonEndDate(now, horizonMonths = HORIZON_MONTHS) {
-  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + horizonMonths - 1, 1));
+function cellKind(year, month, now) {
+  const nowIndex = monthIndex(now.getUTCFullYear(), now.getUTCMonth() + 1);
+  const cellIndex = monthIndex(year, month);
+  if (cellIndex < nowIndex) return 'past';
+  if (cellIndex > nowIndex + HORIZON_MONTHS - 1) return 'optional';
+  return 'required';
 }
 
-function isPastMonth(year, month, now) {
-  const currentYear = now.getUTCFullYear();
-  const currentMonth = now.getUTCMonth() + 1;
-  return year < currentYear || (year === currentYear && month < currentMonth);
-}
-
-function isBeyondRequiredHorizon(year, month, now, horizonMonths = HORIZON_MONTHS) {
-  const end = getRequiredHorizonEndDate(now, horizonMonths);
-  return year * 12 + month > end.getUTCFullYear() * 12 + (end.getUTCMonth() + 1);
-}
-
-function isRequiredForecastMonth(year, month, now, horizonMonths = HORIZON_MONTHS) {
-  return !isPastMonth(year, month, now) && !isBeyondRequiredHorizon(year, month, now, horizonMonths);
-}
-
-function fiscalMonthOrder(month) {
-  return month >= FISCAL_YEAR_START_MONTH ? month : month + 12;
-}
-
-function monthlyAmountFor(provider) {
-  return provider === 'AZURE' ? DEFAULT_MONTHLY_AZURE : DEFAULT_MONTHLY_AWS;
-}
-
-function buildRollingFiscalForecastMonths(monthlyAmount, now, horizonMonths = HORIZON_MONTHS) {
-  const fiscalStartYear = getFiscalYearStartYear(now);
-  const startDate = new Date(Date.UTC(fiscalStartYear, FISCAL_YEAR_START_MONTH - 1, 1));
-  const horizonEnd = getRequiredHorizonEndDate(now, horizonMonths);
-  const horizonEndFyStart = getFiscalYearStartForMonth(horizonEnd.getUTCFullYear(), horizonEnd.getUTCMonth() + 1);
-  const endDate = new Date(Date.UTC(horizonEndFyStart + 1, FISCAL_YEAR_END_MONTH - 1, 1));
-  const monthCount =
-    (endDate.getUTCFullYear() - startDate.getUTCFullYear()) * 12 +
-    (endDate.getUTCMonth() - startDate.getUTCMonth()) +
-    1;
-
-  const monthlyValues = [];
-  for (let i = 0; i < monthCount; i += 1) {
-    const date = new Date(Date.UTC(startDate.getUTCFullYear(), startDate.getUTCMonth() + i, 1));
-    const year = date.getUTCFullYear();
-    const month = date.getUTCMonth() + 1;
-    monthlyValues.push({
-      year,
-      month,
-      amount: isRequiredForecastMonth(year, month, now, horizonMonths) ? monthlyAmount : 0,
-      currency: CURRENCY,
-    });
+function fiscalGrid(now) {
+  const nowYear = now.getUTCFullYear();
+  const nowMonth = now.getUTCMonth() + 1;
+  const fyStartYear = nowMonth >= 4 ? nowYear : nowYear - 1;
+  const horizonEnd = shiftMonth(nowYear, nowMonth, HORIZON_MONTHS - 1);
+  const horizonFyStart = horizonEnd.month >= 4 ? horizonEnd.year : horizonEnd.year - 1;
+  const lastIndex = monthIndex(horizonFyStart + 1, 3);
+  const cells = [];
+  let cursor = { year: fyStartYear, month: 4 };
+  while (monthIndex(cursor.year, cursor.month) <= lastIndex) {
+    cells.push(cursor);
+    cursor = shiftMonth(cursor.year, cursor.month, 1);
   }
-  return monthlyValues;
+  return cells;
 }
 
-function applyPastFiscalMonths(values, now, fromMonth = FISCAL_YEAR_START_MONTH) {
-  const sampleAmount =
-    values.find((value) => isRequiredForecastMonth(value.year, value.month, now) && value.amount > 0)?.amount ?? 0;
-  if (sampleAmount <= 0) return values;
-  const startOrder = fiscalMonthOrder(fromMonth);
-
-  return values.map((value) => {
-    if (!isPastMonth(value.year, value.month, now)) return value;
-    if (fiscalMonthOrder(value.month) < startOrder) return { ...value, amount: 0 };
-    return { ...value, amount: sampleAmount };
-  });
-}
-
-function lastRequiredKeys(values, now, count = INCOMPLETE_REQUIRED_COUNT) {
-  return values
-    .filter((value) => isRequiredForecastMonth(value.year, value.month, now))
-    .slice(-count)
-    .map((value) => monthKey(value.year, value.month));
-}
-
-function applyIncompleteRequiredMonths(values, now) {
-  const toClear = new Set(lastRequiredKeys(values, now));
-  return values.map((value) => (toClear.has(monthKey(value.year, value.month)) ? { ...value, amount: 0 } : value));
-}
-
-function applyIncompleteGaps(values, now) {
-  const toOmit = new Set(lastRequiredKeys(values, now));
-  return values.filter((value) => !toOmit.has(monthKey(value.year, value.month)));
-}
-
-function applySparseOptionalMonth(values, amount = SPARSE_OPTIONAL_AMOUNT, now) {
-  const firstOptional = values.find((value) => isBeyondRequiredHorizon(value.year, value.month, now));
-  if (!firstOptional) return values;
-  return values.map((value) =>
-    value.year === firstOptional.year && value.month === firstOptional.month ? { ...value, amount } : value,
-  );
-}
-
-function applyLastPastMonthLowForecast(values, amount = LOW_LAST_PAST_AMOUNT, now) {
-  const lastPast = [...values].reverse().find((value) => isPastMonth(value.year, value.month, now) && value.amount > 0);
-  if (!lastPast) return values;
-  return values.map((value) =>
-    value.year === lastPast.year && value.month === lastPast.month ? { ...value, amount } : value,
-  );
+function amountForCell(cell, kind, profile, defaultAmount, extras) {
+  const key = `${cell.year}-${cell.month}`;
+  if (kind === 'required') {
+    return extras.zeroRequired.has(key) ? 0 : defaultAmount;
+  }
+  if (kind === 'optional') {
+    return extras.firstOptionalKey === key ? SPARSE_OPTIONAL_AMOUNT : 0;
+  }
+  if (!extras.onboardFrom || fiscalOrder(cell.month) < extras.onboardFrom) return 0;
+  return extras.lowPastKey === key ? LOW_LAST_PAST_AMOUNT : defaultAmount;
 }
 
 export function assignProfiles(products) {
@@ -185,21 +120,38 @@ export function assignProfiles(products) {
 export function buildMonthlyValues(profile, provider, now) {
   if (profile === 'missing') return null;
 
-  let values = buildRollingFiscalForecastMonths(monthlyAmountFor(provider), now);
-  const startMonth = PROFILE_START_MONTH[profile];
-  if (startMonth) {
-    values = applyPastFiscalMonths(values, now, startMonth);
+  const defaultAmount = DEFAULT_MONTHLY[provider] ?? DEFAULT_MONTHLY.AWS_LZA;
+  const onboardFrom = PROFILE_START_MONTH[profile];
+  const grid = fiscalGrid(now);
+  const required = grid.filter((cell) => cellKind(cell.year, cell.month, now) === 'required');
+  const tail = required.slice(-INCOMPLETE_TAIL).map((cell) => `${cell.year}-${cell.month}`);
+  const firstOptional = grid.find((cell) => cellKind(cell.year, cell.month, now) === 'optional');
+  const lastOnboardedPast = [...grid].reverse().find((cell) => {
+    if (cellKind(cell.year, cell.month, now) !== 'past' || !onboardFrom) return false;
+    return fiscalOrder(cell.month) >= onboardFrom;
+  });
+
+  const extras = {
+    onboardFrom,
+    zeroRequired: new Set(profile === 'incomplete-required' ? tail : []),
+    firstOptionalKey:
+      profile === 'sparse-optional' && firstOptional ? `${firstOptional.year}-${firstOptional.month}` : '',
+    lowPastKey:
+      profile === 'low-last-past' && lastOnboardedPast ? `${lastOnboardedPast.year}-${lastOnboardedPast.month}` : '',
+  };
+
+  const monthlyValues = [];
+  for (const cell of grid) {
+    const key = `${cell.year}-${cell.month}`;
+    if (profile === 'incomplete-gaps' && tail.includes(key)) continue;
+    monthlyValues.push({
+      year: cell.year,
+      month: cell.month,
+      amount: amountForCell(cell, cellKind(cell.year, cell.month, now), profile, defaultAmount, extras),
+      currency: CURRENCY,
+    });
   }
-  if (profile === 'incomplete-required') {
-    values = applyIncompleteRequiredMonths(values, now);
-  } else if (profile === 'incomplete-gaps') {
-    values = applyIncompleteGaps(values, now);
-  } else if (profile === 'sparse-optional') {
-    values = applySparseOptionalMonth(values, SPARSE_OPTIONAL_AMOUNT, now);
-  } else if (profile === 'low-last-past') {
-    values = applyLastPastMonthLowForecast(values, LOW_LAST_PAST_AMOUNT, now);
-  }
-  return values;
+  return monthlyValues;
 }
 
 function emptyProfileCounts() {

--- a/data-migrations/migrations/20260908214000-backfill_dev_public_cloud_forecasts.js
+++ b/data-migrations/migrations/20260908214000-backfill_dev_public_cloud_forecasts.js
@@ -8,6 +8,7 @@
  * - required months present at $0 → platform "Incomplete required" filter
  *
  * Classic AWS is left alone. Test and prod skip (APP_ENV !== 'dev').
+ * Month classification uses local Date math, same as forecast-grid-utils.
  */
 import { ObjectId } from 'mongodb';
 
@@ -45,8 +46,8 @@ const PROFILE_START_MONTH = {
 };
 
 function shiftMonth(year, month, delta) {
-  const date = new Date(Date.UTC(year, month - 1 + delta, 1));
-  return { year: date.getUTCFullYear(), month: date.getUTCMonth() + 1 };
+  const date = new Date(year, month - 1 + delta, 1);
+  return { year: date.getFullYear(), month: date.getMonth() + 1 };
 }
 
 function monthIndex(year, month) {
@@ -58,7 +59,7 @@ function fiscalOrder(month) {
 }
 
 function cellKind(year, month, now) {
-  const nowIndex = monthIndex(now.getUTCFullYear(), now.getUTCMonth() + 1);
+  const nowIndex = monthIndex(now.getFullYear(), now.getMonth() + 1);
   const cellIndex = monthIndex(year, month);
   if (cellIndex < nowIndex) return 'past';
   if (cellIndex > nowIndex + HORIZON_MONTHS - 1) return 'optional';
@@ -66,8 +67,8 @@ function cellKind(year, month, now) {
 }
 
 function fiscalGrid(now) {
-  const nowYear = now.getUTCFullYear();
-  const nowMonth = now.getUTCMonth() + 1;
+  const nowYear = now.getFullYear();
+  const nowMonth = now.getMonth() + 1;
   const fyStartYear = nowMonth >= 4 ? nowYear : nowYear - 1;
   const horizonEnd = shiftMonth(nowYear, nowMonth, HORIZON_MONTHS - 1);
   const horizonFyStart = horizonEnd.month >= 4 ? horizonEnd.year : horizonEnd.year - 1;


### PR DESCRIPTION
## Summary
- Add a fail-closed Silver-dev data migration that overwrites `CloudCostForecast` for every AWS LZA and Azure product using the same CA$5k / CA$4k monthly defaults as local seed and the ingest DAG.
- Assign a small set of deterministic profiles (missing, omitted-key incomplete, zero incomplete, late onboard, sparse optional, low last-past) so coverage, platform filters, and over-forecast can be demonstrated.
- Classic AWS, test, prod, and `localdev` are not written.

## Test plan
- [ ] Confirm Helm pre-data-migrations in 101ed4-dev logs profile counts and skips other environments.
- [ ] `/public-cloud/forecast`: With / Missing / Incomplete required filters all have rows; late-onboard plates show empty months before start.
- [ ] `/public-cloud/finance/coverage`: complete, incomplete, and missing states are all present.
- [ ] `/public-cloud/finance`: FYTD forecast chips populate; a few products are excluded as missing a forecast.
- [ ] After the next `_dev` ingest, anomalies can show OVER_FORECAST on the low last-past plates.